### PR TITLE
Added Red SOS codes

### DIFF
--- a/src/content/guide/getting-started/modes.md
+++ b/src/content/guide/getting-started/modes.md
@@ -270,5 +270,20 @@ A pattern of more than 10 red flashes is caused by the firmware crashing. The pa
 [Perform a factory reset](#factory-reset), tweak your firmware and try again!
 {{/if}}
  
+There are a number of other red flash codes that may be expressed after the SOS blinks:
+
+#1 Hard fault
+#2 Non-maskable interrupt fault
+#3 Memory Manager fault
+#4 Bus fault
+#5 Usage fault
+#6 Invalid length
+#7 Exit
+#8 Out of heap memory
+#9 SPI over-run
+#10 Assertion failure
+#11 Invalid case
+#12 Pure virtual call
+ 
 
 Don't forget that the [community forum is always there to help](https://community.particle.io).


### PR DESCRIPTION
These used to be in the documentation, but somehow got dropped. I added them at the very end of this doc, where it talked about red SOS flashes.
