### PR TITLE
correctly print object in getEventStream example

### DIFF
--- a/src/content/reference/javascript.md
+++ b/src/content/reference/javascript.md
@@ -251,21 +251,21 @@ Get event listener to an stream in the Particle cloud with [`getEventStream`](#g
 //Get all events
 particle.getEventStream({ auth: token}).then(function(stream) {
   stream.on('event', function(data) {
-    console.log("Event: " + data);
+    console.log("Event: ", data);
   });
 });
 
 //Get your devices events
 particle.getEventStream({ deviceId: 'mine', auth: token }).then(function(stream) {
   stream.on('event', function(data) {
-    console.log("Event: " + data);
+    console.log("Event: ", data);
   });
 });
 
 //Get test event for specific device
 particle.getEventStream({ deviceId: 'DEVICE_ID', name: 'test', auth: token }).then(function(stream) {
   stream.on('event', function(data) {
-    console.log("Event: " + data);
+    console.log("Event: ", data);
   });
 });
 ```


### PR DESCRIPTION
consoles print "[object Object]" instead of the full object when using "+" because it tries to cast to a string. Using a comma instead prints the full object in browsers and most terminals.