### PR TITLE
Update shields link

### DIFF
--- a/scripts/metalsmith.js
+++ b/scripts/metalsmith.js
@@ -169,6 +169,7 @@ exports.metalsmith = function() {
       '/guide/core/': '/guide/core/start',
       '/reference': '/reference/firmware',
       '/datasheets': '/datasheets/kits/',
+      '/datasheets/photon-shields': '/datasheets/particle-shields',
       '/guide/getting-started': '/guide/getting-started/intro',
       '/guide/how-to-build-a-product': '/guide/how-to-build-a-product/intro/',
       '/guide/tools-and-features': '/guide/tools-and-features/intro',
@@ -187,7 +188,7 @@ exports.metalsmith = function() {
       "/photon/ios" : "/reference/ios",
       "/photon/photon-datasheet" : "/datasheets/photon-datasheet",
       "/photon/p1-datasheet" : "/datasheets/p1-datasheet",
-      "/photon/shields" : "/datasheets/photon-shields",
+      "/photon/shields" : "/datasheets/particle-shields",
       "/photon/cli" : "/reference/cli",
       "/photon/ifttt" : "/guide/tools-and-features/ifttt",
       "/photon/webhooks" : "/guide/tools-and-features/webhooks",
@@ -233,13 +234,13 @@ exports.metalsmith = function() {
       "/photon-datasheet" : "/datasheets/photon-datasheet",
       "/p1-datasheet" : "/datasheets/p1-datasheet",
       "/hardware" : "/datasheets/core-datasheet",
-      "/photon-shields" : "/datasheets/photon-shields",
+      "/photon-shields" : "/datasheets/particle-shields",
       "/shields" : "/datasheets/kits/",
       "/photon/hardware" : "/datasheets/photon-datasheet",
       "/troubleshooting" : "/support/troubleshooting/common-issues",
       "/help" : "/support/troubleshooting/common-issues",
       "/faq" : "/support/support-and-fulfillment/faq"
-    }));    
+    }));
 
   return metalsmith;
 };

--- a/src/content/datasheets/kits.md
+++ b/src/content/datasheets/kits.md
@@ -31,7 +31,7 @@ Here's a quick "what's in the box" for each of our offered kits. More detail is 
 ### Electron Solar Kit
 ![]({{assets}}/images/solarShield.jpg)
 The Solar Kit comes with everything you need to make a solar powered cellular project! Super efficient power design so you can go off-the-grid with no need of wires.
