### PR TITLE
Mark WiFi.getCredentials as available since 0.4.9

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -791,6 +791,8 @@ WiFi.setCredentials("SSID", "PASSWORD", WPA2, WLAN_CIPHER_AES));
 
 ### getCredentials()
 
+*Since 0.4.9.*
+
 Lists the Wi-Fi credentials stored on the device. Returns the number of stored credentials.
 
 {{#if core}}


### PR DESCRIPTION
Per GitHub comment https://github.com/spark/docs/commit/517c61591755c11397742934c5fc47da5e7687b0#commitcomment-15781276
