### PR TITLE
Use `hostname` instead of `URL` terminology

### DIFF
--- a/firmware/firmware.md
+++ b/firmware/firmware.md
@@ -4587,13 +4587,13 @@ Connects to a specified IP address and port. The return value indicates success 
 // SYNTAX
 client.connect();
 client.connect(ip, port);
-client.connect(URL, port);
+client.connect(hostname, port);
 ```
 
 Parameters:
 
 - `ip`: the IP address that the client will connect to (array of 4 bytes)
-- `URL`: the domain name the client will connect to (string, ex.:"particle.io")
+- `hostname`: the host name the client will connect to (string, ex.:"particle.io")
 - `port`: the port that the client will connect to (`int`)
 
 Returns true if the connection succeeds, false if not.


### PR DESCRIPTION
It's pedantic, but `URL` really isn't correct in this context (`TCPClient::connect()`). A URL can consist of several pieces, including a scheme, hostname, port, path, etc. If you tried to provide a valid URL like `http://www.google.com/` to `TCPClient::connect()`, it would be an error. We're really just using a host name here.
