### PR TITLE
Add invisible tags to app examples so script can extract + inject stuff into db

### DIFF
--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -900,8 +900,7 @@ void setup()
 
 	//Register all the Tinker functions
 	Particle.function("digitalread", tinkerDigitalRead);
-        Particle.function("digitalwrite", tinkerDigitalWrite);
-
+	Particle.function("digitalwrite", tinkerDigitalWrite);
 	Particle.function("analogread", tinkerAnalogRead);
 	Particle.function("analogwrite", tinkerAnalogWrite);
 

--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -891,52 +891,54 @@ int tinkerDigitalWrite(String command);
 int tinkerAnalogRead(String pin);
 int tinkerAnalogWrite(String command);
 
+SYSTEM_MODE(AUTOMATIC);
+
 /* This function is called once at start up ----------------------------------*/
 void setup()
 {
-  //Setup the Tinker application here
+	//Setup the Tinker application here
 
-  //Register all the Tinker functions
-  Spark.function("digitalread", tinkerDigitalRead);
-  Spark.function("digitalwrite", tinkerDigitalWrite);
+	//Register all the Tinker functions
+	Particle.function("digitalread", tinkerDigitalRead);
+        Particle.function("digitalwrite", tinkerDigitalWrite);
 
-  Spark.function("analogread", tinkerAnalogRead);
-  Spark.function("analogwrite", tinkerAnalogWrite);
+	Particle.function("analogread", tinkerAnalogRead);
+	Particle.function("analogwrite", tinkerAnalogWrite);
 
 }
 
 /* This function loops forever --------------------------------------------*/
 void loop()
 {
-  //This will run in a loop
+	//This will run in a loop
 }
 
 /*******************************************************************************
  * Function Name  : tinkerDigitalRead
  * Description    : Reads the digital value of a given pin
- * Input          : Pin 
+ * Input          : Pin
  * Output         : None.
  * Return         : Value of the pin (0 or 1) in INT type
                     Returns a negative number on failure
  *******************************************************************************/
 int tinkerDigitalRead(String pin)
 {
-  //convert ascii to integer
-  int pinNumber = pin.charAt(1) - '0';
-  //Sanity check to see if the pin numbers are within limits
-  if (pinNumber< 0 || pinNumber >7) return -1;
+	//convert ascii to integer
+	int pinNumber = pin.charAt(1) - '0';
+	//Sanity check to see if the pin numbers are within limits
+	if (pinNumber< 0 || pinNumber >7) return -1;
 
-  if(pin.startsWith("D"))
-  {
-    pinMode(pinNumber, INPUT_PULLDOWN);
-    return digitalRead(pinNumber);
-  }
-  else if (pin.startsWith("A"))
-  {
-    pinMode(pinNumber+10, INPUT_PULLDOWN);
-    return digitalRead(pinNumber+10);
-  }
-  return -2;
+	if(pin.startsWith("D"))
+	{
+		pinMode(pinNumber, INPUT_PULLDOWN);
+		return digitalRead(pinNumber);
+	}
+	else if (pin.startsWith("A"))
+	{
+		pinMode(pinNumber+10, INPUT_PULLDOWN);
+		return digitalRead(pinNumber+10);
+	}
+	return -2;
 }
 
 /*******************************************************************************
@@ -948,55 +950,55 @@ int tinkerDigitalRead(String pin)
  *******************************************************************************/
 int tinkerDigitalWrite(String command)
 {
-  bool value = 0;
-  //convert ascii to integer
-  int pinNumber = command.charAt(1) - '0';
-  //Sanity check to see if the pin numbers are within limits
-  if (pinNumber< 0 || pinNumber >7) return -1;
+	bool value = 0;
+	//convert ascii to integer
+	int pinNumber = command.charAt(1) - '0';
+	//Sanity check to see if the pin numbers are within limits
+	if (pinNumber< 0 || pinNumber >7) return -1;
 
-  if(command.substring(3,7) == "HIGH") value = 1;
-  else if(command.substring(3,6) == "LOW") value = 0;
-  else return -2;
+	if(command.substring(3,7) == "HIGH") value = 1;
+	else if(command.substring(3,6) == "LOW") value = 0;
+	else return -2;
 
-  if(command.startsWith("D"))
-  {
-    pinMode(pinNumber, OUTPUT);
-    digitalWrite(pinNumber, value);
-    return 1;
-  }
-  else if(command.startsWith("A"))
-  {
-    pinMode(pinNumber+10, OUTPUT);
-    digitalWrite(pinNumber+10, value);
-    return 1;
-  }
-  else return -3;
+	if(command.startsWith("D"))
+	{
+		pinMode(pinNumber, OUTPUT);
+		digitalWrite(pinNumber, value);
+		return 1;
+	}
+	else if(command.startsWith("A"))
+	{
+		pinMode(pinNumber+10, OUTPUT);
+		digitalWrite(pinNumber+10, value);
+		return 1;
+	}
+	else return -3;
 }
 
 /*******************************************************************************
  * Function Name  : tinkerAnalogRead
  * Description    : Reads the analog value of a pin
- * Input          : Pin 
+ * Input          : Pin
  * Output         : None.
  * Return         : Returns the analog value in INT type (0 to 4095)
                     Returns a negative number on failure
  *******************************************************************************/
 int tinkerAnalogRead(String pin)
 {
-  //convert ascii to integer
-  int pinNumber = pin.charAt(1) - '0';
-  //Sanity check to see if the pin numbers are within limits
-  if (pinNumber< 0 || pinNumber >7) return -1;
+	//convert ascii to integer
+	int pinNumber = pin.charAt(1) - '0';
+	//Sanity check to see if the pin numbers are within limits
+	if (pinNumber< 0 || pinNumber >7) return -1;
 
-  if(pin.startsWith("D"))
-  {
-    return -3;
-  }
-  else if (pin.startsWith("A"))
-  {
-    return analogRead(pinNumber+10);
-  }
-  return -2;
+	if(pin.startsWith("D"))
+	{
+		return -3;
+	}
+	else if (pin.startsWith("A"))
+	{
+		return analogRead(pinNumber+10);
+	}
+	return -2;
 }
 
 /*******************************************************************************
@@ -1008,26 +1010,25 @@ int tinkerAnalogRead(String pin)
  *******************************************************************************/
 int tinkerAnalogWrite(String command)
 {
-  //convert ascii to integer
-  int pinNumber = command.charAt(1) - '0';
-  //Sanity check to see if the pin numbers are within limits
-  if (pinNumber< 0 || pinNumber >7) return -1;
+	//convert ascii to integer
+	int pinNumber = command.charAt(1) - '0';
+	//Sanity check to see if the pin numbers are within limits
+	if (pinNumber< 0 || pinNumber >7) return -1;
 
-  String value = command.substring(3);
+	String value = command.substring(3);
 
-  if(command.startsWith("D"))
-  {
-    pinMode(pinNumber, OUTPUT);
-    analogWrite(pinNumber, value.toInt());
-    return 1;
-  }
-  else if(command.startsWith("A"))
-  {
-    pinMode(pinNumber+10, OUTPUT);
-    analogWrite(pinNumber+10, value.toInt());
-    return 1;
-  }
-  else return -2;
+	if(command.startsWith("D"))
+	{
+		pinMode(pinNumber, OUTPUT);
+		analogWrite(pinNumber, value.toInt());
+		return 1;
+	}
+	else if(command.startsWith("A"))
+	{
+		pinMode(pinNumber+10, OUTPUT);
+		analogWrite(pinNumber+10, value.toInt());
+		return 1;
+	}
+	else return -2;
 }
 </code></pre>
