### PR TITLE
Fixed link to Particle API for LabVIEW

### DIFF
--- a/src/content/reference/community.md
+++ b/src/content/reference/community.md
@@ -37,3 +37,7 @@ See [the official Javascript client](/reference/javascript/).
 
 ## .NET
 * [ParticleSDK for .NET](https://github.com/ParticleNET/ParticleSDK/) - A wrapper around the Particle cloud api.
+
+## LabVIEW
+
+* [Particle API for LabVIEW] (https://github.com/freddiepingpong/labview-particle-api) - A set of LabVIEW VIs to connect to the Particle Cloud API.

--- a/src/content/reference/community.md
+++ b/src/content/reference/community.md
@@ -40,4 +40,4 @@ See [the official Javascript client](/reference/javascript/).
 
 ## LabVIEW
 
-* [Particle API for LabVIEW] (https://github.com/freddiepingpong/labview-particle-api) - A set of LabVIEW VIs to connect to the Particle Cloud API.
+* [Particle API for LabVIEW](https://github.com/freddiepingpong/labview-particle-api) - A set of LabVIEW VIs to connect to the Particle Cloud API.


### PR DESCRIPTION
Markdown had space between description and link, so URL didn't render correctly. Removed the space.
