### PR TITLE
Add power pin limits callout to Photon datasheet.

### DIFF
--- a/src/content/datasheets/photon-datasheet.md
+++ b/src/content/datasheets/photon-datasheet.md
@@ -58,9 +58,14 @@ The Photon comes in two physical forms: with headers and without. Prototyping is
 
 ### Power
 
-Power to the Photon is supplied via the on-board USB Micro B connector or directly via the VIN pin.  If power is supplied directly to the VIN pin, the voltage should be regulated between 3.6VDC and 5.5VDC.  When the Photon is powered via the USB port, VIN will output a voltage of approximately 4.8VDC due to a reverse polarity protection series schottky diode between V+ of USB and VIN. When used as an output, the max load on VIN is 1A.
+Power to the Photon is supplied via the on-board USB Micro B connector or directly via the VIN pin.  If power is supplied directly to the VIN pin, the voltage should be regulated between 3.6VDC and 5.5VDC.  When the Photon is powered via the USB port, VIN will output a voltage of approximately 4.8VDC due to a reverse polarity protection series schottky diode between V+ of USB and VIN. 
 
 Typical average current consumption is 80mA with 5V @ VIN with Wi-Fi on. Deep sleep quiescent current is typically 80uA (Please refer to [Recommended Operating Conditions](#recommended-operating-conditions) for more info).  When powering the Photon from the USB connector, make sure to use a quality cable to minimize IR drops (current x resistance = voltage) in the wiring.  If a high resistance cable (i.e., low current) is used, peak currents drawn from the Photon when transmitting and receiving will result in voltage sag at the input which may cause a system brown out or intermittent operation.  Likewise, the power source should be sufficient enough to source 1A of current to be on the safe side.
+
+#### Limits
+
+- When used as an output, the max load on VIN is 1A.
+- When used as an output, the max load on 3.3v is 100mA.
 
 ### RF
 


### PR DESCRIPTION
Added power pin limits to `power` section of Photon datasheet. 

@moors7 mentioned that we could also add it to the FAQ. I looked through it and I don't see a good section in the FAQ to add it to. Thoughts?