### PR TITLE
Properly link between the hardware datasheet pages

### DIFF
--- a/src/content/en/core/hardware.md
+++ b/src/content/en/core/hardware.md
@@ -3,6 +3,7 @@ word: Datasheet
 title: Hardware datasheet
 order: 12
 columns: 2
+photon_link: photon-datasheet
 ---
 
 Spark Core Datasheet

--- a/src/content/en/core/ios.md
+++ b/src/content/en/core/ios.md
@@ -2,7 +2,6 @@
 word: iOS
 title: iOS SDK
 order: 11
-shared: true
 ---
 
 iOS Cloud SDK

--- a/src/content/en/photon/ios.md
+++ b/src/content/en/photon/ios.md
@@ -2,7 +2,6 @@
 word: iOS
 title: iOS SDK
 order: 11
-shared: true
 ---
 
 iOS Cloud SDK

--- a/src/content/en/photon/p1-datasheet.md
+++ b/src/content/en/photon/p1-datasheet.md
@@ -3,6 +3,7 @@ word: Datasheet
 title: P1 datasheet
 order: 13
 columns: 2
+core_link: hardware
 ---
 
 P1 Datasheet <sup>(v003)</sup>

--- a/src/content/en/photon/photon-datasheet.md
+++ b/src/content/en/photon/photon-datasheet.md
@@ -3,6 +3,7 @@ word: Datasheet
 title: Photon datasheet
 order: 12
 columns: 2
+core_link: hardware
 ---
 
 Photon Datasheet <sup>(v010)</sup>

--- a/src/layouts/docs.hbs
+++ b/src/layouts/docs.hbs
@@ -41,9 +41,9 @@
           <img src="{{assets}}/images/particle-docs.png" id="logo">
         </a>
         <a class="toggle-button {{#contains dirname
-          'photon'}}active{{/contains}}" href="/photon/{{basename}}">Photon</a>
+          'photon'}}active{{/contains}}" href="/photon/{{#if page.photon_link}}{{page.photon_link}}{{else}}{{basename}}{{/if}}">Photon</a>
         <a class="toggle-button {{#contains dirname
-          'core'}}active{{/contains}}" href="/core/{{basename}}">Core</a>
+          'core'}}active{{/contains}}" href="/core/{{#if page.core_link}}{{page.core_link}}{{else}}{{basename}}{{/if}}">Core</a>
         <div class="search">
           <script src='{{assets}}/js/google-search.js'></script>
           <gcse:search></gcse:search>


### PR DESCRIPTION
Currently when clicking the [Core button from the Photon datasheet page crashes](http://docs.particle.io/core/photon-datasheet) and clicking the [Photon button from the Core datasheet page shows the old Photon datasheet page](http://docs.particle.io/photon/hardware).

This PR adds new fields to the front matter to allow alternate links for the Photon/Core button at the top of the page (`core_link` and `photon_link`). This can be extended later to add similar links for the Electron.

Any page that exists only in the Core folder should include an appropriate `photon_link`, and vise-versa.

Also fixed here is the Edit link for the `ios.md` page.
