### PR TITLE
edit link for firmware

### DIFF
--- a/templates/helpers/edit-link.js
+++ b/templates/helpers/edit-link.js
@@ -1,0 +1,14 @@
+module.exports = function(branch, path, file) {
+	/* todo - we could check if the file is a symlink and rewrite the path to the target. 
+	  For now we take the simple, trustworthy appraoch. */
+	var content;
+	var base;
+	if (file==="firmware") {
+		content =  "firmware/firmware.md";
+	}
+	else {
+		content = "src/content"+path+file+".md";
+	}
+	base = "https://github.com/spark/docs/tree/"+branch+"/";
+	return base + content;
+}

--- a/templates/partials/header.hbs
+++ b/templates/partials/header.hbs
@@ -63,6 +63,7 @@
         </ul>
       </div>
     {{/if}}
-    <a href='https://github.com/spark/docs/tree/{{branch}}/src/content{{path.href}}{{path.name}}.md' class="nav" target="_blank"><i class="ion-edit"></i>Edit</a>
+    <a href='{{edit-link branch path.href path.name}}' class="nav" target="_blank"><i class="ion-edit"></i>Edit</a>
+ 
   </div>
 </div>


### PR DESCRIPTION
adds a handlebar helper `edit-link` to produce the href for editing a file. This is used to direct `firmware.md` to the correct github file (since firmware.md is a symlink.). I chose the quick and simple approach (hard-coding), rather than resolving symlinks, which can be dangerous.
