### PR TITLE
Topic/event limit still in docs

### DIFF
--- a/src/content/tutorials/device-cloud/console.md
+++ b/src/content/tutorials/device-cloud/console.md
@@ -40,9 +40,9 @@ class="full-width"/>
 You can also take certain actions on devices from this view, such as
 renaming the device and unclaiming it from your account.
 
-### Event Logs
+### Events
 
-The Logs feature provides a clean interface to view event information in real-time, just from your devices. We're hoping that this is handy both while debugging code during development, and checking out recent activity on your device once you power-on your finished project. Tailored around improving the experience of browsing logs, the page provides a handful of tools, like filtering, modifiers which enable you to narrow down your search for events, making it easier to view only the data that is relevant to you. In this view, you'll only see events that come in while the browser window is open.
+The Events feature provides a clean interface to view event information in real-time, just from your devices. We're hoping that this is handy both while debugging code during development, and checking out recent activity on your device once you power-on your finished project. Tailored around improving the experience of browsing logs, the page provides a handful of tools, like filtering, modifiers which enable you to narrow down your search for events, making it easier to view only the data that is relevant to you. In this view, you'll only see events that come in while the browser window is open.
 
 To visit the page go to [https://console.particle.io/events](https://console.particle.io/events)
 
@@ -574,8 +574,6 @@ Particle Device Cloud. For example, this could include a Particle.publish() call
 
 If you have multiple JS applications subscribed to an event then each will consume one of your outbound messages with each published event- watch out for running many copies of your app!
 
-When you hit the outbound event limit you can choose to upgrade to the new tier or stay at the current tier. If you do choose to stay with the current tier then any future events that month won’t be sent. You’ll get a fresh batch of events at the beginning of the next month, and normal behavior will resume then. Don’t worry, we’ll send you a warning before and an alert when you reach the event limit. 
-
 #### Team Members
 
 Team members are people that you’ve added to a Product to give them administrative access to the data, controlling firmware on devices, adding integrations, and more. The product owner can add and remove team members as necessary, but they’ll need to have a Particle account before they can be invited to join your team.
@@ -587,10 +585,10 @@ Products in the Console are billed separately, so if you have more than one they
 All Console plans are billed at the beginning of the plan period; in other words, it’s prepaid. You’ll pay for the following month or year, and can later cancel for a prorated remainder. 
 
 ### Status
-It’s easy to find out the status of your Product’s metrics. Visit [console.particle.io/billing](https://console.particle.io/billing) and you’ll see an up-to-date list of each Product you own, how many outbound events they’ve used that billing cycle, number of devices in each, and how many team members they have. The renewal date for each Product plan is also shown, so you know when the next bill is coming up.
+It’s easy to find out the status of your Product’s metrics. Visit [console.particle.io/billing](https://console.particle.io/billing) and you’ll see an up-to-date list of each Product you own, number of devices in each, and how many team members they have. The renewal date for each Product plan is also shown, so you know when the next bill is coming up.
 
 ### Changing Plans 
-You can upgrade to a higher tier at any time from the Billing view in order to add more team members or devices, or increase your monthly outbound event limit. We’ll send you notifications before you encounter the outbound event limit, but it’s wise to upgrade early because no events will be sent after you hit it. If you’ve hit the event limit, tried to add more devices than are supported by the current tier, or attempted to add a 6th team member while on the free Prototype tier, you’ll be prompted to upgrade to a higher tier.
+You can upgrade to a higher tier at any time from the Billing view in order to add more team members or devices. If you’ve tried to add more devices than are supported by the current tier, or attempted to add a 6th team member while on the free Prototype tier, you’ll be prompted to upgrade to a higher tier.
 
 When you upgrade we’ll prorate the new price for the rest of the month (or year, depending on your billing period) so you’ll never be double-billed.
 

--- a/src/content/tutorials/device-cloud/webhooks.md
+++ b/src/content/tutorials/device-cloud/webhooks.md
@@ -112,7 +112,11 @@ Make sure your device is connected and selected in the IDE (Ensure that the <i c
 
 Your device should now restart and start publishing the event that will trigger the webhook.
 
-To ensure that everything is working properly, head over to your Logs hub on the console. Every time your webhook triggers, a `hook-sent` event will appear in your user event stream. If the webhook receives a response from the targeted web server with something in the `body`, a `hook-response` event will also appear in your event stream containing the response.
+To ensure that everything is working properly, head over to the Events page in the console. You can troubleshoot your integration by.... `What is the best practice now that we dont have the Logs hub? commented out in code below...`
+<!---
+All this should be 
+commented out
+ your Logs hub on the console. Every time your webhook triggers, a `hook-sent` event will appear in your user event stream. If the webhook receives a response from the targeted web server with something in the `body`, a `hook-response` event will also appear in your event stream containing the response.
 
 ![Webhook Logs](/assets/images/webhook-logs.png)
 <p class="caption">`hook-sent` and `hook-response` events will appear in your event stream for an active webhook</p>
@@ -123,6 +127,7 @@ You should see three types of events appearing in your stream:
 - `hook-response/temp/0`: The response that the webhook received from ThingSpeak. According to [ThingSpeak's docs](https://www.mathworks.com/help/thingspeak/update-channel-feed.html), the response is the entry ID of the update. If the update fails, the response is `0`.
 
 Sweet! Things appear to be working properly. Let's check out ThingSpeak and see how our data looks.
+-->
 
 ### See the results
 
@@ -227,6 +232,9 @@ You can also customize the structure of the data that gets sent. In the "Advance
 
 ## Monitoring your webhooks
 
+`Updated best practice should be updated here...`
+<!---
+
 The easiest way to observe webhook activity is to view the Integrations tab in the Particle Console. Double click on the integration you want to view and the page shows the history, recent calls, and recent errors.
 
 Additionally, you can view the Events page of your Particle Console. Every time your webhook triggers, a `hook-sent` event will appear in your user event stream. This is confirmation that the Particle cloud successfully forwarded your event to your webhook's target URL. 
@@ -237,7 +245,7 @@ If the webhook receives a response from the targeted web server with something i
 <p class="caption">`hook-sent` and `hook-response` events will appear in your event stream for an active webhook</p>
 
 Note that this will only appears in the Events page for the device owner. The hook events do not appear in the device-specific event log, or in the product event log.
-
+-->
 ## Custom Template
 
 The "Custom Template" tab of the webhook editor shows the raw configuration for the webhook. The syntax is described in the [webhook reference page](/reference/webhooks/).


### PR DESCRIPTION
*Don't merge yet*, the webhooks troubleshooting best practice hasn't been refactored --> https://github.com/particle-iot/docs/compare/topic/eventLimitStillInDocs?expand=1#diff-cc717ba54d72579f4ac8848c18dc68b3

@jme783  -- correct me if I'm wrong but the best practice is probably using the `Events` page and monitoring the specific events that get published during webhook integration? Eg `hook-sent/` and `hook-response/` 