### PR TITLE
Fixes next and previous arrows in the Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 build/
+build_*/
 npm-debug.log
 api-node
 api-service-libraries

--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,2 @@
+*.min.js
+*.min.css

--- a/scripts/fixLinks.js
+++ b/scripts/fixLinks.js
@@ -1,0 +1,40 @@
+'use strict';
+
+/* Fixes the previous/next links on collections to avoid linking to a page that doesn't exist for a device.
+ * For example, there's no billing guide for the Photon, so the next link on the previous page (code examples) should
+ * skip billing and go directly to the next page (open source).
+ */
+module.exports = function(options) {
+	var key = options.key;
+	var keySingular = key.replace(/s$/, "") + 'Value';
+
+	return function(files, metalsmith, done) {
+		Object.keys(files).forEach(function (fileName) {
+			var file = files[fileName];
+			var forks = file[key];
+			var thisFork = file[keySingular];
+
+			if (!forks) {
+				return;
+			}
+
+			if (file.next) {
+				file.next = updateLinks('next');
+			}
+
+			if (file.previous) {
+				file.previous = updateLinks('previous');
+			}
+
+			function updateLinks(direction) {
+				var target = file[direction];
+				while (target && target[key] && !target[key].includes(thisFork)) {
+					target = target[direction];
+				}
+				return target;
+			}
+		});
+
+		done();
+	};
+};

--- a/scripts/metalsmith.js
+++ b/scripts/metalsmith.js
@@ -28,6 +28,7 @@ var deviceFeatureFlags = require('./device_feature_flags');
 var redirects = require('./redirects');
 var copy = require('metalsmith-copy');
 var fork = require('./fork');
+var fixLinks = require('./fixLinks');
 var inPlace = require('metalsmith-in-place');
 var watch = require('metalsmith-watch');
 var autotoc = require('metalsmith-autotoc');
@@ -150,7 +151,6 @@ exports.metalsmith = function() {
     }))
     // Group files into collections and add collection metadata
     // This plugin is complex and buggy.
-    // It causes the broken previous / next links when a page doesn't exist for a device
     // It causes the duplicate nav bar bug during development with livereload
     .use(collections({
       guide: {
@@ -209,6 +209,10 @@ exports.metalsmith = function() {
     .use(fork({
       key: 'devices',
       redirectTemplate: '../templates/redirector.html.hbs'
+    }))
+		// Fix previous / next links when a page doesn't exist for a specific device
+    .use(fixLinks({
+      key: 'devices'
     }))
     // For files that have the devices key set, add a bunch of properties like has-wifi, has-cellular
     // Use them in Handlebar templates like this:

--- a/src/content/faq/raspberry-pi/general.md
+++ b/src/content/faq/raspberry-pi/general.md
@@ -3,7 +3,7 @@ title: General Questions
 layout: faq.hbs
 columns: two
 devices: [ photon,electron,core,raspberry-pi ]
-order: 100
+order: 1
 ---
 
 # {{title}}

--- a/src/content/faq/raspberry-pi/technical.md
+++ b/src/content/faq/raspberry-pi/technical.md
@@ -3,7 +3,7 @@ title: Technical Questions
 layout: faq.hbs
 columns: two
 devices: [ photon,electron,core,raspberry-pi ]
-order: 100
+order: 2
 ---
 
 # {{title}}

--- a/src/content/faq/raspberry-pi/troubleshooting.md
+++ b/src/content/faq/raspberry-pi/troubleshooting.md
@@ -3,7 +3,7 @@ title: Troubleshooting Questions
 layout: faq.hbs
 columns: two
 devices: [ photon,electron,core,raspberry-pi ]
-order: 100
+order: 3
 ---
 
 # {{title}}


### PR DESCRIPTION
For certain devices, certain pages don't exist, so skip over them with the next and previous arrows to avoid showing a confusing device selector when navigating to a page that doesn't exist for the current device.

Try the fix at https://docs.staging.particle.io

Fixes #679