### PR TITLE
Add note about USBSerial1 on Windows for Electron and P1

### DIFF
--- a/config/device_features.json
+++ b/config/device_features.json
@@ -1,7 +1,7 @@
 {
   "Core": [
-	"stm32",
-	"stm32f1",
+    "stm32",
+    "stm32f1",
     "wifi",
     "embedded",
     "listening",
@@ -24,7 +24,7 @@
     "tcpclient"
   ],
   "Photon": [
-	"stm32",
+    "stm32",
     "stm32f2",
     "wifi",
     "embedded",
@@ -65,7 +65,7 @@
     "udp-multicast"
   ],
   "Electron": [
-	"stm32",
+    "stm32",
     "stm32f2",
     "cellular",
     "embedded",
@@ -116,8 +116,8 @@
     "tcpclient"
   ],
   "Argon": [
-	"nrf52",
-	"nrf52840",
+    "nrf52",
+    "nrf52840",
     "mesh",
     "wifi",
     "embedded",
@@ -151,8 +151,8 @@
     "udp-multicast"
   ],
   "Boron": [
-	"nrf52",
-	"nrf52840",
+    "nrf52",
+    "nrf52840",
     "mesh",
     "cellular",
     "embedded",
@@ -188,8 +188,8 @@
     "udp-multicast"
   ],
   "Xenon": [
-	"nrf52",
-	"nrf52840",
+    "nrf52",
+    "nrf52840",
     "mesh",
     "embedded",
     "listening",

--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -4771,6 +4771,11 @@ To use the hardware serial pins of (Serial1{{#if has-serial2}}/2{{/if}}{{#if has
 **NOTE:** Please take into account that the voltage levels on these pins operate at 0V to 3.3V and should not be connected directly to a computer's RS232 serial port which operates at +/- 12V and will damage the {{device}}.
 
 {{#unless raspberry-pi}}
+
+{{#if has-usb-serial1}}
+**NOTE:** On Windows 10, using `USBSerial1` on the Electron and P1 may not be reliable due to limitations of the USB peripheral used for those 2 platforms. Characters may be dropped between the computer and device. `USBSerial1` is reliable for other Particle platforms and other operating systems. `Serial` is reliable for all platforms and operating systems.
+{{/if}} {{!-- has-usb-serial1 --}}
+
 #### Connect to Serial with a computer
 
 For **Windows** users, we recommend downloading [PuTTY](http://www.putty.org/). Plug your {{device}} into your computer over USB, open a serial port in PuTTY using the standard settings, which should be:
@@ -4965,7 +4970,7 @@ LIN configuration:
 {{/if}} {{!-- has-linbus --}}
 
 {{#if has-usb-serial1}}
-***NOTE*** {{since when="0.6.0"}}: When `USBSerial1` is enabled by calling `USBSerial1.begin()` in `setup()` or during normal application execution, the device will quickly disconnect from Host and connect back with `USBSerial1` enabled. If such behavior is undesirable, `USBSerial1` may be enabled with `STARTUP()` macro, which will force the device to connect to the Host with both `Serial` and `USBSerial1` by default.
+**NOTE** {{since when="0.6.0"}} When `USBSerial1` is enabled by calling `USBSerial1.begin()` in `setup()` or during normal application execution, the device will quickly disconnect from Host and connect back with `USBSerial1` enabled. If such behavior is undesirable, `USBSerial1` may be enabled with `STARTUP()` macro, which will force the device to connect to the Host with both `Serial` and `USBSerial1` by default.
 
 ```C++
 // EXAMPLE USAGE


### PR DESCRIPTION
Due to limited number of USB endpoints on the Electron and P1 and the unavailability of the lowcdc driver for Windows 10, USBSerial1 can be unreliable on Windows 10.