### PR TITLE
Hints provided by ScruffR that should be in the documentation.

### DIFF
--- a/src/content/guide/tools-and-features/libraries.md
+++ b/src/content/guide/tools-and-features/libraries.md
@@ -184,7 +184,7 @@ You can also start with an existing Arduino library from GitHub.  Particle libra
 
 ### Writing the code
 
-The main sources of the library go into `src/lib_name.cpp` and `src/lib_name.h`.
+The main sources of the library go into `src/lib_name.cpp` and `src/lib_name.h`.  More complex libraries may use a nested structure within the `src/` directory.  For example `src/subFolder/subhHeader.h` and referenced as `#include <subFolder/subHeader.h>`.
 
 Create at least one example `.ino` file inside a subfolder of `examples` to show people how to use the library.
 

--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -11300,7 +11300,7 @@ void loop()
 ```
 
 #### loop()
-After creating a setup() function, which initializes and sets the initial values, the loop() function does precisely what its name suggests, and loops consecutively, allowing your program to change and respond. Use it to actively control the device.
+After creating a setup() function, which initializes and sets the initial values, the loop() function does precisely what its name suggests, and loops consecutively, allowing your program to change and respond. Use it to actively control the device.  A return may be used to exit the loop() before it completely finishes.
 
 ```C++
 // EXAMPLE USAGE


### PR DESCRIPTION
REF:

[Nested header structure](https://community.particle.io/t/porting-wolfssl-library/34131/6?u=cermak): I've confirmed that this works.

[use of return possible in loop() and/or setup()](, this can be taken for granted.  I didn't think this was permitted in these special functions, so I think it should be suggested that it can be used to pre-empt full runs of these functions.