### PR TITLE
Update ios.md

### DIFF
--- a/src/content/reference/ios.md
+++ b/src/content/reference/ios.md
@@ -492,7 +492,7 @@ You must have Carthage installed, if you don't then be sure to [install Carthage
 Then to build the iOS Cloud SDK, simply create a `Cartfile` on your project root folder, containing the following line:
 
 ```
-github "spark/spark-sdk-ios" >= 0.4.0
+github "spark/spark-sdk-ios" "master"
 ```
 
 and then run the following command:


### PR DESCRIPTION
github "spark/spark-sdk-ios" >= 0.4.0 throws the following error: 
Dependency "spark-sdk-ios" has no shared framework schemes for any of the platforms: iOS
github "spark/spark-sdk-ios" "master" works fine :)