### PR TITLE
Update firmware.md

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -3151,6 +3151,7 @@ volatile int state = LOW;
 void setup()
 {
   pinMode(ledPin, OUTPUT);
+  pinMode(D2, INPUT);
   attachInterrupt(D2, blink, CHANGE);
 }
 


### PR DESCRIPTION
Added "pinMode(D2, INPUT);" to attachinterrupt code example. If the D2 pin is not declared as an input pin, nothing happens with the attachinterrupt() (at least on a core). Since Arduino code does not require this declaration, not having this in the example is a recipe for disappointment and wasted time for those that come with this assumption that the photon/core will be just like an arduino.
