### PR TITLE
Give fix-it tip for Cloud not connected

### DIFF
--- a/src/content/guide/getting-started/modes.md
+++ b/src/content/guide/getting-started/modes.md
@@ -333,6 +333,8 @@ If the Wi-Fi module is on but not connected to a network, your {{device}} will b
 
 When the {{device}} is connected to a {{#if electron}}cellular{{/if}}{{#if photon}}Wi-Fi{{/if}}{{#if core}}Wi-Fi{{/if}} network but not to the cloud, it will breathe green.
 
+Sometimes that happens due to flashed code that interferes with its ability to connect to the cloud. You can try going into Safe Mode with the instructions above, and then flash new code.
+
 
 ### Bad Public Key
 


### PR DESCRIPTION
Background: Our code uses TCPClient, and in its current stage of development, it often goes into the GREEN stage, and we need to put it into safe mode to flash the new code. We were very perplexed when it first happened, and nearly ordered a new Photon as we didn't understand why it wasn't cloud-connected. We figured it out after some forum hunting though.

So my proposal is to put a tip in the device modes doc, based off the most frequent tip in the forum.
Y'all likely know more about other causes of Cloud not being connected, so you may have better wording.

Thanks!