-

--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -891,18 +891,16 @@ int tinkerDigitalWrite(String command);
 int tinkerAnalogRead(String pin);
 int tinkerAnalogWrite(String command);
 
-SYSTEM_MODE(AUTOMATIC);
-
 /* This function is called once at start up ----------------------------------*/
 void setup()
 {
 	//Setup the Tinker application here
 
 	//Register all the Tinker functions
-	Particle.function("digitalread", tinkerDigitalRead);
-	Particle.function("digitalwrite", tinkerDigitalWrite);
-	Particle.function("analogread", tinkerAnalogRead);
-	Particle.function("analogwrite", tinkerAnalogWrite);
+	Spark.function("digitalread", tinkerDigitalRead);
+	Spark.function("digitalwrite", tinkerDigitalWrite);
+	Spark.function("analogread", tinkerAnalogRead);
+	Spark.function("analogwrite", tinkerAnalogWrite);
 
 }
 

--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -28,7 +28,7 @@ To complete all the examples, you will need the following materials:
 * **Experience**
   * Connecting your Device [with your smartphone](/guide/getting-started/start) or [over USB](/guide/getting-started/connect)
 
-<a id="blink-an-led" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#blink-an-led" data-firmware-example-title="Blink an LED" data-firmware-example-description="Blink an LED">
+<div style="display: none;" id="blink-an-led" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#blink-an-led" data-firmware-example-title="Blink an LED" data-firmware-example-description="Blink an LED"></div>
 
 ## Blink an LED
 
