### PR TITLE
Update LED blink code description

### DIFF
--- a/src/content/support/troubleshooting/troubleshooting-support.md
+++ b/src/content/support/troubleshooting/troubleshooting-support.md
@@ -18,7 +18,7 @@ During initial setup of a device these are the usual LED specifications:
 {{#if has-cellular}}- **Flashing blue:** Listening mode.{{/if}}
 {{#if core}}- **Solid blue:** Smart Config, received Wi-Fi credentials{{/if}}
 - **Flashing green:** Connecting to {{network-type}} network
-- **Flashing cyan:** Connecting to Particle Cloud
+- **Flashing cyan:** Connecting to Particle Cloud. Connected to the network, but not necessarily the internet yet.
 - **High-speed flashing cyan:** Particle Cloud handshake
 - **Breathing cyan:** Connected to Particle Cloud
 - **Flashing magenta:** Receiving new firmware update over-the-air (OTA)


### PR DESCRIPTION
The "Flashing cyan" blink sequence happens when you are connected to a Wifi network (i.e. have an IP), but have not yet connected to the internet. I'm not sure if this is 100% correct or if there are other scenarios where this blink sequence will happen, but that is what I have observed with the Photon.

This might be redundant with the Flash red twice error code, but I'm not sure how long it takes for that error code to appear. Perhaps adding a description of a timeout will clear that up?