### PR TITLE
Correct Subscriber in firmware.md

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -360,7 +360,7 @@ You can register a method in a C++ object as a subscription handler.
 ```cpp
 class Subscriber {
   public:
-    void subscribe() {
+   Subscriber() {
       Particle.subscribe("some_event", &Subscriber::handler, this);
     }
     void handler(const char *eventName, const char *data) {
@@ -369,7 +369,7 @@ class Subscriber {
 };
 
 Subscriber mySubscriber;
-// nothing else needed in setup() or loop()
+// now nothing else is needed in setup() or loop()
 ```
 
 ---


### PR DESCRIPTION
The Example Subscriber did not work as expected (nothing else needed ...) because the Construktor was coded as a method instead.
