### PR TITLE
Update 'connect with your smartphone' section

### DIFF
--- a/src/content/guide/getting-started/start.md
+++ b/src/content/guide/getting-started/start.md
@@ -240,7 +240,7 @@ If your device is not blinking at all, or if the LED is burning a dull orange co
 
 Open the app on your phone. Log in or sign up for an account with Particle if you don't have one.
 
-Follow the instructions on the screen to {{#if photon}}{{{ popup 'connect your device to Wi-Fi.' 'note' 'Your device remembers up to 5 wifi networks, and it will connect to these automatically if it can find them.'}}}{{/if}} {{#if core}}{{{ popup 'connect your device to Wi-Fi.' 'note' 'Your device remembers up to 7 wifi networks, and it will connect to these automatically if it can find them.'}}}{{/if}} Remember that to connect the Core, you need the older Spark Core app and to connect the Photon you need the new Particle App.
+Press the plus icon and select the device you'd like to add. Then follow the instructions on the screen to {{#if photon}}{{{ popup 'connect your device to Wi-Fi.' 'note' 'Your device remembers up to 5 wifi networks, and it will connect to these automatically if it can find them.'}}}{{/if}} {{#if core}}{{{ popup 'connect your device to Wi-Fi.' 'note' 'Your device remembers up to 7 wifi networks, and it will connect to these automatically if it can find them.'}}}{{/if}} Remember that to connect the Core, you need the older Spark Core app and to connect the Photon you need the new Particle App.
 
 This may take a little while - but don't worry.
 


### PR DESCRIPTION
Making it a little bit more detailed to include pressing on the plus icon for starting the process to start connecting the device. 

Perhaps this is obvious to Android users as part of Google's Material Design.
