### PR TITLE
blinking orange fix

### DIFF
--- a/src/content/guide/getting-started/modes.md
+++ b/src/content/guide/getting-started/modes.md
@@ -326,7 +326,7 @@ Blinking red indicates various errors.
 
 - 2 red blinks: Could not reach the internet.
 - 3 red blinks: Connected to the internet, but could not reach the Particle Cloud.
-- Blinking "orange": This sometimes is seen as yellow or red and indicates bad device keys.
+- Blinking "orange": This sometimes is seen as yellow or red and indicates bad server keys. To fix this issue, use the Particle CLI to restore the server keys using ```particle keys server``` in your terminal window, while having the device in DFU mode.
 
 
 ### Red Flash SOS


### PR DESCRIPTION
Suggest a fix when the device exhibits blinking orange state - indicating bad server keys.
