### PR TITLE
dfu-util-0.8 at amazonaws is aging and 32-bit

### DIFF
--- a/src/content/guide/getting-started/modes.md
+++ b/src/content/guide/getting-started/modes.md
@@ -195,9 +195,9 @@ The device will itself automatically enter safe mode if there is no application 
 {{device-animation device "blink" "yellow" }}
 
 If you wish to program your {{device}} with a custom firmware via USB, you'll need to use this mode. This mode triggers the on-board bootloader that accepts firmware binary files via the [dfu-utility.](https://s3.amazonaws.com/spark-assets/dfu-util-0.8-binaries.tar.xz)
-(Note: Some users reported issues with dfu-util on a USB3.0 ports on Windows. Use a USB2.0 port if the USB3.0 port doesn't work.)
+(Note: Some users reported issues with dfu-util on a USB3.0 ports on Windows. Use a USB2.0 port if the USB3.0 port doesn't work. The dfu-util-0.8 binaries are 32-bit. If you need 64-bit, the instructions are [here.](/faq/particle-tools/installing-dfu-util/photon/))
 
-Installation tutorial can be found [here.](/guide/tools-and-features/cli/)
+Installation tutorial can be found [here.](/guide/tools-and-features/cli/photon/)
 
 And a usage guide [here.](/reference/cli/)
 


### PR DESCRIPTION
installing dfu-util-0.9 and later from distro repository is better advice than grabbing v0.8 from an old spark-assets repo. i needed a 64-bit binary.