### PR TITLE
wrong url

### DIFF
--- a/src/content/guide/tools-and-features/cli.md
+++ b/src/content/guide/tools-and-features/cli.md
@@ -63,7 +63,7 @@ To grab the CLI source and play with it locally
 
 ```sh
 # how to get the source code for the CLI
-$ git clone git@github.com:spark/particle-cli.git
+$ git clone https://github.com:spark/particle-cli.git
 $ cd particle-cli
 $ npm install
 $ node app.js help


### PR DESCRIPTION
You need to access github with 'git clone https://github.com/spark/particle-cli.git' otherwise you'll get an error.
