### PR TITLE
add comment on max I2C clock speed.

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -2219,7 +2219,7 @@ This library allows you to communicate with I2C / TWI devices. On the Core/Photo
 
 ### setSpeed()
 
-Sets the I2C clock speed. This is an optional call (not from the original Arduino specs.) and must be called once before calling begin().  The default I2C clock speed is 100KHz.
+Sets the I2C clock speed. This is an optional call (not from the original Arduino specs.) and must be called once before calling begin().  The default I2C clock speed is 100KHz and the maximum clock speed is 400KHz.
 
 ```C++
 // SYNTAX


### PR DESCRIPTION
STM32F1xx and STM32F2xx in Core and Photon supports I2C at Standard or
Fast Mode with a max clock frequency of 400KHz.
