### PR TITLE
Additional notes for tone()

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -1439,6 +1439,19 @@ tone(pin, frequency, duration)
 
 `tone()` does not return anything.
 
+**NOTE:** the Photon's PWM pins / timer channels are allocated as per the following table. If multiple, simultaneous tone() calls are needed (for example, to generate DTMF tones), use pins allocated to separate timers to avoid stuttering on the output:
+
+Pin  | TMR3 | TMR4 | TMR5
+:--- | :--: | :--: | :--:
+D0   |      |  x   |  
+D1   |      |  x   |  
+D2   |  x   |      |  
+D3   |  x   |      |  
+A4   |  x   |      |  
+A5   |  x   |      |  
+WKP  |      |      |  x
+
+
 ```C++
 // EXAMPLE USAGE
 // Plays a melody - Connect small speaker to analog pin A0


### PR DESCRIPTION
Note on how to avoid stuttering when making simultaneous tone() calls to PWM pins that share the same timer channel
