### PR TITLE
String format static method should be called with colons

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -5155,7 +5155,7 @@ Provides printf-style formatting for strings.
 
 ```C++
 
-Particle.publish("startup", String.format("frobnicator started at %s", Time.timeStr()));
+Particle.publish("startup", String::format("frobnicator started at %s", Time.timeStr()));
 
 ```
 


### PR DESCRIPTION
Fixes #203
