### PR TITLE
Incorrect link to localhost

### DIFF
--- a/src/content/guide/getting-started/examples.md
+++ b/src/content/guide/getting-started/examples.md
@@ -47,7 +47,7 @@ To complete all the examples, you will need the following materials:
   * or the local [Particle Dev](http://particle.io/dev)
 * **Experience**
 {{#if raspberry-pi}}
-  * [Connecting your Raspberry Pi to Particle](http://localhost:8080/guide/getting-started/start)
+  * [Connecting your Raspberry Pi to Particle](/guide/getting-started/start)
 {{else}}
   {{#if electron}}
   * Connecting your Device [with your browser or smartphone](/guide/getting-started/start/electron/)


### PR DESCRIPTION
I believe my modifications put the link in the right format to work on the website. I know the localhost part is definitely wrong though so a change is required regardless.