### PR TITLE
Minor edits

### DIFF
--- a/src/assets/files/eclipse-debug/tinkerbreak.cpp
+++ b/src/assets/files/eclipse-debug/tinkerbreak.cpp
@@ -1,5 +1,10 @@
 #include "Particle.h"
 
+// This turns off optimization for this file which makes it easier to debug.
+// Otherwise you can't break on some lines, and some local variables won't
+// be available.
+#pragma GCC optimize ("O0")
+
 /* Function prototypes -------------------------------------------------------*/
 int tinkerDigitalRead(String pin);
 int tinkerDigitalWrite(String command);

--- a/src/content/quickstart/xenon.md
+++ b/src/content/quickstart/xenon.md
@@ -57,8 +57,6 @@ To begin setting up your Xenon, click the button below and follow the onscreen i
 {{box op="start" cssClass="boxed warningBox"}}
 **NOTES:**</br>
 1.) If you have already set up your Xenon, skip to Step #2.<br /><br />
-2.) During set up you may skip setting up a Particle Mesh network and use the Xenon in a standalone mode.
-
 {{box op="end"}}
 
 ---

--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -8489,7 +8489,7 @@ This class allows to define a _LED status_ that represents an application-specif
 
 ```cpp
 // EXAMPLE - defining and using a LED status
-LEDStatus blinkRed(RGB_COLOR_RED, LED_PATTERN_BLINK);
+LEDStatus blinkRed(RGB_COLOR_RED, LED_PATTERN_BLINK, LED_SPEED_NORMAL, LED_PRIORITY_IMPORTANT);
 
 void setup() {
     // Blink red for 3 seconds after connecting to the Cloud
@@ -9642,6 +9642,8 @@ Not supported on the Electron/E series (you can't use attachInterrupt on these p
 
   - D0, A5 (shared with MODE button)
   - D7 (shared with BATT_INT_PC13)
+  - C1 (shared with RXD_UC)
+  - C2 (shared with RI_UC)
 
 No restrictions on the Electron/E series (all of these can be used at the same time):
 
@@ -12579,6 +12581,70 @@ Determine if OTA updates are presently enabled or disabled.
 Indicates if there are OTA updates pending.
 
 **Note:** Currently this function does not really do what the name might suggests but rather indicates whether an update is currently active or not. It can't be used in connection with `System.disableUpdates()` as that would prevent `System.upatesPending()` from becoming `true`. 
+
+## Checking for Features
+
+User firmware is designed to run transparently regardless of what type of device it is run on. However, sometimes you will need to have code that varies, depending on the device.
+
+It's always best to check for a capability, rather than a specific device. For example, checking for cellular instead of checking for the Electron allows the code to work properly on the Boron without modification.
+
+Some commonly used features include:
+
+- Wiring_Cellular
+- Wiring_Ethernet
+- Wiring_IPv6
+- Wiring_Keyboard
+- Wiring_Mesh
+- Wiring_Mouse
+- Wiring_Serial2
+- Wiring_Serial3
+- Wiring_Serial4
+- Wiring_Serial5
+- Wiring_SPI1
+- Wiring_SPI2
+- Wiring_USBSerial1
+- Wiring_WiFi
+- Wiring_Wire1
+- Wiring_Wire3
+- Wiring_WpaEnterprise
+
+For example, you might have code like this to declare two different methods, depending on your network type:
+
+```
+#if Wiring_WiFi
+	const char *wifiScan();
+#endif
+
+#if Wiring_Cellular
+	const char *cellularScan();
+#endif
+```
+
+The official list can be found [in the source](https://github.com/particle-iot/device-os/blob/develop/wiring/inc/spark_wiring_platform.h#L47).
+
+### Checking Device OS Version
+
+The define value `SYSTEM_VERSION` specifies the [system version](https://github.com/particle-iot/device-os/blob/develop/system/inc/system_version.h).
+
+For example, if you had code that you only wanted to include in 0.7.0 and later, you'd check for:
+
+```
+#if SYSTEM_VERSION >= SYSTEM_VERSION_v070
+// Code to include only for 0.7.0 and later
+#endif
+```
+
+### Checking Platform ID
+
+It's always best to check for features, but it is possible to check for a specific platform:
+
+```
+#if PLATFORM_ID == PLATFORM_BORON
+// Boron-specific code goes here
+#endif
+```
+
+You can find a complete list of platforms in [the source](https://github.com/particle-iot/device-os/blob/develop/hal/shared/platforms.h).
 
 ## Arduino Compatibility
 

--- a/src/content/support/troubleshooting/troubleshooting-tools.md
+++ b/src/content/support/troubleshooting/troubleshooting-tools.md
@@ -20,7 +20,7 @@ It is possible to put your {{device}} in [Listening Mode](/tutorials/device-os/l
 
 #### For Windows
 
-For Windows users, we recommend downloading [PuTTY](http://www.putty.org/). You will also need to download and install the [Particle driver](https://github.com/particle-iot/windows-device-drivers/releases/download/v6.1.0.51/particle_drivers_6.1.0.51.exe).
+For Windows users, we recommend downloading [PuTTY](http://www.putty.org/). 
 
 Plug your device into your computer over USB. When the {{device}} is in [Listening Mode](/tutorials/device-os/led/#listening-mode), open a serial port over USB using the standard settings, which should be:
 
@@ -118,30 +118,7 @@ The configuration process will be almost identical to the process laid out in th
 
 ## DFU Commands
 
-If you can't get the CLI working, you may have to put your device in [DFU mode](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-) and use [dfu-util](http://dfu-util.sourceforge.net/) to get some basic commands done. A list of DFU commands is below. To use these, you can download dfu-util via the above link, then go to the command line and run dfu-util with one of the following commands.
-
-We don't recommend using these commands unless you're very comfortable with the platform or unless you've been instructed to do so by Particle Support or an Elite community member.
-
-### Windows Setup
-
-dfu-util works from the command line with macOS, but to use dfu-util on Windows, you'll need several drivers.
-
-- First, you'll need to download and install the [Particle driver](https://github.com/particle-iot/windows-device-drivers/releases/download/v6.1.0.51/particle_drivers_6.1.0.51.exe).
-
-- Once that is done, put your {{device}} in DFU mode.
-
-- Then download the tar files for dfu-util [here](http://dfu-util.sourceforge.net/releases/dfu-util-0.8-binaries.tar.xz).
-
-- You can unzip these files using a utility like [7-zip](http://www.7-zip.org/).
-
-- After this, you should install [Zadig](http://zadig.akeo.ie/).
-
-- Open Zadig and install WinUSB to your Particle device.
-
-{{!-- Is this tutorial still relevant? --}}
-For a better illustrated version of these instructions, check out steps 1-5 of [Jon Gallant's tutorial](http://blog.jongallant.com/2015/08/particle-photon-firmware-flash-windows.html).
-
-Now you are ready for DFU commands!
+There are a number of low-level commands that can be used in [DFU mode](/tutorials/device-os/led/#dfu-mode-device-firmware-upgrade-) 
 
 {{#if core}}
 ### Core DFU commands:

--- a/src/content/tutorials/developer-tools/workbench.md
+++ b/src/content/tutorials/developer-tools/workbench.md
@@ -18,6 +18,12 @@ layout: tutorials.hbs
 
 ## Workbench Features
 
+### Welcome Screen
+
+![Welcome Screen](/assets/images/workbench/welcome.png)
+
+The Welcome Screen has handy tips for using Workbench. If you close it, you can get it back by clicking on the Particle icon in the left toolbar.
+
 ### Left Toolbar
 
 Typically, there is a toolbar on the left with frequently used features.
@@ -30,13 +36,6 @@ Typically, there is a toolbar on the left with frequently used features.
 | <img src="/assets/images/workbench/left-bar-debugger.png" class="toolbarIcon" /> | Source level debugger |
 | <img src="/assets/images/workbench/left-bar-extensions.png" class="toolbarIcon" /> | Add or modify VS Code Extensions |
 | <img src="/assets/images/workbench/left-bar-particle.png" class="toolbarIcon" /> | Particle Welcome Screen |
-
-
-### Welcome Screen
-
-![Welcome Screen](/assets/images/workbench/welcome.png)
-
-The Welcome Screen has handy tips for using Workbench. If you close it, you can get it back by clicking on the Particle icon in the left toolbar.
 
 
 ### Particle Commands
@@ -269,6 +268,8 @@ Navigating into AssetTrackerRK you can see the source and examples, and also the
 
 ![Library Read Me](/assets/images/workbench/library-readme.png)
 
+You can also install a specific version of a library by using a syntax like `dotstar@0.0.4`. You can also change the version by editing the project.properties file at the top of your project.
+
 
 ### Snippets
 
@@ -342,6 +343,14 @@ particle call argon2 div 10
 - When done, **Continue** (4).
 
 ![Debug Breakpoint](/assets/images/workbench/debug-6.png)
+
+- In the TinkerBreak.cpp source file, you'll notice this at the top of the file. This is helpful to add to your source files to turn off compiler optimization, making it easier to debug. Otherwise you can't break on some lines, and some local variables won't be available.
+
+```
+#pragma GCC optimize ("O0")
+```
+
+
 
 That is just a brief introduction to debugging. For more information, see the [VS Code Debugging Documentation](https://code.visualstudio.com/docs/editor/debugging).
 


### PR DESCRIPTION
- Remove mention of using Xenon in standalone mode in quickstart (ch30576)
- attachInterrupt should list C1 and C2 as not available on Electron (ch29890)
- LED status example should include priority (ch30433)
- Document how to specify a particular library version in Workbench (ch30432)
- Add note about setting optimization level when debugging (ch30546)
- Document how to use feature, platform, and version defines (ch30472)