@@ -48,9 +48,7 @@ Go ahead and save this application, then flash it to your Core or Photon. You sh
 
 ### Code
 
-<a data-firmware-example-code-block=true>
-
-```cpp
+<pre><code class="lang-cpp" data-firmware-example-code-block=true>
 // ------------
 // Blink an LED
 // ------------
@@ -122,9 +120,9 @@ void loop() {
   // And repeat!
 }
 
-```
+</code></pre>
 
-<a id="control-led-over-the-net" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#control-leds-over-the-39-net" data-firmware-example-title="Web-Connected LED" data-firmware-example-description="Control an LED over the Internet">
+<div style="display: none;" id="control-led-over-the-net" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#control-leds-over-the-39-net" data-firmware-example-title="Web-Connected LED" data-firmware-example-description="Control an LED over the Internet"></div>
 
 ## Control LEDs over the 'net
 
@@ -144,12 +142,10 @@ As in the previous example, connect everything together as shown in the image be
 
 ![One LED illustration](/assets/images/photon-led-fritzing.png)
 
-<a data-firmware-example-code-block=true>
-
 ### Code
 
 
-```cpp
+<pre><code class="lang-cpp" data-firmware-example-code-block=true>
 // -----------------------------------
 // Controlling LEDs over the Internet
 // -----------------------------------
@@ -219,7 +215,7 @@ int ledToggle(String command) {
     }
 }
 
-```
+</code></pre>
 
 ### Use
 
@@ -298,7 +294,7 @@ Note that the API endpoint is 'led', not 'ledToggle'. This is because the endpoi
 
 To better understand the concept of making API calls to your device over the cloud checkout the [Cloud API reference.](/reference/api)
 
-<a id="variables-and-functions-with-photoresistors" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#read-your-photoresistor-function-and-variable" data-firmware-example-title="Function Variable" data-firmware-example-description="Learn about Variables and Functions using Photoresistors">
+<div style="display: none;" id="variables-and-functions-with-photoresistors" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#read-your-photoresistor-function-and-variable" data-firmware-example-title="Function Variable" data-firmware-example-description="Learn about Variables and Functions using Photoresistors"></div>
 
 ## Read your Photoresistor: Function and Variable
 
