### PR TITLE
Keep titles in lowercase in the reference section

### DIFF
--- a/src/assets/less/content.less
+++ b/src/assets/less/content.less
@@ -346,7 +346,9 @@ body.big-h3 .content h3:before {
   font-family: @base-font-family;
   text-transform: uppercase;
   font-size: 11.5px;
-
+}
+.content.reference h4 {
+  text-transform: none;
 }
 .content h5,
 .content .small-heading,
@@ -371,6 +373,9 @@ body:not(.big-h3) .content h3 {
 }
 body:not(.big-h3) .content h3 {
   font-size: 12px;
+}
+body:not(.big-h3) .content.reference h3 {
+  text-transform: none;
 }
 .content h1:first-child {
   padding: 0;
@@ -1018,8 +1023,4 @@ body:not(.no-literate) .content img[alt="Connection sequence"],
 
 .table-scrollable {
   overflow-x: auto;
-}
-
-.content#Webhooks-content h3 {
-  text-transform: none;
 }

--- a/src/assets/less/firmware.less
+++ b/src/assets/less/firmware.less
@@ -1,9 +1,3 @@
-#Firmware-content {
-	h3, h4 {
-		text-transform: none;
-	}
-}
-
 .ion-cloud, .im-devices-icon {
 	color: @gray;
 }

--- a/templates/layouts/reference.hbs
+++ b/templates/layouts/reference.hbs
@@ -47,7 +47,7 @@
       </div>
       <div class="page-body">
         <div class='content-inner'>
-          <div class="content" id="{{{title}}}-content">
+          <div class="content reference" id="{{path.name}}-content">
             {{{contents}}}
             <div class="code-samples">
             </div>


### PR DESCRIPTION
Several pages in the reference section have headers that are commands (CLI) or function names (JS client). Transforming them to uppercase makes it harder for users to find the correct capitalization.

Also switch the section id to the lowercase filename because it was generating stuff like `id="Command Line Interface (CLI)-content"` otherwise.

Example:
Header for https://docs.particle.io/reference/javascript/#createuser should say createUser not CREATEUSER