### PR TITLE
Show Gradle minimal version

### DIFF
--- a/src/content/reference/android.md
+++ b/src/content/reference/android.md
@@ -257,7 +257,7 @@ dependencies {
 }
 ```
 
-Also note that the SDK is hosted on JCenter, but not Maven Central.
+Also note that the SDK is hosted on JCenter, but not Maven Central. You need a Gradle Version higher than 1.7.
 Make sure your top-level Gradle file contains the following:
 
 ```gradle


### PR DESCRIPTION
Show that Gradle needs tu be a recent Version, because it does not work with 1.4 (from Ubuntu repository)
