### PR TITLE
Add system-button and reset-button template helper

### DIFF
--- a/src/content/guide/getting-started/modes.md
+++ b/src/content/guide/getting-started/modes.md
@@ -56,7 +56,7 @@ When it is breathing cyan, your {{device}} is happily connected to the Internet.
 If your {{device}} is blinking magenta, it is currently loading an app or updating its firmware. This state is triggered by a firmware update or by flashing code from Particle Dev or Particle Build. You will often see this mode when you connect your {{device}} to the cloud for the first time.
 
 
-Note that, if you enter this mode by holding {{#if photon}}`SETUP`{{/if}}{{#unless photon}}`MODE`{{/unless}} on boot, blinking magenta indicates that letting go of the {{#if photon}}`SETUP`{{/if}}{{#unless photon}}`MODE`{{/unless}} button will enter safe mode to connect to the cloud and not run application firmware.
+Note that, if you enter this mode by holding `{{system-button}}` on boot, blinking magenta indicates that letting go of the `{{system-button}}` button will enter safe mode to connect to the cloud and not run application firmware.
 
 ### Looking For Internet
 
@@ -111,7 +111,7 @@ When your {{device}} is in Listening Mode, it is waiting for your input to conne
 {{#if photon}}
 {{{vine "https://vine.co/v/eZUHUIjq7pO/embed/simple"}}}
 
-To put your {{device}} in Listening Mode, hold the `SETUP` button for three seconds, until the RGB LED begins blinking blue.
+To put your {{device}} in Listening Mode, hold the `{{system-button}}` button for three seconds, until the RGB LED begins blinking blue.
 {{/if}}
 
 {{#if electron}}
@@ -119,13 +119,13 @@ To put your {{device}} in Listening Mode, hold the `SETUP` button for three seco
 {{{vine "https://vine.co/v/eZUHUIjq7pO/embed/simple"}}}
 {{/if}}
 
-To put your {{device}} in Listening Mode, hold the `MODE` button for three seconds, until the RGB LED begins blinking blue.
+To put your {{device}} in Listening Mode, hold the `{{system-button}}` button for three seconds, until the RGB LED begins blinking blue.
 {{/if}}
 
 {{#if core}}
 {{{vine "https://vine.co/v/eZUgHYYrYgl/embed/simple"}}}
 
-To put your {{device}} in Listening Mode, hold the `MODE` button for three seconds, until the RGB LED begins blinking blue.
+To put your {{device}} in Listening Mode, hold the `{{system-button}}` button for three seconds, until the RGB LED begins blinking blue.
 {{/if}}
 
 
@@ -135,9 +135,9 @@ To put your {{device}} in Listening Mode, hold the `MODE` button for three secon
 
 {{{vine "https://vine.co/v/eZUwtJljYnK/embed/simple"}}}
 
-To erase the stored wifi networks on your {{device}}, hold the `SETUP` button for about ten seconds, until the RGB LED blinks blue rapidly.
+To erase the stored wifi networks on your {{device}}, hold the `{{system-button}}` button for about ten seconds, until the RGB LED blinks blue rapidly.
 
-You can also reset the Wi-Fi networks by holding the `SETUP` button and tapping `RESET`, then continuing to hold `SETUP` until the light on the {{device}} turns white. (This differs from the Core. Doing this action on the Core will result in a factory reset.)
+You can also reset the Wi-Fi networks by holding the `{{system-button}}` button and tapping `{{reset-button}}`, then continuing to hold `{{system-button}}` until the light on the {{device}} turns white. (This differs from the Core. Doing this action on the Core will result in a factory reset.)
 
 {{/if}}
 
@@ -147,7 +147,7 @@ You can also reset the Wi-Fi networks by holding the `SETUP` button and tapping 
 
 {{{vine "https://vine.co/v/eZU6expA5bA/embed/simple"}}}
 
-To erase the stored wifi networks on your {{device}}, hold the `MODE` button for about ten seconds, until the RGB LED blinks blue rapidly.
+To erase the stored wifi networks on your {{device}}, hold the `{{system-button}}` button for about ten seconds, until the RGB LED blinks blue rapidly.
 
 {{/if}}
 
@@ -164,9 +164,9 @@ Safe mode connects the {{device}} to the cloud, but does not run any application
 To put your device in Safe Mode:
 
 1. Hold down BOTH buttons
-2. Release only the `RESET` button, while holding down the `SETUP` button.
+2. Release only the `{{reset-button}}` button, while holding down the `{{system-button}}` button.
 3. Wait for the LED to start blinking magenta
-6. Release the `SETUP` button
+6. Release the `{{system-button}}` button
 
 The device will itself automatically enter safe mode if there is no application code flashed to the device or when the application is not valid.
 
@@ -187,9 +187,9 @@ Safe mode connects the {{device}} to the cloud, but does not run any application
 To put your device in Safe Mode:
 
 1. Hold down BOTH buttons
-2. Release only the `RESET` button, while holding down the `MODE` button.
+2. Release only the `{{reset-button}}` button, while holding down the `{{system-button}}` button.
 3. Wait for the LED to start blinking magenta
-6. Release the `MODE` button
+6. Release the `{{system-button}}` button
 
 The device will itself automatically enter safe mode if there is no application code flashed to the device or when the application is not valid.
 
@@ -211,9 +211,9 @@ To enter DFU Mode:
 {{#unless core}}
 
 1. Hold down BOTH buttons
-2. Release only the `RESET` button, while holding down the {{#if photon}}`SETUP`{{/if}}{{#if electron}}`MODE`{{/if}} button.
+2. Release only the `{{reset-button}}` button, while holding down the `{{system-button}}` button.
 3. Wait for the LED to start flashing yellow (it will flash magenta first)
-4. Release the {{#if photon}}`SETUP`{{/if}}{{#if electron}}`MODE`{{/if}} button
+4. Release the `{{system-button}}` button
 
 {{#if photon}}
 {{{vine "https://vine.co/v/eZUHnhaUD9Y/embed/simple"}}}
@@ -224,9 +224,9 @@ To enter DFU Mode:
 {{#if core}}
 
 1. Hold down BOTH buttons
-2. Release only the `RST` button, while holding down the `MODE` button.
+2. Release only the `RST` button, while holding down the `{{system-button}}` button.
 3. Wait for the LED to start flashing yellow
-4. Release the `MODE` button
+4. Release the `{{system-button}}` button
 
 {{{vine "https://vine.co/v/eZUgeu0r639/embed/simple"}}}
 
@@ -265,14 +265,14 @@ A factory reset restores the firmware on the {{device}} to the default Tinker ap
 
 Procedure:
 
-The procedure is same as the one described above (DFU Mode), but in this case you should continue holding down the MODE button until you see the {{device}} change from blinking yellow to blinking white. Then release the button.  The {{device}} should begin after the factory reset is complete.
+The procedure is same as the one described above (DFU Mode), but in this case you should continue holding down the `{{system-button}}` button until you see the {{device}} change from blinking yellow to blinking white. Then release the button.  The {{device}} should begin after the factory reset is complete.
 
 1. Hold down BOTH buttons
-2. Release only the `RST` button, while holding down the `MODE` button.
-3. Wait for the LED to start blinking yellow (continue to hold the `MODE` button)
-4. The LED will turn solid white (continue to hold the `MODE` button)
+2. Release only the `RST` button, while holding down the `{{system-button}}` button.
+3. Wait for the LED to start blinking yellow (continue to hold the `{{system-button}}` button)
+4. The LED will turn solid white (continue to hold the `{{system-button}}` button)
 5. Finally, the LED will turn blink white rapidly
-6. Release the `MODE` button
+6. Release the `{{system-button}}` button
 
 
 You can reset Wi-Fi credentials by performing a [WiFi Network Reset](#wi-fi-network-reset).

--- a/src/content/guide/getting-started/start.md
+++ b/src/content/guide/getting-started/start.md
@@ -87,7 +87,7 @@ to wired power source. Consider this battery your Electron's best friend!
 {{#if photon}}
 {{{popup '**Buttons**' 'img' 'photon-buttons.jpg'}}} **and** {{{popup '**LEDs.**' 'img' 'photon-leds.jpg'}}} There are several awesome buttons and LEDs on your Photon to make it easier to use.
 
-- The `SETUP` button is on the left and the `RESET` button is on the right. You can use these buttons to help you set your device's [mode](/guide/getting-started/modes).
+- The `{{system-button}}` button is on the left and the `{{reset-button}}` button is on the right. You can use these buttons to help you set your device's [mode](/guide/getting-started/modes).
 - The RGB LED is in the center of your Photon, above the module. The color of the RGB LED tells you what [mode](/guide/getting-started/modes) your Photon is currently in.
 - The D7 LED is next to the D7 pin on your Photon, on the upper right quadrant. This LED will turn on when the D7 pin is set to `HIGH`.
 
@@ -98,7 +98,7 @@ to wired power source. Consider this battery your Electron's best friend!
 
 {{{popup '**Buttons**' 'img' 'core-buttons.jpg'}}} **and** {{{popup '**LEDs.**' 'img' 'core-leds.jpg'}}} There are several awesome buttons and LEDs on your Core to make it easier to use.
 
-- The `MODE` button is on the left and the `RESET` button is on the right. You can use these buttons to help you set your device's [mode](/guide/getting-started/modes).
+- The `{{system-button}}` button is on the left and the `{{reset-button}}` button is on the right. You can use these buttons to help you set your device's [mode](/guide/getting-started/modes).
 - The **RGB LED** is in the center of your Core, above the module. The color of the RGB LED tells you what [mode](/guide/getting-started/modes) your Core is currently in.
 - The **D7 LED** in the upper right side of your device. This LED will turn on when the D7 pin is set to `HIGH`.
 
@@ -114,12 +114,12 @@ For more technical details on what comes on your device, go {{#if core}}[here](/
 - When the LED turns off, the battery is fully charged
 
 ### Display signal strength!
-- Press MODE once quickly when the Electron is breathing cyan
+- Press `{{system-button}}` once quickly when the Electron is breathing cyan
 - The signal strength (RSSI) will be shown in a 0-5 green blinks, 5 being the strongest
 
 ### Soft Power Down
-- Tap MODE twice quickly, then the LED will show white, and then it will turn off in a few seconds
-- To turn it back on tap RESET once
+- Tap `{{system-button}}` twice quickly, then the LED will show white, and then it will turn off in a few seconds
+- To turn it back on tap `{{reset-button}}` once
 - You can use use soft power down instead of unplugging the battery or power
 - This uses a deep sleep mode for the Electron, and will still use 0.13mA
 {{/if}}
@@ -259,7 +259,7 @@ This may take a little while - but don't worry.
 
 If you can't seem to get the Mobile App to connect your device, that's okay! Read over this example quickly, and then check out the [next lesson](/guide/getting-started/connect) to connect your device using the USB cable.
 
-Once you have connected your device, it has learned that network. Your device can store up to {{#if core}}seven{{/if}} {{#if photon}}five{{/if}} networks. To add a new network after your initial setup, you'd put your device into {{#if photon}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZUH7WaWjMT/embed/simple'}}}{{/if}}{{#if core}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZU6YiK20Hl/embed/simple'}}}{{/if}} again and proceede as above (the claiming part can be skipped). If you feel like your device has too many networks on it, you can wipe your device's memory of any wifi networks it has learned. You can do so by continuing to hold the {{#if photon}}SETUP{{/if}}{{#if core}}MODE{{/if}} button for 10 seconds until the RGB LED flashes blue quickly, signaling that all profiles have been deleted.
+Once you have connected your device, it has learned that network. Your device can store up to {{#if core}}seven{{/if}} {{#if photon}}five{{/if}} networks. To add a new network after your initial setup, you'd put your device into {{#if photon}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZUH7WaWjMT/embed/simple'}}}{{/if}}{{#if core}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZU6YiK20Hl/embed/simple'}}}{{/if}} again and proceede as above (the claiming part can be skipped). If you feel like your device has too many networks on it, you can wipe your device's memory of any wifi networks it has learned. You can do so by continuing to hold the `{{system-button}}` button for 10 seconds until the RGB LED flashes blue quickly, signaling that all profiles have been deleted.
 
 ### Step 3: Blink an LED!
 {{#if core}}The Spark Core App should now be on the {{{ popup 'Tinker' 'note' 'We have taken the liberty of loading some firmware onto your device for you. It is called Tinker, and it helps you talk to your device by sending power to the pins and reading power levels from the pins. More info about Tinker is available [here](/guide/getting-started/tinker/core).'}}} screen, as shown below.
@@ -326,7 +326,7 @@ This may take a little while - but don't worry.
 
 If you can't seem to get the Mobile App to connect your device, that's okay! Read over this example quickly, and then check out the [next lesson](/guide/getting-started/connect) to connect your device using the USB cable.
 
-Once you have connected your device, it has learned that network. Your device can store up to {{#if core}}seven{{/if}} {{#if photon}}five{{/if}} networks. To add a new network after your initial setup, you'd put your device into {{#if photon}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZUH7WaWjMT/embed/simple'}}}{{/if}}{{#if core}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZU6YiK20Hl/embed/simple'}}}{{/if}} again and proceede as above (the claiming part can be skipped). If you feel like your device has too many networks on it, you can wipe your device's memory of any wifi networks it has learned. You can do so by continuing to hold the {{#if photon}}SETUP{{/if}}{{#if core}}MODE{{/if}} button for 10 seconds until the RGB LED flashes blue quickly, signaling that all profiles have been deleted.
+Once you have connected your device, it has learned that network. Your device can store up to {{#if core}}seven{{/if}} {{#if photon}}five{{/if}} networks. To add a new network after your initial setup, you'd put your device into {{#if photon}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZUH7WaWjMT/embed/simple'}}}{{/if}}{{#if core}}{{{popup 'Listening Mode' 'vine' 'https://vine.co/v/eZU6YiK20Hl/embed/simple'}}}{{/if}} again and proceede as above (the claiming part can be skipped). If you feel like your device has too many networks on it, you can wipe your device's memory of any wifi networks it has learned. You can do so by continuing to hold the `{{system-button}}` button for 10 seconds until the RGB LED flashes blue quickly, signaling that all profiles have been deleted.
 
 ### Step 3: Blink an LED!
 {{#if core}}The Spark Core App should now be on the {{{ popup 'Tinker' 'note' 'We have taken the liberty of loading some firmware onto your device for you. It is called Tinker, and it helps you talk to your device by sending power to the pins and reading power levels from the pins. More info about Tinker is available [here](/guide/getting-started/tinker/core).'}}} screen, as shown below.

--- a/src/content/languages/fr/connect.md
+++ b/src/content/languages/fr/connect.md
@@ -122,7 +122,7 @@ Si vous souhaitez programmer un Core avec un firmware personnalisé via USB, vou
 
 Procédure:
 
-Enfoncez les deux boutons, puis relâchez le bouton RST, tout en laissant enfoncé le bouton MODE. Relâchez le bouton MODE dès que la LED commence à clignoter en jaune. Le Core est maintenant en mode DFU.
+Enfoncez les deux boutons, puis relâchez le bouton RST, tout en laissant enfoncé le bouton `{{system-button}}`. Relâchez le bouton `{{system-button}}` dès que la LED commence à clignoter en jaune. Le Core est maintenant en mode DFU.
 
 
 <iframe class="vine-embed" src="https://vine.co/v/MahhI1Fg7O6/embed/simple" width="320" height="320" frameborder="0"></iframe>
@@ -134,7 +134,7 @@ Une remise au paramètres d'usine restaure le firmware sur le Core avec l'applic
 
 Procédure: 
 
-La procédure est la même que celle décrite ci-dessus (mode DFU), mais dans ce cas vous devez continuer d'appuyer sur le bouton MODE jusqu'à ce que le Core passe du clignotement en jaune au clignotement en blanc. Puis relâchez le bouton. Le Core devrait commencer à clignoter en bleu une fois la remise aux paramètres d'usine terminée.
+La procédure est la même que celle décrite ci-dessus (mode DFU), mais dans ce cas vous devez continuer d'appuyer sur le bouton `{{system-button}}` jusqu'à ce que le Core passe du clignotement en jaune au clignotement en blanc. Puis relâchez le bouton. Le Core devrait commencer à clignoter en bleu une fois la remise aux paramètres d'usine terminée.
 
 **Note :** La vidéo ci-dessous est la suite de la vidéo précédente (mode DFU).
 

--- a/src/content/languages/fr/start.md
+++ b/src/content/languages/fr/start.md
@@ -95,16 +95,16 @@ Quand le Core de connecte à Internet, il crée une connexion au *Spark Cloud*. 
 
 ### Boutons
 
-Il y a deux boutons sur le Core : le bouton RESET (sur la droite) et le bouton MODE (sur la gauche).
+Il y a deux boutons sur le Core : le bouton `{{reset-button}}` (sur la droite) et le bouton `{{system-button}}` (sur la gauche).
 
-Le bouton RESET va effectuer un redémarrage matériel du Core, en coupant et réactivant son alimentation. C'est une bonne manière pour redémarrer une application que vous avez téléchargé sur le Core.
+Le bouton `{{reset-button}}` va effectuer un redémarrage matériel du Core, en coupant et réactivant son alimentation. C'est une bonne manière pour redémarrer une application que vous avez téléchargé sur le Core.
 
-Le bouton MODE a trois fonctions :
+Le bouton `{{system-button}}` a trois fonctions :
 
-- Tenez le bouton MODE enfoncé pendant trois secondes pour mettre le Core en mode *Smart Config* afin de le connecter à votre réseau Wi-Fi local. La LED devrait commencer à clignoter en bleu.
-- Tenez le bouton MODE enfoncé pendant dix secondes pour effacer de la mémoire du Core les informations sur les réseaux Wi-Fi
-- Tenez le bouton MODE enfoncé, appuyez un coup sur le bouton RESET, et patientez *trois secondes* pour entrer dans le mode *Bootloader*, d'où vous pouvez reprogrammer le Core via USB ou JTAG. Relâchez le bouton MODE quand la LED commence à clignoter en jaune. Si vous le faites accidentellement, appuyez juste un coup sur le bouton RESET pour quitter le mode *Bootloader*
-- Tenez le bouton MODE enfoncé, appuyez un coup sur le bouton RESET, et patientez *dix secondes* pour effectuer une *restauration des paramètres d'usine* où le Core est reprogrammé avec l'application qui y était installée à l'usine (l'application Tinker). La LED devrait clignoter en blanc pendant trois secondes puis se mettre à clignoter rapidement. Quand la LED clignote d'une autre couleur, le Core a été remis aux valeurs par défaut. C'est très utile quand vous avez un bug dans votre firmware ou bien que vous souhaitez réinstaller l'application Tinker.
+- Tenez le bouton `{{system-button}}` enfoncé pendant trois secondes pour mettre le Core en mode *Smart Config* afin de le connecter à votre réseau Wi-Fi local. La LED devrait commencer à clignoter en bleu.
+- Tenez le bouton `{{system-button}}` enfoncé pendant dix secondes pour effacer de la mémoire du Core les informations sur les réseaux Wi-Fi
+- Tenez le bouton `{{system-button}}` enfoncé, appuyez un coup sur le bouton `{{reset-button}}`, et patientez *trois secondes* pour entrer dans le mode *Bootloader*, d'où vous pouvez reprogrammer le Core via USB ou JTAG. Relâchez le bouton `{{system-button}}` quand la LED commence à clignoter en jaune. Si vous le faites accidentellement, appuyez juste un coup sur le bouton `{{reset-button}}` pour quitter le mode *Bootloader*
+- Tenez le bouton `{{system-button}}` enfoncé, appuyez un coup sur le bouton `{{reset-button}}`, et patientez *dix secondes* pour effectuer une *restauration des paramètres d'usine* où le Core est reprogrammé avec l'application qui y était installée à l'usine (l'application Tinker). La LED devrait clignoter en blanc pendant trois secondes puis se mettre à clignoter rapidement. Quand la LED clignote d'une autre couleur, le Core a été remis aux valeurs par défaut. C'est très utile quand vous avez un bug dans votre firmware ou bien que vous souhaitez réinstaller l'application Tinker.
 
 
 ### LEDs
@@ -139,7 +139,7 @@ Le Core possède 24 broches que vous pouvez connecter à un circuit. Ces broches
 - _VIN_ : Connectez à cette broche une alimentation non régulée d'une tension comprise entre 3,6V et 6V pour alimenter le Core. Si vous alimentez le Core via USB, cette broche *ne doit pas* être utilisée.
 - _3V3_ : Cette broche fournie une tension régulée de 3,3V que vous pouvez utiliser pour alimenter d'autres composants en dehors du Core. (De même, si vous possédez votre propre alimentation régulée de 3,3V, vous pouvez la brancher ici pour alimenter le Core).
 - _3V3*_ : Cette broche fournie une autre tension régulée de 3,3V, mais filtrée. Elle est destinée à alimenter des circuits sensibles au bruit provenant des composants électroniques. Si vous utilisez des capteurs analogiques sensibles, alimentez les via la broche _3V3*_ plutôt que la broche _3V3_.
-- _!RST_ : Vous pouvez redémarrer le Core (de la même manière qu'en appuyant sur le bouton RESET) en connectant cette broche à GND.
+- _!RST_ : Vous pouvez redémarrer le Core (de la même manière qu'en appuyant sur le bouton `{{reset-button}}`) en connectant cette broche à GND.
 - _GND_ : Ces broches sont les broches de mise à la masse.
 - _D0 à D7_ : Ces broches sont les broches à tout faire du Spark Core : 8 broches GPIO (General Purpose Input/Output). Elles sont libellées « D » parce que ce sont des broches « numériques » (Digital), ce qui signifie qu'elles ne peuvent pas lire les valeurs des capteurs analogiques. Certaines de ces broches possèdent des périphériques additionnels (SPI, JTAG, etc.), plus d'infos plus loin.
 - _A0 à A7_ : Ces broches sont 8 broches GPIO supplémentaires, pour un total de 16. Elles sont identiques à D0 à D7, si ce n'est qu'elles sont des broches « analogiques », ce qui signifie qu'elles peuvent lire les valeurs de capteurs analogiques (techniquement, elles possèdent un périphérique de conversion analogique vers numérique). Tout comme les broches numériques, certaines de ces broches possèdent des périphériques additionnels

--- a/src/content/languages/it/connect.md
+++ b/src/content/languages/it/connect.md
@@ -9,7 +9,7 @@ Per tutti i metodi seguenti lo Spark Core deve essere in modalità "ascolto", ri
 
 <iframe class="vine-embed" src="https://vine.co/v/hFHlpBDELeU/embed/simple" width="320" height="320" frameborder="0"></iframe>
 
-Il Core parte in modo ascolto per default quindi, se il vostro Core è nuovo, dovrebbe partire direttamente in modalità ascolto. Altrimenti tenete premuto il bottone MODE per tre secondi.
+Il Core parte in modo ascolto per default quindi, se il vostro Core è nuovo, dovrebbe partire direttamente in modalità ascolto. Altrimenti tenete premuto il bottone `{{system-button}}` per tre secondi.
 
 ## Configurazione smart con l'app Spark
 
@@ -155,7 +155,7 @@ Spesso gli apparecchi elettronici cominciano a comportarsi in modo corretto dopo
 
 - Chiudere la vostra applicazione mobile e riaprirla
 - Scollegare e ricollegare lo Spark Core
-- Pulire la memoria delle reti Wi-Fi dello Spark Core tenendo premuto il bottone MODE per 10 secondi. Dopo 3 secondi la luce dovrebbe cominciare a lampeggiare blu; dopo 10 secondi dovrebbe emettere dei veloci flashes blu. Questo significa che la memoria è stata liberata.
+- Pulire la memoria delle reti Wi-Fi dello Spark Core tenendo premuto il bottone `{{system-button}}` per 10 secondi. Dopo 3 secondi la luce dovrebbe cominciare a lampeggiare blu; dopo 10 secondi dovrebbe emettere dei veloci flashes blu. Questo significa che la memoria è stata liberata.
 - Impostare il firmware dello Spark Core ai valori predefiniti di fabbrica. Fare questo in modo giusto può essere un po' complicato, si veda [questo video](https://community.particle.io/t/how-to-do-a-factory-reset/2579) per un'illustrazione.
 
 ## PASSO 4: Controllare i valori del router
@@ -225,5 +225,5 @@ Completate i seguenti passi:
 2. Provate un'altro alimentatore. Dovreste alimentare il vostro Core con un alimentatore capace di fornire almeno 500mA di corrente. Raccomandiamo l'utilizzo di un alimentatore 5V/1A come quelli usati per caricare i cellulari.
 3. Se la vostra rete ha una pagina di benvenuto o simili, il Core non riuscirà a connettersi; provate a configurarlo su un'altra rete.
 4. Provate [reboot e liberare la memoria](/#/connect/troubleshooting-step-3-reboot-e-liberare-la-memoria).
-5. Provate un factory reset.  Premete entrambi i bottoni, rilasciate il bottone RST tenendo premuto il bottone MODE. Il LED dovrebbe cominciare a lampeggiare in giallo. Continuate a tenere premuto il bottone MODE fino a quando vedete il Core che cambia da giallo a bianco lampeggiante. A questo punto lasciate il bottone. Il Core dovrebbe iniziare a [lampeggiare blu](https://v.cdn.vine.co/r/videos/E465A8959B1015390893882101760_178fcfd2b3c.4.3.11510817618992331600_MIW9HE1mtZ9H_SpBlKdK1lv2UfmniExCFQHrgJ7iqiFDUiDb0E31bR7GwvB_7wz0.mp4?versionId=eS01KUZ6NaUZgEipSDeVi0rxZENByp1N) dopo che l'inizializzazione è completata.
+5. Provate un factory reset.  Premete entrambi i bottoni, rilasciate il bottone RST tenendo premuto il bottone `{{system-button}}`. Il LED dovrebbe cominciare a lampeggiare in giallo. Continuate a tenere premuto il bottone `{{system-button}}` fino a quando vedete il Core che cambia da giallo a bianco lampeggiante. A questo punto lasciate il bottone. Il Core dovrebbe iniziare a [lampeggiare blu](https://v.cdn.vine.co/r/videos/E465A8959B1015390893882101760_178fcfd2b3c.4.3.11510817618992331600_MIW9HE1mtZ9H_SpBlKdK1lv2UfmniExCFQHrgJ7iqiFDUiDb0E31bR7GwvB_7wz0.mp4?versionId=eS01KUZ6NaUZgEipSDeVi0rxZENByp1N) dopo che l'inizializzazione è completata.
 6. Provate a far di nuovo girare il patch pro

--- a/src/content/languages/it/start.md
+++ b/src/content/languages/it/start.md
@@ -94,16 +94,16 @@ Quando il Core si connette a internet, stabilisce una connessione con lo *Spark 
 
 ### Bottoni
 
-Ci sono due bottoni sul Core: il bottone RESET (sulla destra) e il bottone MODE (sulla sinistra). 
+Ci sono due bottoni sul Core: il bottone `{{reset-button}}` (sulla destra) e il bottone `{{system-button}}` (sulla sinistra). 
 
-Con il bottone RESET si esegue un hard reset, proprio togliendo e rimettendo l'alimentazione al microprocessore. Questo è il modo migliore per far ripartire l'applicazione che avete caricato nel Core. Questo è il modo migliore per far ripartire l'applicazione che avete scaricato sul Core.
+Con il bottone `{{reset-button}}` si esegue un hard reset, proprio togliendo e rimettendo l'alimentazione al microprocessore. Questo è il modo migliore per far ripartire l'applicazione che avete caricato nel Core. Questo è il modo migliore per far ripartire l'applicazione che avete scaricato sul Core.
 
-Il bottone MODE serve ha tre funzioni:
+Il bottone `{{system-button}}` serve ha tre funzioni:
 
-- Tenendo premuto il bottone MODE per tre secondi il Core entra in modalità *Smart Config* per connetterlo alla vostra rete Wi-Fi locale. Il LED dovrebbe cominciare a lampeggiare blu.
-- Tenere premuto il bottone MODE per dieci secondi permette di cancellare la memoria delle reti Wi-Fi del Core.
-- Tenendo premuto il bottone MODE e premendo una volta il bottone RESET e aspettando per *tre secondi* il Core entra in modalità *Bootloader*, dove potete riprogrammare il Core via USB o JTAG. Lasciare il bottone quando il LED lampeggia giallo. Se avete fatto tutto questo per errore, semplicemente premere il bottone RESET per lasciare la modalità *Bootloader*.
-- Tenendo premuto il bottone MODE e premendo una volta il bottone RESET e aspettando per *dieci secondi* si effettua un *Factory Reset*, dove il Core viene riprogrammato con il software caricato in fabbrica (l'applicazione Tinker). Il LED dovrebbe diventare bianco per tre secondi e poi lampeggiare velocemente; quando il LED cambia su un altro colore il Core è stato inizializzato. Questa operazione è utile se avete problemi col il vostro firmware o se semplicemente volete tornare a Tinker.
+- Tenendo premuto il bottone `{{system-button}}` per tre secondi il Core entra in modalità *Smart Config* per connetterlo alla vostra rete Wi-Fi locale. Il LED dovrebbe cominciare a lampeggiare blu.
+- Tenere premuto il bottone `{{system-button}}` per dieci secondi permette di cancellare la memoria delle reti Wi-Fi del Core.
+- Tenendo premuto il bottone `{{system-button}}` e premendo una volta il bottone `{{reset-button}}` e aspettando per *tre secondi* il Core entra in modalità *Bootloader*, dove potete riprogrammare il Core via USB o JTAG. Lasciare il bottone quando il LED lampeggia giallo. Se avete fatto tutto questo per errore, semplicemente premere il bottone `{{reset-button}}` per lasciare la modalità *Bootloader*.
+- Tenendo premuto il bottone `{{system-button}}` e premendo una volta il bottone `{{reset-button}}` e aspettando per *dieci secondi* si effettua un *Factory Reset*, dove il Core viene riprogrammato con il software caricato in fabbrica (l'applicazione Tinker). Il LED dovrebbe diventare bianco per tre secondi e poi lampeggiare velocemente; quando il LED cambia su un altro colore il Core è stato inizializzato. Questa operazione è utile se avete problemi col il vostro firmware o se semplicemente volete tornare a Tinker.
 
 
 ### LEDs
@@ -135,7 +135,7 @@ Il Core ha 24 pins a cui si può collegare un circuito. Questi pins sono:
 - _VIN_: Collegate qui un'alimentazione non regolata tra 3.6V e 6V per alimentare il Core. Se si alimenta il Core via USB, questo pin *non* deve essere usato.
 - _3V3_: Questo pin fornisce una tensione regolata di 3.3V che può essere usata per alimentare delle componenti esterne al Core (Se avete la vostra alimentazione regolata di 3.3V la potete collegare qui per alimentare il Core).
 - _3V3*_: Questa è una alimentazione regolata a basso disturbo di 3.3V da usare per circuiti analogici che potrebbero essere sensibili ai disturbi delle componenti digitali. Se usate dei sensori analogici sensibili alimentateli dal pin _3V3*_ invece che dal _3V3_.
-- _!RST_: Potete inizializzare il Core (come premendo il tasto RESET) connettendo questo pin a massa (GND).
+- _!RST_: Potete inizializzare il Core (come premendo il tasto `{{reset-button}}`) connettendo questo pin a massa (GND).
 - _GND_: Questi pins sono collegati a massa.
 - _D0 a D7_: Questi sono il pane e il burro dello Spark Core: 8 GPIO (General Purpose Input/Output) pins. Sono indicati con "D" perchè sono pins digitali, cioè non possono leggere i valori di sensori analogici. Alcuni di questi mettono a disposizione delle periferiche aggiuntive (SPI, JTAG, etc.), vedi più avanti per maggiori informazioni.
 - _A0 a A7_: Questi pins sono 8 GPIO in più che portano il totale a 16. Questi pins sono come quelli da D0 a D7, ma sono "Analogici", cioè possono leggere i dati dai sensori analogici (tecnicamente hanno una periferica ADC). Come per i pins digitali anche questi hanno delle periferiche aggiuntive.

--- a/src/content/languages/zh/start.md
+++ b/src/content/languages/zh/start.md
@@ -100,16 +100,16 @@ Spark Core 还具有Wi-Fi模块，它连接到您的本地 Wi-Fi 网络，像您
 
 ### 按钮
 
-Spark Core 上有两个按钮：按RESET按钮（右侧）和MODE按钮（左侧).
+Spark Core 上有两个按钮：按`{{reset-button}}`按钮（右侧）和`{{system-button}}`按钮（左侧).
 
-RESET按钮将会把 Spark Core 硬复位，有效切除微控制器的电源和重新通电。这是重新启动，您已经下载到核心的应用程序的好方.
+`{{reset-button}}`按钮将会把 Spark Core 硬复位，有效切除微控制器的电源和重新通电。这是重新启动，您已经下载到核心的应用程序的好方.
 
-MODE 按钮有三个功能:
+`{{system-button}}` 按钮有三个功能:
 
-- 按住 MODE 键三秒钟把 Spark Core 进入 *Smart Config*（聪明配置) 模式，将它连接到您的本地 Wi-Fi 网络. LED应开始蓝色闪烁.
-- 按住 MODE 按钮十秒钟以清除 Spark Core 内存的 Wi-Fi 网络.
-- 按住 MODE 键，点击RESET按钮，等待*3秒* 进入 *Bootloader* (引导程序)的模式. 当您看到LED闪烁黄色, 松开MODE按钮.在这里您可以通过 USB 或 JTAG 重新编程 Spark Core.  如果你不小心这样做，只需点击 RESET 按钮就能离开 *Bootloader* 的模式.
-- 按住 MODE 键，点击 RESET 按钮，等待 *10秒* 做 *出厂重置*， 将 Spark Core 重新编程，回到工厂安装的Spark软件 (Tinker 小应用程序). LED应该变成白色三秒钟，然后开始快速闪烁; 当 LED 切换到另一种颜色的核心已被重置. 如果遇到固件错误, 或者如果你只是想回 Tinker 小应用程序匠,这是有用的.
+- 按住 `{{system-button}}` 键三秒钟把 Spark Core 进入 *Smart Config*（聪明配置) 模式，将它连接到您的本地 Wi-Fi 网络. LED应开始蓝色闪烁.
+- 按住 `{{system-button}}` 按钮十秒钟以清除 Spark Core 内存的 Wi-Fi 网络.
+- 按住 `{{system-button}}` 键，点击`{{reset-button}}`按钮，等待*3秒* 进入 *Bootloader* (引导程序)的模式. 当您看到LED闪烁黄色, 松开`{{system-button}}`按钮.在这里您可以通过 USB 或 JTAG 重新编程 Spark Core.  如果你不小心这样做，只需点击 `{{reset-button}}` 按钮就能离开 *Bootloader* 的模式.
+- 按住 `{{system-button}}` 键，点击 `{{reset-button}}` 按钮，等待 *10秒* 做 *出厂重置*， 将 Spark Core 重新编程，回到工厂安装的Spark软件 (Tinker 小应用程序). LED应该变成白色三秒钟，然后开始快速闪烁; 当 LED 切换到另一种颜色的核心已被重置. 如果遇到固件错误, 或者如果你只是想回 Tinker 小应用程序匠,这是有用的.
 
 
 ### LEDs
@@ -143,7 +143,7 @@ Spark Core 具有 24 可以将电路连接的管脚，这些管脚是:
 - _VIN_: 这里连接一个不受管制的电源与3.6V至6V的电压来驱动 Spark Core. 如果您通过 USB 供电到 Spark Core，该引脚应*不*使用。
 - _3V3_: 该引脚将输出一个稳定的 3.3V 电源轨，可用于 Spark Core之外的任何组件提供电力. (此外，如果你有自己的 3.3V 稳压电源，您可以将其插入这里驱动 Spark Core）.
 - _3V3*_: 这是一个单独的低噪声稳定的 3.3V 电轨设计用于可能容易受到数字元件噪声影响的模拟电路。 如果您正在使用任何敏 感的模拟传感器，请用_3V3*_ 电源，而不是从_3V3_.
-- _!RST_: 把该引脚连接到GND， 您可以重置 Spark Core (就像是按 RESET 按钮)
+- _!RST_: 把该引脚连接到GND， 您可以重置 Spark Core (就像是按 `{{reset-button}}` 按钮)
 - _GND_: 这些引脚是您的电气接地引脚。
 - _D0 to D7_: 这些都是 Spark Core 的基础: 8 GPIO (通用输入/输出) 管脚. 它们标有“D” 因为它们是“数字”管脚, 这意味着它们无法读取模拟���感器的值. 有些管脚可有额外的外设（SPI，JTAG，等). 请继续阅读以了解更多信息.
 - _A0 to A7_:这些是多 8 个 GPIO 管脚, 把总数拉到 16. 这些管脚就像D0到D7，但它们是“模拟”管脚， 这意味着它们可以读取模拟传感器的值(从技术上来说，它们有一个ADC外设).和“数���”管脚一样，其中的一些管脚有额外的可用外设

--- a/src/content/languages/zh/troubleshooting.md
+++ b/src/content/languages/zh/troubleshooting.md
@@ -41,7 +41,7 @@ Spark Core 与传统家庭网络的效果最佳：设用 WPA/WPA2 或 WEP 安全
 
 - 关闭您的移动应用程序，并重新打开它
 - 拔开 Spark Core USB 然后把它插回
-- 按住 MODE 按钮 10 秒钟清除 Spark Core 内存的 Wi-Fi 网络. 3秒钟后，指示灯应开始闪烁蓝色; 10秒后，它应该做一个快速的蓝色闪烁. 这意味着记忆已被清除.
+- 按住 `{{system-button}}` 按钮 10 秒钟清除 Spark Core 内存的 Wi-Fi 网络. 3秒钟后，指示灯应开始闪烁蓝色; 10秒后，它应该做一个快速的蓝色闪烁. 这意味着记忆已被清除.
 - 恢复 Spark Core 的固件到出厂默认值状态. [此视频](https://community.particle.io/t/how-to-do-a-factory-reset/2579) 作说明.
 
 ## 步骤 4: 请检查您的路由器设置
@@ -110,7 +110,7 @@ Spark Core 有一个 RGB LED 定位在的前部,显示 core 的连接状态.此�
 2. 尝试新的点源适配器. 您所用的电源应能够提 core，为 500mA 的电流. 我们建议使用通常用于手机充电的 5V/1A 电源适配器.
 3. 如果您的网络有一个登陆页面，核心将无法进行连接;尝试将其配置到不同的网络.
 4. 尝试 [重新启动 core 和清除它的内存](/#/connect/troubleshooting-step-3-reboot-and-clear-memory).
-5. 尝试恢复出厂设置.按住两个按键，然后只松开RST键. LED应开始闪烁黄色.  继续按住 MODE 键直到您看到闪烁的黄色变化成闪烁的白色, 然后松开按钮. Core 恢复出厂设置完成后应该开始 [闪烁蓝色](https://v.cdn.vine.co/r/videos/E465A8959B1015390893882101760_178fcfd2b3c.4.3.11510817618992331600_MIW9HE1mtZ9H_SpBlKdK1lv2UfmniExCFQHrgJ7iqiFDUiDb0E31bR7GwvB_7wz0.mp4?versionId=eS01KUZ6NaUZgEipSDeVi0rxZENByp1N)
+5. 尝试恢复出厂设置.按住两个按键，然后只松开RST键. LED应开始闪烁黄色.  继续按住 `{{system-button}}` 键直到您看到闪烁的黄色变化成闪烁的白色, 然后松开按钮. Core 恢复出厂设置完成后应该开始 [闪烁蓝色](https://v.cdn.vine.co/r/videos/E465A8959B1015390893882101760_178fcfd2b3c.4.3.11510817618992331600_MIW9HE1mtZ9H_SpBlKdK1lv2UfmniExCFQHrgJ7iqiFDUiDb0E31bR7GwvB_7wz0.mp4?versionId=eS01KUZ6NaUZgEipSDeVi0rxZENByp1N)
 6. 尝试通过 USB 运行,重新补丁程序员,更新 CC3000 的固件. 您可以在 [这里](https://community.sparkdevices.com/t/failed-connecting-to-wifi/648/53) 找到详细的说明.
 7. 如果以上都不成功，请 [联系 Spark Team]（邮寄地址：hello@sparkdevices.com），并为我们提供路由器的品牌和型号.
 
@@ -125,7 +125,7 @@ Spark Core 有一个 RGB LED 定位在的前部,显示 core 的连接状态.此�
 请完成以下步骤：
   
 1. 尝试打 RST 键，以确保您没不小心设定您的核心进入 DFU 模式.
-2. 尝试恢复出厂设置.按住两个按键，然后只松开RST键. LED应开始闪烁黄色.  继续按住 MODE 键直到您看到闪烁的黄色变化成闪烁的白色, 然后松开按钮. Core 后恢复出厂设置完成后应该开始 [闪烁蓝色](https://v.cdn.vine.co/r/videos/E465A8959B1015390893882101760_178fcfd2b3c.4.3.11510817618992331600_MIW9HE1mtZ9H_SpBlKdK1lv2UfmniExCFQHrgJ7iqiFDUiDb0E31bR7GwvB_7wz0.mp4?versionId=eS01KUZ6NaUZgEipSDeVi0rxZENByp1N)
+2. 尝试恢复出厂设置.按住两个按键，然后只松开RST键. LED应开始闪烁黄色.  继续按住 `{{system-button}}` 键直到您看到闪烁的黄色变化成闪烁的白色, 然后松开按钮. Core 后恢复出厂设置完成后应该开始 [闪烁蓝色](https://v.cdn.vine.co/r/videos/E465A8959B1015390893882101760_178fcfd2b3c.4.3.11510817618992331600_MIW9HE1mtZ9H_SpBlKdK1lv2UfmniExCFQHrgJ7iqiFDUiDb0E31bR7GwvB_7wz0.mp4?versionId=eS01KUZ6NaUZgEipSDeVi0rxZENByp1N)
 3. 如果恢复出厂设置不成功，那么我们就通过 DFU 更新固件. 您可以按照以下的步骤做：
 
 Mac 使用自制软件， Windows 需要到 http://dfu-util.gnumonks.org 下载，或者您也可以从源代码在Linux上构建，安装 DFU-util：
@@ -192,7 +192,7 @@ Mac 使用自制软件， Windows 需要到 http://dfu-util.gnumonks.org 下载�
 - *问题是什么?* 您的 core 缺失的固件.
 - *我如何修复它?*
 
-1. 尝试恢复出厂设置.按住两个按键，然后只松开RST键. LED应开始闪烁黄色.  继续按住 MODE 键直到您看到闪烁的黄色变化成闪烁的白色, 然后松开按钮. Core 恢复出厂设置完成后应该开始.
+1. 尝试恢复出厂设置.按住两个按键，然后只松开RST键. LED应开始闪烁黄色.  继续按住 `{{system-button}}` 键直到您看到闪烁的黄色变化成闪烁的白色, 然后松开按钮. Core 恢复出厂设置完成后应该开始.
 2. 如果您在恢复出厂设置后没有看到闪灯，那么您的 core 可能暂时不起作用.  如果你有一个 JTAG shield, [联系 Spark Team ](邮寄地址：hello@spark.io)这样我们就可以帮您完成重新安装内核固件.  如果你没有一个 JTAG shield, 请 [联系 Spark Team ](邮寄地址：hello@spark.io) 让我们知道，我们会帮助您采取下一步措施.
 
 ## LED 灯关闭，反应迟钝

--- a/src/content/support/troubleshooting/common-issues.md
+++ b/src/content/support/troubleshooting/common-issues.md
@@ -114,7 +114,7 @@ The easiest way to identify a bad contact in the holder is by removing the SIM c
 ![Identifying and fixing SIM holder](/assets/images/bad-sim-socket.png)
 <p class="caption"> <a target="_blank" href="/assets/images/bad-sim-socket.png">Click here</a> for a larger image.</p>
 
-Try using your hands to press down on the SIM card to improve contact between the SIM and the metal pins underneath--while pressing on the SIM card, press the `RESET` button on the Electron. If you see the device begin to connect to the cellular network (flash green), you may have a damaged SIM card holder and should [contact Particle](/support/support-and-fulfillment/menu-base/).
+Try using your hands to press down on the SIM card to improve contact between the SIM and the metal pins underneath--while pressing on the SIM card, press the `{{reset-button}}` button on the Electron. If you see the device begin to connect to the cellular network (flash green), you may have a damaged SIM card holder and should [contact Particle](/support/support-and-fulfillment/menu-base/).
 
 ### 5\. Is your SIM card damaged or defective?
 Try using the SIM card from your cell phone, if you have one. If the RGB LED on the Electron begins to blink green when your phone's SIM is inserted, your Particle SIM may need to be replaced, and you should [contact Particle](/support/support-and-fulfillment/menu-base/).
@@ -155,7 +155,7 @@ More details coming soon.
 More details coming soon.
 
 **Using the Particle CLI**
-- Put your device into DFU mode by holding the `MODE` and `RESET` buttons, then releasing the `RESET` button while continuing to hold the `MODE` button. The LED on your Electron will begin flashing yellow.
+- Put your device into DFU mode by holding the `{{system-button}}` and `{{reset-button}}` buttons, then releasing the `{{reset-button}}` button while continuing to hold the `{{system-button}}` button. The LED on your Electron will begin flashing yellow.
 - Open up a terminal session and type `particle update`
 - Your device will download the most recent version of system firmware and will reboot successfully.
 

--- a/src/content/support/troubleshooting/connection-help.md
+++ b/src/content/support/troubleshooting/connection-help.md
@@ -62,7 +62,7 @@ So often, electronics start behaving after you shut them off and turn them back 
 
 - Closing your mobile app and re-opening it
 - Un-plugging the Core and plugging it back in
-- Clear the Core's memory of Wi-Fi networks by holding the MODE button for 10 seconds. After 3 seconds, the light should start flashing blue; after 10 seconds, it should do a quick burst of blue flashes. That means the memory has been cleared.
+- Clear the Core's memory of Wi-Fi networks by holding the `{{system-button}}` button for 10 seconds. After 3 seconds, the light should start flashing blue; after 10 seconds, it should do a quick burst of blue flashes. That means the memory has been cleared.
 - Restoring the Core's firmware to the factory default. Getting this right can be tricky, see [this video](https://community.particle.io/t/how-to-do-a-factory-reset/2579) for illustration.
 
 **STEP 4: Check your router settings**
@@ -105,7 +105,7 @@ Please post issues with connectivity either as responses to this topic or, if th
 - **What’s the problem?** Your Core is missing firmware.
 - **How do I fix it?**
 
-1. Try a factory reset. Hold down both buttons, then release the RST button, while holding down the MODE button. The LED should begin flashing yellow. Continue holding down the MODE button until you see the Core change from flashing yellow to flashing white. Then release the button. The Core should begin after the factory reset is complete. [Here](http://docs.particle.io/core/connect/#appendix-factory-reset) is a video to illustrate it being done.
+1. Try a factory reset. Hold down both buttons, then release the RST button, while holding down the `{{system-button}}` button. The LED should begin flashing yellow. Continue holding down the `{{system-button}}` button until you see the Core change from flashing yellow to flashing white. Then release the button. The Core should begin after the factory reset is complete. [Here](http://docs.particle.io/core/connect/#appendix-factory-reset) is a video to illustrate it being done.
 
 2. If you see no flashing lights during factory reset, then your Core may be temporarily nonfunctional. If you have a JTAG shield, contact [hello @ particle dot io] so we can help walk you through re-installing the Core firmware. If you do not have a JTAG shield, please contact the Particle team to let us know, and we’ll help you take next steps.
 

--- a/templates/helpers/reset-button.js
+++ b/templates/helpers/reset-button.js
@@ -1,0 +1,3 @@
+module.exports = function(context) {
+  return context.data.root.device == "Core" ?  "RST" : "RESET";
+};

--- a/templates/helpers/system-button.js
+++ b/templates/helpers/system-button.js
@@ -1,0 +1,3 @@
+module.exports = function(context) {
+  return context.data.root.device == "Photon" ?  "SETUP" : "MODE";
+};


### PR DESCRIPTION
- `{{system-button}}` inserts SETUP or MODE depending on the device
- `{{reset-button}}` inserts RESET or RST depending on the device
- Replace SETUP/MODE/RESET/RST in the docs with new template helpers

This is a more complete version of #311 so it closes #311
