### PR TITLE
fix EEPROM default value example+doc mismatch

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -6161,7 +6161,7 @@ from the type of object.
 int addr = 10;
 uint16_t value;
 EEPROM.get(addr, value);
-if(value == 0xFFFF) {
+if(value == 0xFF) {
   // EEPROM was empty -> initialize value
   value = 25;
 }


### PR DESCRIPTION
The documentation says, in four places, the default value is 0xFF. The example uses 0xFFFF. The former makes sense, given 8 bits in a byte. That means `0xFFFF` would fail (unless it happens to work by ignoring the upper bits).
