### PR TITLE
Docs for System.uptime() and System.millis()

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -9945,6 +9945,18 @@ Disables the system flag.
 
 Returns `true` if the system flag is enabled.
 
+### System Uptime
+
+_Since 0.8.0_
+
+#### System.millis()
+
+Returns the number of milliseconds passed since the device was last reset. This function is similar to the global [`millis()`](#millis-) function but returns a 64-bit value.
+
+#### System.uptime()
+
+Returns the number of seconds passed since the device was last reset.
+
 {{#if has-interrupts}}
 
 ## System Interrupts


### PR DESCRIPTION
This PR adds reference docs for `System.uptime()` and `System.millis()` functions introduced in https://github.com/spark/firmware/pull/1393.

**Note:** Let's keep this PR open until we figure out which release will have this feature.