@@ -323,9 +319,7 @@ Bend the LED and the PHotoresistor so that they are pointing at each other. (You
 
 Copy and paste the following code into your [online IDE](http://build.particle.io) or [Particle Dev](http://particle.io/dev) environment.
 
-<a data-firmware-example-code-block=true>
-
-```cpp
+<pre><code class="lang-cpp" data-firmware-example-code-block=true>
 // -----------------------------------------
 // Function and Variable with Photoresistors
 // -----------------------------------------
@@ -396,7 +390,7 @@ int ledToggle(String command) {
 
 }
 
-```
+</code></pre>
 
 ### Use
 
@@ -469,7 +463,7 @@ and make sure you replace `device_name` with either your device ID or the casual
 
 Now you can turn your LED on and off and see the values at A0 change based on the photoresistor!
 
-<a id="publish-and-the-dashboard" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#make-a-motion-detector-publish-and-the-dashboard" data-firmware-example-title="Publish" data-firmware-example-description="Publish and the Dashboard">
+<div style="display: none;" id="publish-and-the-dashboard" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#make-a-motion-detector-publish-and-the-dashboard" data-firmware-example-title="Publish" data-firmware-example-description="Publish and the Dashboard"></div>
 
 ## Make a Motion Detector: Publish and the Dashboard
 
@@ -497,9 +491,7 @@ Ensure that the short end of the LED is plugged into `GND` and that the LED and 
 
 ### Code
 
-<a data-firmware-example-code-block=true>
-
-```cpp
+<pre><code class="lang-cpp" data-firmware-example-code-block=true>
 // -----------------------------------------
 // Publish and Dashboard with Photoresistors
 // -----------------------------------------
@@ -660,9 +652,9 @@ void loop() {
   }
 
 }
-```
+</code></pre>
 
-<a id="publish-and-subscribe-with-photoresistors" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#the-buddy-system-publish-and-subscribe" data-firmware-example-title="Subscribe" data-firmware-example-description="Learn about Publish and Subscribe using Photoresistors">
+<div style="display: none;" id="publish-and-subscribe-with-photoresistors" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#the-buddy-system-publish-and-subscribe" data-firmware-example-title="Subscribe" data-firmware-example-description="Learn about Publish and Subscribe using Photoresistors"></div>
 
 ## The Buddy System: Publish and Subscribe
 
@@ -691,9 +683,7 @@ Ensure that the short end of the LED is plugged into `GND` and that the LED and 
 
 ### Code
 
-<a data-firmware-example-code-block=true>
-
-```cpp
+<pre><code class="lang-cpp" data-firmware-example-code-block=true>
 // -----------------------------------------
 // Publish and Subscribe with Photoresistors
 /* -----------------------------------------
@@ -869,9 +859,9 @@ void myHandler(const char *event, const char *data)
   }
 }
 
-```
+</code></pre>
 
-<a id="annotated-tinker-firmware" data-firmware-example-url="http://docs.particle.io/photon/tinker/#annotated-tinker-firmware" data-firmware-example-title="Tinker" data-firmware-example-description="The factory default firmware that mobile apps interact with">
+<div style="display: none;" id="annotated-tinker-firmware" data-firmware-example-url="http://docs.particle.io/photon/tinker/#annotated-tinker-firmware" data-firmware-example-title="Tinker" data-firmware-example-description="The factory default firmware that mobile apps interact with"></div>
 
 ## Tinker
 
@@ -894,9 +884,7 @@ I know what you're thinking: this is amazing, but I really want to use Tinker *w
 
 Combine your code with this framework, flash it to your device, and Tinker away. You can also access Tinker code by clicking on the last example in the online IDE's code menu.
 
-<a data-firmware-example-code-block=true>
-
-```cpp
+<pre><code class="lang-cpp" data-firmware-example-code-block=true>
 /* Function prototypes -------------------------------------------------------*/
 int tinkerDigitalRead(String pin);
 int tinkerDigitalWrite(String command);
@@ -1041,5 +1029,5 @@ int tinkerAnalogWrite(String command)
   }
   else return -2;
 }
-```
+</code></pre>
 

--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -28,6 +28,7 @@ To complete all the examples, you will need the following materials:
 * **Experience**
   * Connecting your Device [with your smartphone](/guide/getting-started/start) or [over USB](/guide/getting-started/connect)
 
+<a id="blink-an-led" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#blink-an-led" data-firmware-example-title="Blink an LED" data-firmware-example-description="Blink an LED">
 
 ## Blink an LED
 
@@ -47,6 +48,7 @@ Go ahead and save this application, then flash it to your Core or Photon. You sh
 
 ### Code
 
+<a data-firmware-example-code-block=true>
 
 ```cpp
 // ------------
@@ -122,6 +124,7 @@ void loop() {
 
 ```
 
+<a id="control-led-over-the-net" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#control-leds-over-the-39-net" data-firmware-example-title="Web-Connected LED" data-firmware-example-description="Control an LED over the Internet">
 
 ## Control LEDs over the 'net
 
@@ -140,6 +143,8 @@ We've heavily commented the code below so that you can see what's going on. Basi
 As in the previous example, connect everything together as shown in the image below. The negative (shorter) pin of the LED is connected to ground via a resistor and the positive (longer) pin is connected to D0.
 
 ![One LED illustration](/assets/images/photon-led-fritzing.png)
+
+<a data-firmware-example-code-block=true>
 
 ### Code
 
@@ -293,6 +298,8 @@ Note that the API endpoint is 'led', not 'ledToggle'. This is because the endpoi
 
 To better understand the concept of making API calls to your device over the cloud checkout the [Cloud API reference.](/reference/api)
 
+<a id="variables-and-functions-with-photoresistors" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#read-your-photoresistor-function-and-variable" data-firmware-example-title="Function Variable" data-firmware-example-description="Learn about Variables and Functions using Photoresistors">
+
 ## Read your Photoresistor: Function and Variable
 
 ### Intro
@@ -315,6 +322,8 @@ Bend the LED and the PHotoresistor so that they are pointing at each other. (You
 ### Code
 
 Copy and paste the following code into your [online IDE](http://build.particle.io) or [Particle Dev](http://particle.io/dev) environment.
+
+<a data-firmware-example-code-block=true>
 
 ```cpp
 // -----------------------------------------
@@ -460,6 +469,7 @@ and make sure you replace `device_name` with either your device ID or the casual
 
 Now you can turn your LED on and off and see the values at A0 change based on the photoresistor!
 
+<a id="publish-and-the-dashboard" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#make-a-motion-detector-publish-and-the-dashboard" data-firmware-example-title="Publish" data-firmware-example-description="Publish and the Dashboard">
 
 ## Make a Motion Detector: Publish and the Dashboard
 
@@ -487,6 +497,7 @@ Ensure that the short end of the LED is plugged into `GND` and that the LED and 
 
 ### Code
 
+<a data-firmware-example-code-block=true>
 
 ```cpp
 // -----------------------------------------
@@ -651,6 +662,8 @@ void loop() {
 }
 ```
 
+<a id="publish-and-subscribe-with-photoresistors" data-firmware-example-url="https://docs.particle.io/guide/getting-started/examples/photon/#the-buddy-system-publish-and-subscribe" data-firmware-example-title="Subscribe" data-firmware-example-description="Learn about Publish and Subscribe using Photoresistors">
+
 ## The Buddy System: Publish and Subscribe
 
 ### Intro
@@ -677,6 +690,8 @@ The setup is the same as in the last example. Set up your breadboard as follows:
 Ensure that the short end of the LED is plugged into `GND` and that the LED and Photoresistor are bent to face each other. (You want the LED, when turned on, to shine its beam of light directly at the photoresistor.) Try to leave enough space between the LED and the Photoresistor for your finger or a piece of paper.
 
 ### Code
+
+<a data-firmware-example-code-block=true>
 
 ```cpp
 // -----------------------------------------
@@ -856,6 +871,8 @@ void myHandler(const char *event, const char *data)
 
 ```
 
+<a id="annotated-tinker-firmware" data-firmware-example-url="http://docs.particle.io/photon/tinker/#annotated-tinker-firmware" data-firmware-example-title="Tinker" data-firmware-example-description="The factory default firmware that mobile apps interact with">
+
 ## Tinker
 
 Remember back when we were blinking lights and reading sensors with Tinker on the mobile app?
@@ -877,6 +894,7 @@ I know what you're thinking: this is amazing, but I really want to use Tinker *w
 
 Combine your code with this framework, flash it to your device, and Tinker away. You can also access Tinker code by clicking on the last example in the online IDE's code menu.
 
+<a data-firmware-example-code-block=true>
 
 ```cpp
 /* Function prototypes -------------------------------------------------------*/


### PR DESCRIPTION
Hey @cmsunu28 @brycekahle , here's a PR that adds these invisible tags so app examples in the web ide are synced with the documentation.

Christine: Please give the staging web ide a look and confirm everything imported correctly.
Bryce: If this looks good to you, please merge it in and close PR.

Thanks!
