### PR TITLE
Fix positioning of download pdf button on mobile

### DIFF
--- a/src/assets/less/content.less
+++ b/src/assets/less/content.less
@@ -519,10 +519,19 @@ body.no-literate .content pre > code:hover::-webkit-scrollbar-thumb {
   border-radius:18px;
 }
 
-.buttonUpperRight {
-  position: fixed;
-  top: 50px;
-  right: 18px;
+// Don't actually position the upper right buttons in the upper right on mobile, since they'll
+// obscure the header
+@media (max-width: 799px) {
+  .buttonUpperRight {
+  }
+}
+
+@media (min-width: 800px) {
+  .buttonUpperRight {
+	  position: fixed;
+	  top: 50px;
+	  right: 18px;
+  }
 }
 
 h1 small.beta {


### PR DESCRIPTION
It was obscuring the title. Now it's inline under it.