### PR TITLE
Updated javascript.md. Corrected object reference

### DIFF
--- a/src/content/reference/javascript.md
+++ b/src/content/reference/javascript.md
@@ -273,7 +273,7 @@ var publishEventPr = particle.publishEvent({ name: 'test', data: {}, auth: token
 
 publishEventPr.then(
   function(data) {
-    if (data.ok) { console.log("Event published succesfully") }
+    if (data.body.ok) { console.log("Event published succesfully") }
   },
   function(err) {
     console.log("Failed to publish event: " + err)


### PR DESCRIPTION
the `ok` property is not available at the root of `data`. It's inside the `body` property of `data`.
