### PR TITLE
Update modes.md

### DIFF
--- a/src/content/guide/getting-started/modes.md
+++ b/src/content/guide/getting-started/modes.md
@@ -201,6 +201,7 @@ The device will itself automatically enter safe mode if there is no application 
 {{{device-animation device "blink" "yellow" }}}
 
 If you wish to program your {{device}} with a custom firmware via USB, you'll need to use this mode. This mode triggers the on-board bootloader that accepts firmware binary files via the [dfu-utility.](https://s3.amazonaws.com/spark-assets/dfu-util-0.8-binaries.tar.xz)
+(Note: On Windows, dfu-util will not see devices connected via a USB3.0 port. Use a USB2.0 port as noted in this [post.](https://community.particle.io/t/spark-core-common-issues/12383/10)
 
 Installation tutorial can be found [here.](/guide/tools-and-features/cli/)
 


### PR DESCRIPTION
I'm on Win 7 and couldn't flash using dfu-util even though I had all the drivers installed. Even though my Electron is visible as a dfu device in my device manager, dfu-util will not detect it as a dfu device if it is connected via a usb3 port. I connected my electron via an old usb hub and it worked. Telling people about this prior will save them time.
