### PR TITLE
Fix merge conflict in examples.md

### DIFF
--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -998,17 +998,6 @@ int tinkerAnalogRead(String pin)
 	return -2;
 }
 
-<<<<<<< HEAD
-**Also**, check out and join our [community forums](http://community.particle.io/) for advanced help, tutorials, and troubleshooting.
-
-{{#if photon}}
-[Go to Community Forums >](http://community.particle.io/c/troubleshooting)
-{{/if}}
-
-{{#if core}}
-[Go to Community Forums >](http://community.particle.io/c/troubleshooting)
-{{/if}}
-=======
 /*******************************************************************************
  * Function Name  : tinkerAnalogWrite
  * Description    : Writes an analog value (PWM) to the specified pin
@@ -1040,4 +1029,13 @@ int tinkerAnalogWrite(String command)
 	else return -2;
 }
 </code></pre>
->>>>>>> master
+
+**Also**, check out and join our [community forums](http://community.particle.io/) for advanced help, tutorials, and troubleshooting.
+
+{{#if photon}}
+[Go to Community Forums >](http://community.particle.io/c/troubleshooting)
+{{/if}}
+
+{{#if core}}
+[Go to Community Forums >](http://community.particle.io/c/troubleshooting)
+{{/if}}


### PR DESCRIPTION
The markup in examples.md has a few lines from an unresolved conflict from this merge https://github.com/spark/docs/commit/9c3cd0e49e5fadacc3c63cd09dbfed9ea89b4774

I just removed the git conflict markers and fixed the conflict.
