### PR TITLE
missing markdown for BSSID code

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -1469,6 +1469,7 @@ void loop() {}
 
 `WiFi.BSSID()` retrieves the 6-byte MAC address of the access point the device is currently connected to.
 
+```cpp
 byte bssid[6];
 
 void setup() {
@@ -1479,7 +1480,7 @@ void setup() {
   WiFi.BSSID(bssid);
   Serial.printlnf("%02X:%02X:%02X:%02X:%02X:%02X", bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]);
 }
-
+```
 
 ### RSSI()
 


### PR DESCRIPTION
docs look really scary without some markdown :)

![screenshot 2018-11-06 at 20 27 46](https://user-images.githubusercontent.com/6760914/48064330-7412c800-e202-11e8-8b86-686a48e711ed.png)
