### PR TITLE
device-os: clarify description of button_click event

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -11181,7 +11181,7 @@ Setup mode is also referred to as listening mode (blinking dark blue).
 |       | firmware_update_pending | 512 | notifies the application that a firmware update is available. This event is sent even when updates are disabled, giving the application chance to re-enable firmware updates with `System.enableUpdates()` | not used |
 |       | reset_pending | 1024 | notifies the application that the system would like to reset. This event is sent even when resets are disabled, giving the application chance to re-enable resets with `System.enableReset()` | not used |
 |       | reset | 2048 | notifies that the system will reset once the application has completed handling this event | not used |
-|       | button_click | 4096 | event sent each time setup button is clicked. | `int clicks = system_button_clicks(param); ` retrieves the number of clicks so far. |
+|       | button_click | 4096 | event sent each time SETUP/MODE button is clicked. | `int clicks = system_button_clicks(param); ` retrieves the number of clicks so far. |
 |       | button_final_click | 8192 | sent after a run of one or more clicks not followed by additional clicks. Unlike the `button_click` event, the `button_final_click` event is sent once, at the end of a series of clicks. | `int clicks = system_button_clicks(param); ` retrieves the number of times the button was pushed. |
 | 0.6.1 | time_changed | 16384 | device time changed | `time_changed_manually` or `time_changed_sync` |
 | 0.6.1 | low_battery | 32768 | generated when low battery condition is detected. | not used |


### PR DESCRIPTION
The "setup" button is the same button as the "mode" button.

When I read these docs initially, I asked myself "what's the 'setup' button? I only have 'mode' and 'reset' buttons..."

I figure this might trip someone else up as well.