### PR TITLE
Misc Updates

### DIFF
--- a/config/device_features.json
+++ b/config/device_features.json
@@ -142,7 +142,9 @@
     "tcpserver",
     "tcpclient",
     "udp-cloud",
-    "ethernet"
+    "ethernet",
+    "battery-voltage",
+    "eeprom-file"
   ],
   "Boron": [
 	"nrf52",
@@ -174,7 +176,8 @@
     "set-credentials",
     "set-active-sim",
     "udp-cloud",
-    "ethernet"
+    "ethernet",
+    "eeprom-file"
   ],
   "Xenon": [
 	"nrf52",
@@ -205,6 +208,8 @@
     "tcpserver",
     "tcpclient",
     "udp-cloud",
-    "ethernet"
+    "ethernet",
+    "battery-voltage",
+    "eeprom-file"
   ]
 }

--- a/src/content/datasheets/accessories/mesh-accessories.md
+++ b/src/content/datasheets/accessories/mesh-accessories.md
@@ -198,6 +198,8 @@ The Ethernet driver for this wing is baked into the Mesh Device OS. When you set
 
 The hardware design for this wing is completely opensource. All the files are available on our [GitHub repository here.](https://github.com/particle-iot/ethernet-wing)
 
+If you are using the Adafruit Ethernet Feather Wing, be sure to connect the nRESET and nINTERRUPT pins (on the small header on the short side) to pins D3 and D4 with jumper wires. These are required for proper operation.
+
 ## Classic Adapter
 
 <div align=center><img src="/assets/images/accessories/classic-adapter.png" ></div>

--- a/src/content/datasheets/mesh/xenon-datasheet.md
+++ b/src/content/datasheets/mesh/xenon-datasheet.md
@@ -99,7 +99,7 @@ The following antenna is optional, as the Xenon comes with an on-board PCB anten
 | :---:|:---:|:---:|
 | Digital | 20 | I/O |
 | Analog (ADC) | 6 | I |
-| UART | 1 | I/O |
+| UART | 2 | I/O |
 | SPI  | 1 | I/O |
 | I2C  | 2 | I/O |
 | USB  | 1 | I/O |
@@ -162,6 +162,10 @@ You can download a high resolution <a href="/assets/images/xenon/xenon-pinout-v1
 |MO,MI,SCK| These are the SPI interface pins,  but can also be used as a digital GPIO.|
 |D2-D8  | These are generic GPIO pins. D2-D8 are PWM-able.|
 |A0-A5  | These are analog input pins that can also act as standard digital GPIO. A0-A5 are PWM-able.|
+|D4 | TX for Serial2. Can be used as GPIO if not using Serial2.|
+|D5 | RX for Serial2. Can be used as GPIO if not using Serial2.|
+|D6 | CTS for Serial2. Can be used as GPIO if not using Serial2.|
+|D8 | RTS for Serial2. Can be used as GPIO if not using Serial2.|
 
 ---
 

--- a/src/content/support/particle-devices-faq/electron-3rdparty-sims.md
+++ b/src/content/support/particle-devices-faq/electron-3rdparty-sims.md
@@ -498,7 +498,7 @@ The only thing you need to do when switching between Particle and 3rd-party SIM 
 
 You don't need to do anything with the cloud settings or claiming when swapping between SIM cards. 
 
-## Models and cellular bands - Electron and E Series
+## Models and cellular bands - Electron
 
 ### Electron
 


### PR DESCRIPTION
- Document interrupts (ch25251)
- Document reading Xenon and Argon battery voltage (ch25252)
- Document EEPROM (ch25042)
- Document enabling Ethernet (ch25069)
- Document differences between Particle and Adafruit Ethernet (ch25241)
- Add not implemented yet notes for: System.sleep, Mesh antenna selection, Cellular.command
- Add Xenon Serial2 to Xenon datasheet