### PR TITLE
Added 'particle publish' to the CLI Reference

### DIFF
--- a/src/content/reference/cli.md
+++ b/src/content/reference/cli.md
@@ -267,7 +267,7 @@ $ particle subscribe eventName 0123456789ABCDEFGHI
 
 ## particle publish
 
-  Publishes events to the cloud as if they came from the Particle Core/Photon via Spark.publish (deprecated) or Particle.publish.
+  Publishes events to the cloud via API, similar to running Spark.publish() (deprecated) or Particle.publish() on a Particle Device.
   
 ```sh
 $ particle publish eventName data

--- a/src/content/reference/cli.md
+++ b/src/content/reference/cli.md
@@ -265,9 +265,14 @@ $ particle subscribe eventName CoreName
 $ particle subscribe eventName 0123456789ABCDEFGHI
 ```
 
+## particle publish
 
-
-
+  Publishes events to the cloud as if they came from the Particle Core/Photon via Spark.publish (deprecated) or Particle.publish.
+  
+```sh
+$ particle publish eventName data
+```
+ 
 ## particle serial list
 
   Shows currently connected Particle Core's acting as serial devices over USB


### PR DESCRIPTION
Added particle publish to the CLI Reference documentation.  Wording might need to be reviewed...
