### PR TITLE
Make page numbers links in datasheet TOC

### DIFF
--- a/scripts/pdf-generation/pdf-generation-gulpfile.js
+++ b/scripts/pdf-generation/pdf-generation-gulpfile.js
@@ -102,7 +102,6 @@ gulp.task('transfrom md to pdf', ['assets', 'css'], () => gulp.src(paths.md)
 
 gulp.task('prepare dirs', () => {
     del.sync(paths.build);
-    del.sync(paths.distrib);
     if (!existsSync(paths.build)) {
         mkdirSync(paths.build);
     }

--- a/scripts/pdf-generation/styles/toc.xsl
+++ b/scripts/pdf-generation/styles/toc.xsl
@@ -32,6 +32,8 @@
                     }
                     a {
                         text-decoration: none;
+                    }
+                    a.toc-section {
                         color: black;
                     }
 
@@ -49,7 +51,7 @@
 
             <xsl:if test="@title!=''">
                 <div>
-                    <a>
+                    <a class="toc-section">
 
                         <xsl:if test="@link">
 
@@ -64,7 +66,14 @@
                         <xsl:value-of select="@title"/>
                     </a>
                     <span>
-                        <xsl:value-of select="@page"/>
+                        <a>
+                            <xsl:if test="@link">
+
+                                <xsl:attribute name="href"><xsl:value-of select="@link"/></xsl:attribute>
+                            </xsl:if>
+
+                            <xsl:value-of select="@page"/>
+                        </a>
                     </span>
                 </div>
             </xsl:if>


### PR DESCRIPTION
I was under the impression there were no links in the table of contents for the PDF datasheets because I always clicked on the page numbers, maybe because they were blue instead of black. I just saw the titles were links so I added a transformation to make the page numbers links as well.

I also made it so the PDFs are not deleted before being regenerated. My PDF viewer will automatically refresh when the document is overwritten which is quite convenient.