### PR TITLE
FindStrongestSSID example always returns null (logic error)

### DIFF
--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -1277,7 +1277,7 @@ public:
     const char* scan()
     {
         // initialize data
-        strongest_rssi = 0;
+        strongest_rssi = -128;
         strongest_ssid[0] = 0;
         // perform the scan
         WiFi.scan(handle_ap, this);


### PR DESCRIPTION
strongest_rssi is initialised as 0

the logic is: if ((ap.rssi < 0) && (ap.rssi > strongest_rssi))

thus the strongestFinder.scan() example always returns null as rssi values are between -127 and -1 - and never satisfying (ap.rssi > strongest_rssi)

this PR changes the init value to -128 thus any ap found (including with -127 rssi) will be matched - and the strongest will be found accordingly.