### PR TITLE
Make navigation bar slide out and push content on mobile

### DIFF
--- a/src/assets/js/docs.js
+++ b/src/assets/js/docs.js
@@ -291,12 +291,31 @@ Created by Zach Supalla.
   Docs.toggleNav = function() {
     $('.toggle-navigation').click(function(e) {
       e.preventDefault();
-      if ($('.menubar').css('opacity') === '1') {
-        $('.menubar, .page-body').addClass('menu-hidden').removeClass('menu-visible');
-      } else {
-        $('.menubar, .page-body').addClass('menu-visible').removeClass('menu-hidden');
-      }
+      toggleNav();
+      updateBackdrop();
     });
+
+    $(document).on('click', '.menubar-backdrop', function(e) {
+      e.preventDefault();
+      closeNav();
+      updateBackdrop();
+    });
+
+    function toggleNav() {
+      $('body').toggleClass('menubar-show');
+    }
+
+    function closeNav() {
+      $('body').removeClass('menubar-show');
+    }
+
+    function updateBackdrop() {
+      if($('body').hasClass('menubar-show')) {
+        $('body').append('<div class="menubar-backdrop"></div>');
+      } else {
+        $('.menubar-backdrop').remove();
+      }
+    }
   };
 
   // Ok, then let's do it!

