### PR TITLE
Add B0-B5, C0-C5 to GPIO list in note for electron

### DIFF
--- a/firmware/firmware.md
+++ b/firmware/firmware.md
@@ -2155,7 +2155,7 @@ void loop()
 }
 ```
 
-**Note:** All GPIO pins (`D0`..`D7`, `A0`..`A7`, `DAC`, `WKP`, `RX`, `TX`) can be used as long they are not used otherwise (e.g. as `Serial1` `RX`/`TX`).
+**Note:** All GPIO pins (`A0`..`A7`, {{#if electron}}`B0`..`B5`, `C0`..`C5`, {{/if}}`D0`..`D7`, `DAC`, `WKP`, `RX`, `TX`) can be used as long they are not used otherwise (e.g. as `Serial1` `RX`/`TX`).
 
 ### digitalRead()
 
@@ -2189,7 +2189,7 @@ void loop()
 }
 
 ```
-**Note:** All GPIO pins (`D0`..`D7`, `A0`..`A7`, `DAC`, `WKP`, `RX`, `TX`) can be used as long they are not used otherwise (e.g. as `Serial1` `RX`/`TX`).
+**Note:** All GPIO pins (`A0`..`A7`, {{#if electron}}`B0`..`B5`, `C0`..`C5`, {{/if}}`D0`..`D7`, `DAC`, `WKP`, `RX`, `TX`) can be used as long they are not used otherwise (e.g. as `Serial1` `RX`/`TX`).
 
 ### analogWrite() (PWM)
 


### PR DESCRIPTION
There's an offhand list of GPIO's in two notes in the firmware docs for the Input/Output functions. These lists of GPIO's are currently photon-specific. This PR adds the additional electron GPIO's to the lists, if the `electron` flag is set.
