### PR TITLE
Added clarification when powering the Boron

### DIFF
--- a/src/content/datasheets/cellular/boron-datasheet.md
+++ b/src/content/datasheets/cellular/boron-datasheet.md
@@ -67,7 +67,13 @@ The USB port is the easiest way to power up the Boron. Please make sure that the
 For powering the Boron 2G/3G version, you'll either need a USB port that is able support 2A current, or have the LiPo battery plugged in when powering over USB. This is because the on-board u-blox modem can consumes up to 1.8A peak current when operating in 2G mode. The Boron will intelligently source power from the USB most of the time and keep the battery charged. During peak current requirements, the additional power will be sourced from the battery. This reduces the charge-discharge cycle load on the battery, thus improving its longevity.
 
 #### VUSB PIN
-The pin is internally connected to the VBUS of the USB port. The nominal output should be around 4.5 to 5 VDC when the device is plugged into the USB port and 0 when not connected to a USB source. You can use this pin to power peripherals that operate at such voltages. Do not exceed the current rating of the USB port, which is nominally rated to 500mA.
+The pin is internally connected to the VBUS of the USB port.
+
+#####When used to power the Boron
+The Boron can be powered via the Vusb pin. The voltage range is 3.9V-12VDC.
+
+#####When used to power Peripherals
+The nominal output should be around 4.5 to 5 VDC when the device is plugged into the USB port and 0 when not connected to a USB source. You can use this pin to power peripherals that operate at such voltages. Do not exceed the current rating of the USB port, which is nominally rated to 500mA.
 
 #### LiPo
 If you want to make your projects truly wireless, you can power the device with a single cell LiPo (3.7V). The Boron has an on board LiPo charger that will charge and power the device when USB source is plugged in, or power the device from the LiPo alone in the absence of the USB.


### PR DESCRIPTION
Added clarification that the Boron can be powered via the Vusb pin and the acceptable voltage range (copied from the Electron datasheet.)

There will be questions on how to power the Boron from an external power supply until it is clarified. The Gen 2 devices had a Vin pin which better indicated the intent of the pin. See community discussions such as this one: https://community.particle.io/t/powering-electron-via-solar-power/30399/34?u=ninjatill

Verbiage is negotiable but the clarification is still needed IMHO.