--- a/src/assets/js/docs.js
+++ b/src/assets/js/docs.js
@@ -289,29 +289,30 @@ Created by Zach Supalla.
   };
 
   Docs.toggleNav = function() {
+    var $root = $(".content-root");
     $('.toggle-navigation').click(function(e) {
       e.preventDefault();
       toggleNav();
       updateBackdrop();
     });
 
-    $(document).on('click', '.menubar-backdrop', function(e) {
+    $root.on('click', '.menubar-backdrop', function(e) {
       e.preventDefault();
       closeNav();
       updateBackdrop();
     });
 
     function toggleNav() {
-      $('body').toggleClass('menubar-show');
+      $root.toggleClass('menubar-show');
     }
 
     function closeNav() {
-      $('body').removeClass('menubar-show');
+      $root.removeClass('menubar-show');
     }
 
     function updateBackdrop() {
-      if($('body').hasClass('menubar-show')) {
-        $('body').append('<div class="menubar-backdrop"></div>');
+      if($root.hasClass('menubar-show')) {
+        $root.prepend('<div class="menubar-backdrop"></div>');
       } else {
         $('.menubar-backdrop').remove();
       }

--- a/src/assets/less/content.less
+++ b/src/assets/less/content.less
@@ -489,7 +489,6 @@ h1 small.beta {
   // Start with menu hidden on mobile
   @media(max-width: @medium-size) {
     left: 0;
-    width: 100%;
   }
 }
 

--- a/src/assets/less/content.less
+++ b/src/assets/less/content.less
@@ -482,21 +482,14 @@ h1 small.beta {
   right: 0;
   overflow-y: auto;
   -webkit-transform: translate3d(0,0,0);
-  z-index: 1;
+  z-index: @pageBodyZindex;
   background: @white;
-  left: 281px;
+  left: @menubarWidth;
 
   // Start with menu hidden on mobile
   @media(max-width: @medium-size) {
     left: 0;
-  }
-
-  &.menu-hidden {
-    left: 0;
-  }
-
-  &.menu-visible {
-    left: 281px;
+    width: 100%;
   }
 }
 

--- a/src/assets/less/header.less
+++ b/src/assets/less/header.less
@@ -26,6 +26,7 @@
 .toggle-nav {
   float: left;
   margin: 10px 10px 0 15px;
+  display: none;
   a {
     color: @light-gray;
     .transition(color 0.2s);
@@ -35,6 +36,9 @@
   }
   i {
     font-size: 2em;
+  }
+  @media(max-width: @medium-size) {
+    display: block;
   }
 }
 
@@ -74,13 +78,13 @@ a.nav-device {
 .header {
   background: @almost-white;
   zoom: 1;
-  height: 52px;
+  height: @headerHeight;
   border-bottom: solid 1px #dfe2e7;
   position: absolute;
   top: 0;
   left: 0;
   right: 0;
-  z-index: 2;
+  z-index: @headerZindex;
 }
 
 .header .right {
@@ -133,7 +137,7 @@ a.nav-device {
   position: absolute;
   top: 100%;
   left: 0;
-  z-index: 1000;
+  z-index: @dropdownZindex;
   display: none;
   float: left;
   min-width: 70px;
@@ -233,7 +237,7 @@ a.nav-device {
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 990;
+  z-index: @dropdownBackdropZindex;
 }
 .pull-right > .dropdown-menu {
   right: 0;

--- a/src/assets/less/menu.less
+++ b/src/assets/less/menu.less
@@ -17,7 +17,7 @@
 
   // Start with menu hidden on mobile
   @media(max-width: @medium-size) {
-    transition: left @menuTransitionTime;
+    transition: all @menuTransitionTime;
     left: -@menubarWidth;
   }
 
@@ -39,7 +39,12 @@
 @media(max-width: @medium-size) {
   .menubar-show {
     .menubar {
-      left: 0;
+      transform: translate(@menubarWidth, 0);
+      -ms-transform: translate(@menubarWidth, 0);
+    }
+
+    .page-body {
+      -webkit-filter: blur(5px);
     }
   }
 

--- a/src/assets/less/menu.less
+++ b/src/assets/less/menu.less
@@ -10,43 +10,61 @@
   left: 0;
   top: 0;
   bottom: 0;
-  width: 280px;
+  width: @menubarWidth;
+  box-sizing: border-box;
   border-right: solid 1px #dfe2e7;
-  z-index: 0;
-  .transition(opacity 0);
+  z-index: @menuZindex;
+  transition: all @menuTransitionTime;
 
   // Start with menu hidden on mobile
   @media(max-width: @medium-size) {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  &.menu-hidden {
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  &.menu-visible {
-    opacity: 1;
-    pointer-events: auto;
+    left: -@menubarWidth;
   }
 
   > ul {
     padding: 10px 20px;
 
-   p {
-     font-weight: 700;
-     text-transform: uppercase;
-     margin-top: 10px;
-   }
+    p {
+      font-weight: 700;
+      text-transform: uppercase;
+      margin-top: 10px;
+    }
 
-   > li > ul > li {
-     padding-left: 10px;
-   }
-
-
+    > li > ul > li {
+      padding-left: 10px;
+    }
   }
 }
+
+.page-body {
+  transition: all @menuTransitionTime;
+}
+
+@media(max-width: @medium-size) {
+  .menubar-show {
+    .content-root {
+      overflow-x: hidden;
+    }
+
+    .menubar {
+      left: 0;
+    }
+
+    .page-body {
+      margin-left: @menubarWidth;
+    }
+  }
+
+  .menubar-backdrop {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: @headerHeight;
+    z-index: @menuBackdropZindex;
+  }
+}
+
 .menubar .section {
   padding: 0 10px;
   overflow: hidden;

--- a/src/assets/less/menu.less
+++ b/src/assets/less/menu.less
@@ -14,10 +14,10 @@
   box-sizing: border-box;
   border-right: solid 1px #dfe2e7;
   z-index: @menuZindex;
-  transition: all @menuTransitionTime;
 
   // Start with menu hidden on mobile
   @media(max-width: @medium-size) {
+    transition: left @menuTransitionTime;
     left: -@menubarWidth;
   }
 
@@ -36,22 +36,10 @@
   }
 }
 
-.page-body {
-  transition: all @menuTransitionTime;
-}
-
 @media(max-width: @medium-size) {
   .menubar-show {
-    .content-root {
-      overflow-x: hidden;
-    }
-
     .menubar {
       left: 0;
-    }
-
-    .page-body {
-      margin-left: @menubarWidth;
     }
   }
 
@@ -62,6 +50,7 @@
     bottom: 0;
     top: @headerHeight;
     z-index: @menuBackdropZindex;
+    background-color: rgba(255,255,255,0.5);
   }
 }
 

--- a/src/assets/less/popup.less
+++ b/src/assets/less/popup.less
@@ -14,7 +14,7 @@
     opacity: 0;
     visibility: hidden;
     width: 100%;
-    z-index: 1;
+    z-index: @popupZindex;
     -webkit-transition: opacity .25s, visibility .25s;
     -moz-transition: opacity .25s, visibility .25s;
     transition: opacity .25s, visibility .25s;
@@ -53,7 +53,7 @@
     opacity: 0;
     visibility: hidden;
     width: 100%;
-    z-index: 1;
+    z-index: @popupZindex;
     -webkit-transition: opacity .25s, visibility .25s;
     -moz-transition: opacity .25s, visibility .25s;
     transition: opacity .25s, visibility .25s;

--- a/src/assets/less/support.less
+++ b/src/assets/less/support.less
@@ -202,7 +202,6 @@
 	bottom: 25px;
 	left: 25px; 
 	z-index: 999;
-
 }
 
 #buttonParticle {

--- a/src/assets/less/variables.less
+++ b/src/assets/less/variables.less
@@ -51,13 +51,24 @@
 @pomegranate: #c0392b;
 @champaign: #E9DDCC;
 
-@sidebarWidth: 60px;
-@drawerWidth: 300px;
+@headerHeight: 52px;
+
 @consoleHeight: 300px;
 @hiddenConsoleHeight: 250px;
 @inactiveConsoleHeight: @consoleHeight - @hiddenConsoleHeight;
-@realDrawerWidth: @drawerWidth - @sidebarWidth;
 @tabHeight: 36px;
+
+@menubarWidth: 280px;
+@menuTransitionTime: 0.3s;
+
+/* Z-index */
+@popupZindex: 1;
+@pageBodyZindex: 1;
+@menuBackdropZindex: 90;
+@menuZindex: 100;
+@headerZindex: 200;
+@dropdownBackdropZindex: 990;
+@dropdownZindex: 1000;
 
 /* Media Queries */
 @xsmall-size: 320px;


### PR DESCRIPTION
The left navigation panel behavior was very annoying on mobile: opening it would shrink the content and scroll to a different area.

Rework the navigation bar to slide out and push the content off screen.

Changes:
- Hide the hamburger (menu toggle) button on desktop
- Slide the left panel on menu toggle
- Push the content off screen on menu toggle
- Close the left panel on tap on content
- Don't close the left panel on link click since that was too jarring.
- Make sure the section dropdown (Guide, Reference, etc) appears on top of the left panel.

May fix #382