-[More Info >](/datasheets/photon-shields/#electron-solar-kit)
+[More Info >](/datasheets/particle-shields/#electron-solar-kit)
 - (1) Electron
 - (1) USB Micro B Cable
 - (1) Particle SIM Card
@@ -56,7 +56,7 @@ AND
 ### Electron Asset Tracker
 ![]({{assets}}/images/assetTracker.jpg)
 The Asset Tracker is a GPS shield that also includes and accelerometer and waterproof box. Designed by Adafruit!
-[More Info >](/datasheets/photon-shields/#electron-asset-tracker)
+[More Info >](/datasheets/particle-shields/#electron-asset-tracker)
 - (1) Electron
 - (1) USB Micro B Cable
 - (1) Particle SIM Card
@@ -78,7 +78,7 @@ AND
 
 ### Electron Sensor Kit
 This is the big one! A fantastic collection of premium and versatile sensors.
-[More Info >](/datasheets/photon-shields/#electron-sensor-kit)
+[More Info >](/datasheets/particle-shields/#electron-sensor-kit)
 - (1) Electron
 - (1) USB Micro B Cable
 - (1) Particle SIM Card
@@ -114,7 +114,7 @@ AND
 
 ### Photon Kit
 ![]({{assets}}/images/photon-kit-new.jpg)
-[More Info >](/datasheets/photon-shields/#photon-kit)
+[More Info >](/datasheets/particle-shields/#photon-kit)
 
 - (1) Photon
 - (1) USB Micro B Cable
@@ -125,7 +125,7 @@ AND
 
 ### Photon Maker Kit
 ![]({{assets}}/images/photon-mkit-grey.png)
-[More Info >](/datasheets/photon-shields/#photon-maker-kit-contents)
+[More Info >](/datasheets/particle-shields/#photon-maker-kit-contents)
 
 - Basics
   - (1) Photon with Headers
@@ -173,7 +173,7 @@ AND
 ![Shield Shield](/assets/images/shields/shield-shield/shield-shield.png)
 Sometimes life can be a little difficult in the land of electronics when two systems talk a different voltage language. How do you make them talk to each other without making one of them _burn out_? The Shield Shield is the answer. This shield performs all the necessary voltage translation and provides an Arduino-compatible footprint to make it easier for you to plug in your existing Arduino shields or talk to other 5V hardware.
 
-[More Info >](/datasheets/photon-shields/#shield-shield)
+[More Info >](/datasheets/particle-shields/#shield-shield)
 
 ### Relay Shield
 
@@ -182,28 +182,28 @@ The Relay Shield allows you to take over the world, one electric appliance at a 
 
 The shield comes with four relays that are rated at a max of 220V @10Amp allowing you to control any electric appliance rated at under 2000 Watts. You are not just limited to an appliance though; any gadget that requires high voltage and/or a lot of current can be controlled with this shield.
 
-[More Info >](/datasheets/photon-shields/#relay-shield)
+[More Info >](/datasheets/particle-shields/#relay-shield)
 
 ### Programmer Shield
 
 ![Programmer Shield](/assets/images/shields/prog-shield/prog-shield.png)
 This is a FT2232H based JTAG programmer shield that is compatible with OpenOCD and Broadcom's WICED IDE. The FT2232 chip is setup to provide an USB-JTAG and USB-UART interface simultaneously. The FT2232 can be also reconfigured by the user by reprogramming the on-board config EEPROM. The unused pins are clearly marked and broken out into easy to access header holes.
 
-[More Info >](/datasheets/photon-shields/#programmer-shield)
+[More Info >](/datasheets/particle-shields/#programmer-shield)
 
 ### Power Shield
 
 ![Power Shield](/assets/images/shields/power-shield/power-shield.png)
 The Power Shield, as the name implies, allows the Particle device to be powered from different types of power sources. The shield has an intelligent battery charger and power management unit along with a wide input voltage regulator and an I2C based fuel-gauge. You can power a Particle device with either a USB plug or a DC supply of anywhere from 7 to 20VDC and charge a [3.7V LiPo battery](https://www.sparkfun.com/products/8483) all at the same time.
 
-[More Info >](/datasheets/photon-shields/#power-shield)
+[More Info >](/datasheets/particle-shields/#power-shield)
 
 ### Internet Button
 
 ![Internet Button](/assets/images/shields/internet-button/button.png)
 The Internet Button is not only an easy way to get started on the Internet of Things, it's also a clean and simple way to start building your own prototypes. Quickly start playing with LEDs, multiple buttons, an accelerometer and more without any wires or soldering.
 
-[More Info >](/datasheets/photon-shields/#internet-button)
+[More Info >](/datasheets/particle-shields/#internet-button)
 
 
 
@@ -258,7 +258,3 @@ The Internet Button is not only an easy way to get started on the Internet of Th
   - (1) NPN Transistor
   - (6) Diode
   - (1) Shift Register IC
-
-
-
-

--- a/src/content/datasheets/particle-shields.md
+++ b/src/content/datasheets/particle-shields.md
@@ -620,10 +620,10 @@ The Solar Kit comes with everything you need to make a solar powered cellular pr
 ### Using the Solar Kit
 Assembly:
 1. Screw the cable gland into the side of the box. If you want it to be truly water-tight, you should add some silicone caulk. Also, the inner nut may not have enough clearance to fit, but that's fine with caulking.
-2. Screw the Solar Shield down inside the box using the included M4 screws. 
-3. Pass the barrel jack wire through the cable gland, leaving the bare wires inside the box and the connector outside. 
-4. Put the red wire into the terminal block marked "+" and the black wire into "GND" and tighten them down firmly with a small screwdriver. 
-5. Tighten the cable gland around the barrel jack wire, 
+2. Screw the Solar Shield down inside the box using the included M4 screws.
+3. Pass the barrel jack wire through the cable gland, leaving the bare wires inside the box and the connector outside.
+4. Put the red wire into the terminal block marked "+" and the black wire into "GND" and tighten them down firmly with a small screwdriver.
+5. Tighten the cable gland around the barrel jack wire,
 6. Plug the Electron into the shield with the USB pointing inward
 7. Connect the male JST wire from the shield to the female JST on the Electron
 8. Plug the battery into the Solar Shield's female JST

--- a/src/content/guide/getting-started/contributing.md
+++ b/src/content/guide/getting-started/contributing.md
@@ -64,9 +64,9 @@ The [`docs`](https://github.com/spark/docs) repo contains Particle's open source
 
 Particle maintains several open source libraries to be used with official Particle shields. They include:
 
-- [`InternetButton`](https://github.com/spark/InternetButton): the library intended for use with the [Internet Button](/datasheets/photon-shields/#internet-button).
-- [`RelayShield`](https://github.com/spark/RelayShield): the library intended for use with the [Photon Relay Shield](/datasheets/photon-shields/#relay-shield)
-- [`PowerShield`](https://github.com/spark/PowerShield): the library intended for use with the [Photon Power Shield](/datasheets/photon-shields/#power-shield)
+- [`InternetButton`](https://github.com/spark/InternetButton): the library intended for use with the [Internet Button](/datasheets/particle-shields/#internet-button).
+- [`RelayShield`](https://github.com/spark/RelayShield): the library intended for use with the [Photon Relay Shield](/datasheets/particle-shields/#relay-shield)
+- [`PowerShield`](https://github.com/spark/PowerShield): the library intended for use with the [Photon Power Shield](/datasheets/particle-shields/#power-shield)
 
 
 ### Local Cloud
@@ -79,9 +79,9 @@ The [`spark-server`](https://github.com/spark/spark-server) repo is an API compa
 We share some hardware design files for each of our dev boards. These open source repos are designed mostly to give you a sense of what we are working on, but you are welcome to make contributions here as well if you have interest and expertise.
 
 Current hardware design repos include:
-- [`electron`](https://github.com/spark/electron) 
-- [`photon`](https://github.com/spark/photon) 
-- [`core`](https://github.com/spark/core) 
+- [`electron`](https://github.com/spark/electron)
+- [`photon`](https://github.com/spark/photon)
+- [`core`](https://github.com/spark/core)
 - [Official Libraries](#official-libraries) such as the [`InternetButton`](https://github.com/spark/InternetButton), [`RelayShield`](https://github.com/spark/RelayShield), and [`PowerShield`](https://github.com/spark/PowerShield)
 - [`eagle-libraries`](https://github.com/spark/eagle-libraries)
 

--- a/src/content/guide/tools-and-features/button.md
+++ b/src/content/guide/tools-and-features/button.md
@@ -9,7 +9,7 @@ order: 7
 # The Internet Button
 
 {{#if electron}}
-**_Note_**: The internet button is not currently available for the Electron. 
+**_Note_**: The internet button is not currently available for the Electron.
 {{/if}}
 
 ![](/assets/images/internet-button-cover.jpg)
@@ -37,7 +37,7 @@ If you {{{popup 'turn your internet button over' 'img' 'internet-button-bottom.j
 </br>
 You can also remove the module cover and Photon, then the shield cover, to expose the {{{popup 'top of the shield' 'img' 'internet-button-uncovered.jpg'}}}. Here, you can see the exposed LEDs and and the accelerometer.
 
-For more information, check out the [Internet Button datasheet](/datasheets/photon-shields/#internet-button).
+For more information, check out the [Internet Button datasheet](/datasheets/particle-shields/#internet-button).
 
 ## Connecting
 


### PR DESCRIPTION
Use the `particle-shields` link as per the title of the document instead of the old `photon-shields`

Would appreciate a review and merge. @technobly @monkbroc 
