### PR TITLE
Changed cd firmware to cd device-os

### DIFF
--- a/src/content/support/particle-tools-faq/local-build.md
+++ b/src/content/support/particle-tools-faq/local-build.md
@@ -405,7 +405,7 @@ In other words, the src directory in the user's documents directory, for example
 
 ```bash
 git clone https://github.com/particle-iot/device-os.git
-cd firmware
+cd device-os
 git checkout release/stable
 ```
 


### PR DESCRIPTION
The folder created during git clone will be **device-os** not firmware anymore