### PR TITLE
improve firmware menu css

### DIFF
--- a/src/stylesheets/content.less
+++ b/src/stylesheets/content.less
@@ -471,8 +471,11 @@ code .comment {
   margin-top: 10px;
   padding-left: 10px;
 }
-.menubar .level-2, .menubar .level-3 {
+.menubar .level-2 {
   padding-left: 10px;
+}
+.menubar .level-3 {
+  padding-left: 20px;
 }
 
 

--- a/src/stylesheets/menu.less
+++ b/src/stylesheets/menu.less
@@ -108,8 +108,8 @@
 }
 
 .menu a.level-1 {
-  font-size: 12px;
-  font-weight: 500;
+  font-size: 13px;
+  font-weight: bold;
 }
 
 .menu li:first-child a.level-1 {
@@ -125,7 +125,7 @@
   color: #565666;
 }
 .menu a.level-2 {
-  font-weight: normal;
+  font-weight: bold;
   font-size: 12px;
 }
 .menu a.level-3 {


### PR DESCRIPTION
Fixes: https://github.com/spark/docs/issues/28
- Bold heading for level 1 & 2
- left-pad 20px level 2 heading
- Increase heading to 13px

Ping @jme783 @zsup @moors7 @wgbartley 
