### PR TITLE
Adds simple script to call `docker run` similar to server.js

### DIFF
--- a/scripts/docker-server.sh
+++ b/scripts/docker-server.sh
@@ -1,12 +1,2 @@
 #!/bin/sh
-
-if [ -z $REPO_PATH ]; then
-    echo "$0 ERROR: The REPO_PATH environment variable is required!"
-    echo "Try this: export REPO_PATH=\`pwd\`"
-    exit 5
-elif ! [ -d $REPO_PATH ]; then
-    echo "$0 ERROR: $REPO_PATH is not a valid directory"
-    exit 6
-fi
-
-docker run --interactive --mount type=bind,source=$REPO_PATH,target=/particle-iot/docs --net host --rm --tty particle/docs
+docker run --interactive --mount type=bind,source=$(pwd),target=/particle-iot/docs --net host --rm --tty particle/docs "$@"

--- a/scripts/docker-server.sh
+++ b/scripts/docker-server.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+if [ -z $REPO_PATH ]; then
+    echo "$0 ERROR: The REPO_PATH environment variable is required!"
+    echo "Try this: export REPO_PATH=\`pwd\`"
+    exit 5
+elif ! [ -d $REPO_PATH ]; then
+    echo "$0 ERROR: $REPO_PATH is not a valid directory"
+    exit 6
+fi
+
+docker run --interactive --mount type=bind,source=$REPO_PATH,target=/particle-iot/docs --net host --rm --tty particle/docs


### PR DESCRIPTION
On my mac, even after letting this script run for 52 minutes, requests to localhost:8080 were still not succeeding. By contrast `npm start` starts serving the docs in about 40 seconds.