### PR TITLE
Spark.publish() example updated

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -214,8 +214,15 @@ Publish a public event with the given name, no data, and the default TTL of 60 s
 Spark.publish(const char *eventName);
 Spark.publish(String eventName);
 
+RETURNS
+boolean (true or false)
+
 // EXAMPLE USAGE
-Spark.publish("motion-detected");
+bool success;
+success = Spark.publish("motion-detected");
+if (!success) {
+  // get here if event publish did not work
+}
 ```
 
 ---


### PR DESCRIPTION
Spark.publish() now returns a boolean. I updated the example to be more like the example for Spark.connected
