### PR TITLE
Add mention of the publish based ParticleWebLog

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -12813,6 +12813,7 @@ Parameters:
 The log handlers below are written by the community and are not considered "Official" Particle-supported log handlers. If you have any issues with them please raise an issue in the forums or, ideally, in the online repo for the handler.
 
 - [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Build](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
+- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Build](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
 - More to come (feel free to add your own by editing the docs on GitHub)
 
 ### Logger Class


### PR DESCRIPTION
Hi, 
I've just written a new LogHandler that allows remote logging using only the standard Particle.publish (which of course has pros and cons).  But it worked well for me because my network is pretty hostile to UDP, I couldn't use ParticlePapertrail.  Instead, I publish to the particle servers and then use a webhook to send my (low rate) log messages to a log server.  During development I just watch the standard particle web console.