### PR TITLE
Fix typo in example for System.version()

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -4952,7 +4952,7 @@ void setup()
 {
    Serial.printlnf("System version: %s", System.version());
    // prints
-   // System versio: 0.4.7
+   // System version: 0.4.7
 }
 
 ```


### PR DESCRIPTION
Was:
// System versio: 0.4.7

Corrected:
// System version: 0.4.7
