### PR TITLE
Misc fixes

### DIFF
--- a/src/content/datasheets/certifications/certification.md
+++ b/src/content/datasheets/certifications/certification.md
@@ -101,12 +101,12 @@ Particle's certifications will help you decrease the time and cost associated wi
 - [Certificate of Conformity - G350](/assets/pdfs/electron/fcc-g350-certificate.pdf)
 - [Test Reports - G350](/assets/pdfs/electron/fcc-g350-test-report.pdf)
 
-#### E-Series E310 (U201)
+#### E Series E310 (U201)
 - FCC ID: [XPY1CGM5NNN](https://apps.fcc.gov/oetcf/eas/reports/ViewExhibitReport.cfm?mode=Exhibits&RequestTimeout=500&calledFromFrame=N&application_id=3vkdOEQAe%2Fc2YGK%2FBZsiJQ%3D%3D&fcc_id=XPY1CGM5NNN)
 - [Certificate of Conformity](/assets/pdfs/electron/fcc-u201-certificate.pdf)
 - [Test Reports - E310](/assets/pdfs/electron/fcc-u201-test-report.pdf)
 
-#### E-Series E402 LTE (R410M)
+#### E Series E402 LTE (R410M)
 
 - FCC ID: [XPY2AGQN4NNN](https://apps.fcc.gov/oetcf/eas/reports/ViewExhibitReport.cfm?mode=Exhibits&RequestTimeout=500&calledFromFrame=N&application_id=ikrR3FBKrpgwIGJS1sm7Bw%3D%3D&fcc_id=XPY2AGQN4NNN)
 - [Certificate of Conformity](/assets/pdfs/e402-fcc.pdf)
@@ -158,7 +158,7 @@ For certificates of conformity, search [here](https://sms-sgs.ic.gc.ca/equipment
 - [Certificate of Conformity](/assets/pdfs/electron/ic-u201-certificate.pdf)
 - [Test Report](/assets/pdfs/electron/ic-u201-test-report.pdf)
 
-#### E-Series E402 LTE (R410M)
+#### E Series E402 LTE (R410M)
 - IC ID: **8595A-2AGQN4NNN**.
 - [Certificate of Conformity](/assets/pdfs/e402-ic.pdf)
 
@@ -329,13 +329,18 @@ When an End Product like the Electron is connected to a host device (PC, PDA, et
 - Product has completed and passed all PTCRB test requirements. Please [contact Particle](https://www.particle.io/sales) if you are building an end product with our 2G cellular solutions.
 
 #### E Series E310 (U201)
+- [Certified Device Detail](https://www.ptcrb.com/certified-devices/device-details/?model=39636)
 - [Certificate of Conformity](/assets/pdfs/electron/ptcrb-u201-certificate.pdf)
 - [Test Reports](/assets/pdfs/electron/ptcrb-u201-test-report.pdf)
 
-#### E-Series E402 LTE (R410M)
-
+#### E Series E402 LTE (R410M)
+- [Certified Device Detail](https://www.ptcrb.com/certified-devices/device-details/?model=41338)
 - [Certificate of Conformity](/assets/pdfs/e402-ptcrb.pdf)
 - [AT&T LTE Certification](/assets/pdfs/e402-ota-att.pdf)
+
+#### Boron LTE (R410M)
+
+- [Certified Device Detail](https://www.ptcrb.com/certified-devices/device-details/?model=40983)
 
 ## GCF<img class="inline-header-image" src="/assets/images/logo-gcf.png"/>
 ### Description
@@ -349,6 +354,12 @@ The GCF is a certification partnership between European network operators, mobil
 
 #### Electron 3G (U270)
 - Product has completed and passed all GCF test requirements. Please [contact Particle](https://www.particle.io/sales) if you are building an end product with our 3G-U270 cellular solutions.
+
+## Carrier Certifications
+
+#### AT&T (LTE Cat M1)
+
+The Boron LTE (BRN402) and E Series LTE (E402) are certified for use on the AT&T LTE Cat M1 network. From the [AT&T Certified Devices page](https://iotdevices.att.com/certified-devices.aspx) search for "Particle".
 
 
 

--- a/src/content/reference/device-cloud/api.md
+++ b/src/content/reference/device-cloud/api.md
@@ -223,7 +223,7 @@ we'll give you lots of notice and a clear upgrade path.
 
 ## Devices
 
-Note: The connected or online state of devices is not always accurate. When a Wi-Fi device is unplugged, for example, it may still be listed as online when not. For cellular (Electron, E-Series) and mesh (Argon, Boron, Xenon) devices, the connected or online state is set to true on the first connection and never set to false again.
+Note: The connected or online state of devices is not always accurate. When a Wi-Fi device is unplugged, for example, it may still be listed as online when not. For cellular (Electron, E Series) and Gen 3 (Argon, Boron, Xenon) devices, the connected or online state is set to true on the first connection and never set to false again.
 
 {{> api group=apiGroups.Devices}}
 ## Remote Diagnostics

--- a/src/content/support/troubleshooting/firmware-upgrades.md
+++ b/src/content/support/troubleshooting/firmware-upgrades.md
@@ -13,7 +13,7 @@ How do I upgrade my firmware?
 
 ## The Simple Way (one CLI command)
 
-**Warning:** The particle update command has not been updated to work with the Argon, Boron, and Xenon yet. You also should not use it with the E Series E402 (LTE). Use the manual instructions below, instead.
+**Warning:** The particle update command has not been updated to work with the Argon, Boron, and Xenon yet. Use the manual instructions below, instead.
 
 If you are using the [Particle CLI](/tutorials/developer-tools/cli) and have been able to use it successfully to login to your account, then you should be able to upgrade your device firmware and it will auto-update the CLI for you. Yeah I know, it's great right?!
 
@@ -31,64 +31,50 @@ Install the [Particle CLI](/tutorials/developer-tools/cli) if you have not alrea
 
 ### Argon, Boron, and Xenon
 
-- Go to the [mesh firmware releases page](https://github.com/particle-iot/device-os/releases/tag/v0.8.0-rc.25-mesh).
-- Download the hybrid .bin file for your device. For example: hybrid-0.8.0-rc.25-argon.bin
+- Go to the [mesh firmware releases page](https://github.com/particle-iot/device-os/releases/tag/v0.9.0).
+- Download the hybrid .bin file for your device. For example: hybrid-0.9.0-argon.bin
 - Put your device into DFU mode (blinking yellow), instructions [here](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-).
 - Flash the code:
 
 ```html
-particle flash --usb hybrid-0.8.0-rc.25-argon.bin
+particle flash --usb hybrid-0.9.0-argon.bin
 ```
 
 ### Photon
 
-- Go to the [latest firmware releases page](https://github.com/particle-iot/device-os/releases/latest). At the time of writing, this was 0.7.0.
-- Download the system-part1 and system-part2 for your device, for example: system-part1-0.7.0-photon.bin and system-part2-0.7.0-photon.bin.
+- Go to the [latest firmware releases page](https://github.com/particle-iot/device-os/releases/latest). At the time of writing, this was 1.0.0.
+- Download the system-part1 and system-part2 for your device, for example: system-part1-1.0.0-photon.bin and system-part2-1.0.0-photon.bin.
 - Put your device into DFU mode (blinking yellow), instructions [here](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-).
 - Flash the code:
 
 ```html
-particle flash --usb system-part1-0.7.0-photon.bin
-particle flash --usb system-part2-0.7.0-photon.bin
+particle flash --usb system-part1-1.0.0-photon.bin
+particle flash --usb system-part2-1.0.0-photon.bin
 ```
 
 ### P1
 
-- Go to the [latest firmware releases page](https://github.com/particle-iot/device-os/releases/latest). At the time of writing, this was 0.7.0.
-- Download the system-part1 and system-part2 for your device, for example: system-part1-0.7.0-p1.bin and system-part2-0.7.0-p1.bin.
+- Go to the [latest firmware releases page](https://github.com/particle-iot/device-os/releases/latest). At the time of writing, this was 1.0.0.
+- Download the system-part1 and system-part2 for your device, for example: system-part1-1.0.0-p1.bin and system-part2-1.0.0-p1.bin.
 - Put your device into DFU mode (blinking yellow), instructions [here](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-).
 - Flash the code:
 
 ```html
-particle flash --usb system-part1-0.7.0-p1.bin
-particle flash --usb system-part2-0.7.0-p1.bin
+particle flash --usb system-part1-1.0.0-p1.bin
+particle flash --usb system-part2-1.0.0-p1.bin
 ```
 
+### Electron and E Series
 
-### E Series E402 (LTE)
-
-- Go to the [E402 firmware releases page](https://github.com/particle-iot/device-os/releases/tag/v0.8.0-rc.11).
-- Download the system-part1, part2, and part3. for your device, for example: system-part1-0.8.0-rc.11-electron.bin, system-part2-0.8.0-rc.11-electron.bin, and system-part3-0.8.0-rc.11-electron.bin. (The Electron and E series use the same system firmware.)
+- Go to the [firmware releases page](https://github.com/particle-iot/device-os/releases/latest). At the time of writing, this was 1.0.0.
+- Download the system-part1, part2, and part3. for your device, for example: system-part1-1.0.0-electron.bin, system-part2-1.0.0-electron.bin, and system-part3-1.0.0-electron.bin. (The Electron and E series use the same system firmware.)
 - Put your device into DFU mode (blinking yellow), instructions [here](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-).
 - Flash the code:
 
 ```html
-particle flash --usb system-part1-0.8.0-rc.11-electron.bin
-particle flash --usb system-part2-0.8.0-rc.11-elecron.bin
-particle flash --usb system-part3-0.8.0-rc.11-electron.bin
-```
-
-### Electron and E Series (except E402)
-
-- Go to the [firmware releases page](https://github.com/particle-iot/device-os/releases/latest). At the time of writing, this was 0.7.0.
-- Download the system-part1, part2, and part3. for your device, for example: system-part1-0.7.0-electron.bin, system-part2-0.7.0-electron.bin, and system-part3-0.7.0-electron.bin. (The Electron and E series use the same system firmware.)
-- Put your device into DFU mode (blinking yellow), instructions [here](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-).
-- Flash the code:
-
-```html
-particle flash --usb system-part1-0.7.0-electron.bin
-particle flash --usb system-part2-0.7.0-electron.bin
-particle flash --usb system-part3-0.7.0-electron.bin
+particle flash --usb system-part1-1.0.0-electron.bin
+particle flash --usb system-part2-1.0.0-electron.bin
+particle flash --usb system-part3-1.0.0-electron.bin
 ```
 
 {{else}}

--- a/src/content/tutorials/cellular-connectivity/billing.md
+++ b/src/content/tutorials/cellular-connectivity/billing.md
@@ -8,7 +8,7 @@ order: 21
 ## Billing Service with Particle
 Welcome to the wonderful world of inexpensive cellular data for your
 devices! Up to 3MB of Cellular data is _included_ with your Device Cloud
-subscription for your cellular Particle devices (Electrons and E-Series
+subscription for your cellular Particle devices (Electrons and E Series
 modules). You will be charged overages for cellular data consumed beyond
 3MB in a given month. 
 


### PR DESCRIPTION
- Document Keep-alive for Xenon (ch29283)
- Document maximum stop mode sleep time for Gen 3 (ch29283)
- Update Device OS upgrade instructions for 0.9.0 and 1.0.0 (ch28831)
- Fix references to "E-Series" (should not have hyphen) (ch29277)
- Include the correct flash data sheet in the Argon, Boron, and Xenon repos (ch28708)
- Add links to PTCRB and carrier certifications (ch28127)