### PR TITLE
Possible typo?

### DIFF
--- a/src/content/reference/javascript.md
+++ b/src/content/reference/javascript.md
@@ -27,7 +27,7 @@ Next, open a command prompt or terminal, and install by typing:
 $ npm install particle-api-js
 ```
 
-### Browser
+### Bower
 
 Particle API JS can be included using bower:
 


### PR DESCRIPTION
Heading says "Browser" but detail text indicates to install using the JS Bower package management tool. Is this a typo?