### PR TITLE
Fix and clarify pin descriptions

### DIFF
--- a/src/content/datasheets/electron-datasheet.md
+++ b/src/content/datasheets/electron-datasheet.md
@@ -224,12 +224,12 @@ echo -e "\xFF" > fillbyte && dfu-util -d 2b04:d00a -a 1 -s 34 -D fillbyte
 | RST | Active-low reset input. On-board circuitry contains a 10k ohm pull-up resistor between RST and 3V3, and 0.1uF capacitor between RST and GND. |
 | VBAT |Supply to the internal RTC, backup registers and SRAM when 3V3 is not present (1.65 to 3.6VDC). The Pin is internally connected to 3V3 supply via a 0 ohm resistor. If you wish to power is via an external supply, you'll need to remove this resistor. Instructions to remove this resistor can be found here <add link here> |
 | 3V3 |This pin is the output of the on-board regulator. When powering the Electron via VIN or the USB port, this pin will output a voltage of 3.3VDC. The max load on 3V3 is 800mA. It should not be used as an input to power the Electron. |
-| WKP |Active-high wakeup pin, wakes the module from sleep/standby modes. When not used as a WAKEUP, this pin can also be used as a digital GPIO, ADC input or PWM.|
-| DAC |12-bit Digital-to-Analog (D/A) output (0-4095), and also a digital GPIO. DAC is used as DAC or DAC1 in software, and A3 is a second DAC output used as DAC2 in software. |
+| WKP |Active-high wakeup pin, wakes the module from sleep/standby modes. When not used as a WAKEUP, this pin can also be used as a digital GPIO, ADC input or PWM.  Can be referred to as `A7` when used as an ADC.|
+| DAC |12-bit Digital-to-Analog (D/A) output (0-4095), referred to as `DAC` or `DAC1` in software. Can also be used as digital GPIO and ADC. Can be referred to as `A6` when used as ADC.|
 | RX |Primarily used as UART RX, but can also be used as a digital GPIO or PWM.|
 | TX |Primarily used as UART TX, but can also be used as a digital GPIO or PWM.|
 | D0-D7 | Digital only GPIO |
-| A0-A5 | 12-bit Analog-to-Digital (A/D) inputs (0-4095), and also digital GPIOs. A6 and A7 are code convenience mappings, which means pins are not actually labeled as such but you may use code like `analogRead(A7)`. A6 maps to the DAC pin and A7 maps to the WKP pin.|
+| A0-A5 | 12-bit Analog-to-Digital (A/D) inputs (0-4095), and also digital GPIOs. A3 is also a second DAC output used as `DAC2` in software.|
 | B0-B5 | B0 and B1 are digital only while B2, B3, B4, B5 are 12-bit A/D inputs as well as digital GPIOs|
 | C0-C5 | Digital only GPIO |
 | VUSB | This pin is internally connected to USB supply and will output 5V when the Electron is plugged into an USB port. It is intentionally left unpopulated. |

--- a/src/content/datasheets/electron-datasheet.md
+++ b/src/content/datasheets/electron-datasheet.md
@@ -228,8 +228,8 @@ echo -e "\xFF" > fillbyte && dfu-util -d 2b04:d00a -a 1 -s 34 -D fillbyte
 | DAC |12-bit Digital-to-Analog (D/A) output (0-4095), and also a digital GPIO. DAC is used as DAC or DAC1 in software, and A3 is a second DAC output used as DAC2 in software. |
 | RX |Primarily used as UART RX, but can also be used as a digital GPIO or PWM.|
 | TX |Primarily used as UART TX, but can also be used as a digital GPIO or PWM.|
-| D0-D1 | Digital only GPIO |
-| A0-A1 | 12-bit Analog-to-Digital (A/D) inputs (0-4095), and also digital GPIOs. A6 and A7 are code convenience mappings, which means pins are not actually labeled as such but you may use code like `analogRead(A7)`. A6 maps to the DAC pin and A7 maps to the WKP pin.|
+| D0-D7 | Digital only GPIO |
+| A0-A5 | 12-bit Analog-to-Digital (A/D) inputs (0-4095), and also digital GPIOs. A6 and A7 are code convenience mappings, which means pins are not actually labeled as such but you may use code like `analogRead(A7)`. A6 maps to the DAC pin and A7 maps to the WKP pin.|
 | B0-B5 | B0 and B1 are digital only while B2, B3, B4, B5 are 12-bit A/D inputs as well as digital GPIOs|
 | C0-C5 | Digital only GPIO |
 | VUSB | This pin is internally connected to USB supply and will output 5V when the Electron is plugged into an USB port. It is intentionally left unpopulated. |


### PR DESCRIPTION
1. Fixed typos. Changed `A0-A1` to `A0-A5` and `D0-D1` to `D0-D7`.
2. Moved descriptions of alternate pin functions to appropriate locations.
