### PR TITLE
EEPROM.write() is void

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -4507,9 +4507,6 @@ Write a byte of data to the emulated EEPROM.
 
 - On the Core, this must be a value between 0 and 99
 - On the Photon, this must be a value between 0 and 2047
-
-The function returns `0xFF` when an invalid address is used.
-
 ```C++
 // EXAMPLE USAGE
 


### PR DESCRIPTION
EEPROM.write() doesn't return anything on error since it is void.

https://github.com/spark/firmware/blob/91172bb7864ba6580654bdd8154bcb5f1953edfc/wiring/inc/spark_wiring_eeprom.h#L128
