### PR TITLE
Fix #147 - Add license information

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "particle-docs",
   "version": "0.3.0",
   "private": false,
+  "license": "CC-BY-SA-3.0",
   "repository": {
     "type": "git",
     "url": "git://github.com/spark/docs.git"


### PR DESCRIPTION
Related to #147 

The Creative Commons Attribution-ShareAlike 3.0 license information (CC-BY-SA-3.0) was added to the package.json file.

https://docs.npmjs.com/files/package.json#license
