### PR TITLE
note about micros wrap around

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -2755,7 +2755,12 @@ The parameter for millis is an unsigned long, errors may be generated if a progr
 
 ### micros()
 
-Returns the number of microseconds since the device began running the current program. This number will overflow (go back to zero), after exactly 59,652,323 microseconds (0 .. 59,652,322) on the Core and after exactly 35,791,394 microseconds (0 .. 35,791,394) on the Photon.
+Returns the number of microseconds since the device began running the current program. 
+
+Firmware v0.4.3 and earlier:
+- This number will overflow (go back to zero), after exactly 59,652,323 microseconds (0 .. 59,652,322) on the Core and after exactly 35,791,394 microseconds (0 .. 35,791,394) on the Photon.
+
+
 
 `unsigned long time = micros();`
 


### PR DESCRIPTION
micros wrap-around fixed in 0.4.4. https://github.com/spark/docs/issues/91
