### PR TITLE
Add partial templates to Metalsmith watcher

### DIFF
--- a/scripts/metalsmith.js
+++ b/scripts/metalsmith.js
@@ -337,6 +337,7 @@ exports.server = function(callback) {
           '../templates/layouts/datasheet.hbs': 'content/datasheets/*.md',
           '../templates/layouts/support.hbs': 'content/support/**/*.md',
           '../templates/layouts/suppMenu.hbs': 'content/support/**/*.md',
+          '../templates/partials/**/*.hbs': 'content/**/*.md',
           '${source}/assets/js/*.js*' : true,
           '${source}/assets/images/**/*' : true,
           '../config/device_features.json': 'content/**/*.md',


### PR DESCRIPTION
Glob to trigger rebuilds `content/**/*.md` may be too loose, though.