### PR TITLE
Update GCC-ARM toolchain to point to exe installer

### DIFF
--- a/src/content/faq/particle-tools/local-build.md
+++ b/src/content/faq/particle-tools/local-build.md
@@ -80,7 +80,7 @@ The gcc-arm toolchains are here: [https://launchpad.net/gcc-arm-embedded](https:
 
 Currently, the 4.9-2015-q3-update is recommended. The 5.3.1 version can be used now and will be used for cloud compiles starting with system firmware 0.7.0. The 5.4.x and 6.x versions are not recommended at this time.
 
-- For Windows, download the installer [gcc-arm-none-eabi-4_9-2015q3-20150921-win32.exe](https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-win32.zip).
+- For Windows, download the installer [gcc-arm-none-eabi-4_9-2015q3-20150921-win32.exe](https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-win32.exe).
 
 - Run the installer. Select **Next >** and **I Agree** for the terms and conditions of the license.
 


### PR DESCRIPTION
Link was pointing to a zip, not an exe, making the instructions confusing.