### PR TITLE
Minor edits

### DIFF
--- a/src/content/datasheets/kits-and-accessories/particle-shields.md
+++ b/src/content/datasheets/kits-and-accessories/particle-shields.md
@@ -279,6 +279,7 @@ There are two status LEDs located on the left of the JST battery connector label
 |OFF     | ON     | Charge done             |
 |OFF     | OFF    | Charge suspend (temperature), timer fault, and sleep mode |
 
+The Power Shield includes a MAX17043 I2C fuel gauge chip to monitor the battery level. This is connected using the I2C interface, pins D0 and D1. You can still use the I2C interface in your design, however you should avoid using D0 and D1 as GPIO as it will interfere with the fuel gauge. The Power Shield includes the I2C pull-up resistors.
 
 ### Power Shield - Specifications
  - Operating voltage: USB or External DC of 7 to 20V

--- a/src/content/guide/getting-started/start.md
+++ b/src/content/guide/getting-started/start.md
@@ -472,6 +472,7 @@ If your device is not blinking blue, {{#if photon}}{{popup 'hold down the SETUP 
 
 If your device is not blinking at all, or if the LED is burning a dull orange color, it may not be getting enough power. Try changing your power source or USB cable.
 
+{{#if photon}}
 ### Step 2a: Connect your Photon to the Internet using the setup web application
 
 *Note: This process only works in Chrome / Firefox / Opera*
@@ -496,6 +497,11 @@ After opening the file:
 We care a lot about security, and we want to make sure that everything you do is safe. Downloading a local file ensures that the credentials are sent directly to the Photon, without any chance of being intercepted.
 
 ### Step 2b: Connect your Photon to the Internet using your smartphone
+{{/if}}
+
+{{#if core}}
+### Step 2: Connect your Core to the Internet using your smartphone
+{{/if}}
 
 Open the app on your phone. Log in or sign up for an account with Particle if you don't have one.
 

--- a/src/content/reference/firmware.md
+++ b/src/content/reference/firmware.md
@@ -2882,8 +2882,17 @@ void loop()
 }
 ```
 
+- When using INPUT\_PULLDOWN make sure a high level signal does not exceed 3.3V.
 - INPUT\_PULLUP does not work as expected on TX on the P1, Electron, and  E Series and should not be used. 
 - INPUT\_PULLDOWN does not work as expected on D0 and D1 on the P1 because the P1 module has hardware pull-up resistors on these pins. 
+
+Also beware when using pins D3, D5, D6, and D7 as OUTPUT controlling external devices. After reset, these pins will be briefly taken over for JTAG/SWD, before being restored to the default high-impedance INPUT state during boot.
+
+- D3, D5, and D7 are pulled high with a pull-up
+- D6 is pulled low with a pull-down
+- D4 is left floating
+
+The brief change in state (especially when connected to a MOSFET that can be triggered by the pull-up or pull-down) may cause issues when using these pins in certain circuits. You can see this with the D7 blue LED which will blink dimly and briefly at boot.
 
 ### getPinMode(pin)
 
@@ -3161,6 +3170,10 @@ On the Core, this parameter can be one of the following values (ADC clock = 18MH
  * ADC_SampleTime_112Cycles: Sample time equal to 112 cycles, 3.73us
  * ADC_SampleTime_144Cycles: Sample time equal to 144 cycles, 4.80us
  * ADC_SampleTime_480Cycles: Sample time equal to 480 cycles, 16.0us
+
+The default is ADC_SampleTime_480Cycles. This means that the ADC is sampled for 16 us which can provide a more accurate reading, at the expense of taking longer than using a shorter ADC sample time. If you are measuring a high frequency signal, such as audio, you will almost certainly want to reduce the ADC sample time.
+ 
+Furthermore, 5 consecutive samples at the sample time are averaged in analogRead(), so the time to convert is closer to 80 us, not 16 us, at 480 cycles.
 
 {{/if}} {{!-- has-adc --}}
 


### PR DESCRIPTION
Document default ADC sample time:
https://github.com/particle-iot/docs/issues/394
Document OUTPUT pins that are affected by JTAG
Getting started guide for Core should not list web setup option
Power shield does not mention use of I2C for fuel gauge:
https://github.com/particle-iot/docs/issues/385