### PR TITLE
Add community supported clients page

### DIFF
--- a/src/content/reference/community.md
+++ b/src/content/reference/community.md
@@ -1,0 +1,32 @@
+---
+title: Community Supported Clients
+template: reference.hbs
+columns: two
+order: 7
+---
+
+# Community Supported Clients
+
+These client libraries can help you interact with Particle devices
+and the Particle cloud using your favorite programming language or
+framework.
+
+Note that these client libraries have not been tested by
+Particle. If you develop an open-source client library that you would
+like to add to this page, please submit a pull request.
+
+## Javascript
+
+See [the official Javascript client](/reference/javascript/).
+
+* [Cylon.js robotics framework adapter by The Hybrid Group](http://cylonjs.com/documentation/platforms/spark/)
+
+## Ruby
+
+* [particlerb: Ruby client for the Particle.io API by Julien Vanier](https://github.com/monkbroc/particlerb)
+* [Artoo robotics framework adapter by The Hybrid Group](http://artoo.io/documentation/platforms/spark/)
+
+## Go
+
+* [Gobot robotics framework adapter by The Hybrid Group](http://gobot.io/documentation/platforms/spark/)
+


### PR DESCRIPTION
This PR adds a "Community Supported Clients" page with a clear notice that this code is not tested by Particle. This is where open-source Ruby, Go, Python or even Java ;-) clients written by community members can be made visible to other community members.
