### PR TITLE
Update client.read()

### DIFF
--- a/firmware/firmware.md
+++ b/firmware/firmware.md
@@ -5969,7 +5969,7 @@ or `int read(uint8_t *buffer, size_t size)` reads all readily available bytes up
 bytesRead = client.read(buffer, length);
 ```
 
-Returns the number of bytes (or characters) read into `buffer`.
+Returns the number of bytes (or characters) read into `bytesRead`.
 
 ### flush()
 


### PR DESCRIPTION
I may be misreading it, but my guess is that it can't both put the data into `buffer` and report num read into `buffer`. So I think its meant to say `bytesRead`. Alternatively, it should probably just not say 'into...' at all, since variable name depends on usage.