### PR TITLE
Docs for RGB.brightness() getter function

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -7059,6 +7059,16 @@ RGB.brightness(128);
 RGB.brightness(255);
 ```
 
+### brightness()
+
+Returns current brightness value.
+
+```cpp
+// EXAMPLE
+
+uint8_t value = RGB.brightness();
+```
+
 ### onChange(handler)
 
 Specifies a function to call when the color of the RGB LED changes. It can be used to implement an external RGB LED.


### PR DESCRIPTION
This PR adds missing docs for the `RGB.brightness()` getter function.