### PR TITLE
[community] Add a page about po-util to "Tools and Features"

### DIFF
--- a/src/content/guide/tools-and-features/po-util.md
+++ b/src/content/guide/tools-and-features/po-util.md
@@ -32,7 +32,7 @@ order: 8
 You can download **po-util** from [GitHub](https://github.com/nrobinson2000/po-util), or install the latest version with:
 
 ```
-curl po-util.com/download
+curl po-util.com/download | bash
 ```
 
 ## Examples
@@ -99,7 +99,7 @@ po electron ota YOUR_DEVICE_NAME
 ```
 {{/if}}
 
-# Support
+## Support
 
 Nathan Robinson can be contacted on the [Particle Forums](https://community.particle.io/users/nrobinson2000).
 

--- a/src/content/guide/tools-and-features/po-util.md
+++ b/src/content/guide/tools-and-features/po-util.md
@@ -1,0 +1,143 @@
+---
+title: po-util
+template: guide.hbs
+columns: two
+devices: [ photon,electron ]
+order: 8
+---
+# Particle Offline Utility
+
+<p align="center" >
+<img src="http://po-util.com/logos/po-util-updated.svg" width="600px">
+</p>
+
+**Particle Offline Utility**, more commonly known as **po-util**, is a tool written by community member, [Nathan Robinson](https://github.com/nrobinson2000), that simplifies the installation and use of the Particle Toolchain so that new users can easily develop locally on Mac OSX and Ubuntu-based Linux Distributions.
+
+## Features
+
+**Po-util** features commands for:
+
+* Installing the [ARM toolchain](https://launchpad.net/gcc-arm-embedded), [dfu-util](http://dfu-util.sourceforge.net/), [nodejs](https://nodejs.org/en/), [particle-cli](https://github.com/spark/particle-cli) and the [Particle firmware source code](https://github.com/spark/firmware)
+* Building firmware and saving as a binary
+* Building firmware and Flashing over USB using dfu-util
+* Initializing a directory into a project folder
+* Upgrade the System firmware on your {{device}}
+* Uploading firmware with particle-cli
+* Monitoring the serial output of your {{device}}
+* Putting your {{device}} into DFU mode and getting your {{device}} out of DFU mode
+* Quickly flashing pre-compiled code with dfu-util
+
+## Download
+
+You can download **po-util** from [GitHub](https://github.com/nrobinson2000/po-util), or install the latest version with:
+
+```
+curl po-util.com/download
+```
+
+## Examples
+
+### Build firmware
+
+{{#if photon}}
+```BASH
+po photon build
+```
+{{/if}}
+
+{{#if electron}}
+```BASH
+po electron build
+```
+{{/if}}
+
+### Build firmware and flash using dfu-util
+
+{{#if photon}}
+```BASH
+po photon flash
+```
+{{/if}}
+
+{{#if electron}}
+```BASH
+po electron flash
+```
+{{/if}}
+
+### Upgrade system firmware
+
+{{#if photon}}
+```BASH
+po photon upgrade
+```
+{{/if}}
+
+{{#if electron}}
+```BASH
+po electron upgrade
+```
+{{/if}}
+
+### Open serial monitor
+
+```BASH
+po serial
+```
+
+### Upload firmware Over the Air
+
+{{#if photon}}
+```BASH
+po photon ota YOUR_DEVICE_NAME
+```
+{{/if}}
+
+{{#if electron}}
+```BASH
+po electron ota YOUR_DEVICE_NAME
+```
+{{/if}}
+
+# All commands
+
+```BASH
+
+po-util Copyright (GPL) 2016  Nathan Robinson
+This program comes with ABSOLUTELY NO WARRANTY.
+Read more at http://po-util.com
+
+Usage: po DEVICE_TYPE COMMAND DEVICE_NAME
+       po DFU_COMMAND
+       po install [full_install_path]
+
+Commands:
+  install      Download all of the tools needed for development.
+               Requires sudo. You can optionally install to an
+               alternate location by specifying [full_install_path].
+               Ex.:
+                   po install ~/particle
+
+               By default, Firmware is installed in ~/github.
+
+  build        Compile code in "firmware" subdirectory
+  flash        Compile code and flash to device using dfu-util
+  clean        Refresh all code (Run after switching device or directory)
+  init         Initialize a new po-util project
+  patch        Apply system firmware patch to change baud rate
+  update       Update Particle firmware, particle-cli and po-util
+  upgrade      Upgrade system firmware on device
+  ota          Upload code Over The Air using particle-cli
+  serial       Monitor a device's serial output (Close with CRTL-A +D)
+
+DFU Commands:
+  dfu         Quickly flash pre-compiled code
+  dfu-open    Put device into DFU mode
+  dfu-close   Get device out of DFU mode
+```
+
+# Support
+
+Nathan Robinson can be contacted on the [Particle Forums](https://community.particle.io/users/nrobinson2000).
+
+He can also be contacted on his personal [Slack](http://nrobinson2000.herokuapp.com/).

--- a/src/content/guide/tools-and-features/po-util.md
+++ b/src/content/guide/tools-and-features/po-util.md
@@ -17,7 +17,7 @@ order: 8
 
 **Po-util** features commands for:
 
-* Installing the [ARM toolchain](https://launchpad.net/gcc-arm-embedded), [dfu-util](http://dfu-util.sourceforge.net/), [nodejs](https://nodejs.org/en/), [particle-cli](https://github.com/spark/particle-cli) and the [Particle firmware source code](https://github.com/spark/firmware)
+* Installing the [ARM toolchain](https://launchpad.net/gcc-arm-embedded), [dfu-util](http://dfu-util.sourceforge.net/), [nodejs](https://nodejs.org/en/), [particle-cli](https://github.com/spark/particle-cli) and the [Particle firmware](https://github.com/spark/firmware)
 * Building firmware and saving as a binary
 * Building firmware and Flashing over USB using dfu-util
 * Initializing a directory into a project folder
@@ -98,43 +98,6 @@ po photon ota YOUR_DEVICE_NAME
 po electron ota YOUR_DEVICE_NAME
 ```
 {{/if}}
-
-# All commands
-
-```BASH
-
-po-util Copyright (GPL) 2016  Nathan Robinson
-This program comes with ABSOLUTELY NO WARRANTY.
-Read more at http://po-util.com
-
-Usage: po DEVICE_TYPE COMMAND DEVICE_NAME
-       po DFU_COMMAND
-       po install [full_install_path]
-
-Commands:
-  install      Download all of the tools needed for development.
-               Requires sudo. You can optionally install to an
-               alternate location by specifying [full_install_path].
-               Ex.:
-                   po install ~/particle
-
-               By default, Firmware is installed in ~/github.
-
-  build        Compile code in "firmware" subdirectory
-  flash        Compile code and flash to device using dfu-util
-  clean        Refresh all code (Run after switching device or directory)
-  init         Initialize a new po-util project
-  patch        Apply system firmware patch to change baud rate
-  update       Update Particle firmware, particle-cli and po-util
-  upgrade      Upgrade system firmware on device
-  ota          Upload code Over The Air using particle-cli
-  serial       Monitor a device's serial output (Close with CRTL-A +D)
-
-DFU Commands:
-  dfu         Quickly flash pre-compiled code
-  dfu-open    Put device into DFU mode
-  dfu-close   Get device out of DFU mode
-```
 
 # Support
 


### PR DESCRIPTION
I was thinking that we could add a page about po-util, the script that I have been developing into the Particle documentation.  I have been using it for all of my Particle development and I think that other users will benefit from having it in the documentation.
