### PR TITLE
Add link to OLED example code

### DIFF
--- a/src/content/datasheets/particle-shields.md
+++ b/src/content/datasheets/particle-shields.md
@@ -608,6 +608,9 @@ Note: The Ground pin may vary as Brown or Black, +5V pin may vary as Orange or R
 
 This is a 128x64 pixel graphic OLED screen that can be either controlled via the SPI (default) or I2C.
 
+**Sample code**
+- https://github.com/pkourany/Adafruit_SSD1306
+
 **Specifications:**
 - Supply Voltage: 3.0V to 5V DC
 - Current consumption: 50mA max

--- a/src/content/datasheets/particle-shields.md
+++ b/src/content/datasheets/particle-shields.md
@@ -609,6 +609,7 @@ Note: The Ground pin may vary as Brown or Black, +5V pin may vary as Orange or R
 This is a 128x64 pixel graphic OLED screen that can be either controlled via the SPI (default) or I2C.
 
 **Sample code**
+- [Adafruit SSD1306 in the Particle Build Library](https://build.particle.io/libs/5397d8d028979ed3cc000731)
 - https://github.com/pkourany/Adafruit_SSD1306
 
 **Specifications:**


### PR DESCRIPTION
It took awhile to figure out which software and which wiring I needed for my OLED that came with the Photon. This link will help others get started.

See also the PR I just submitted to help user figure out which OLED (hardware or software SPI) they have: https://github.com/pkourany/Adafruit_SSD1306/pull/10
