### PR TITLE
Minor edits

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -1030,11 +1030,13 @@ The publish function takes two parameters:
 Mesh.publish(const char *name, const char *data);
 
 RETURNS
-boolean (true or false)
+int (0 = success, non-zero = system error code)
 
 // EXAMPLE USAGE
 Mesh.publish("motion-sensor", "living room");
 ```
+
+Note that the return value for Mesh.publish is 0 (`SYSTEM_ERROR_NONE`) for success, where the return value for Particle.publish is true (1) for success.
 
 ### subscribe()
 
@@ -11411,6 +11413,16 @@ void so_timing_sensitive()
 }
 ```
 
+You must avoid within a SINGLE_THREADED_BLOCK:
+
+- Lengthy operations
+- Calls to delay()
+- Any call that can block (Particle.publish, Cellular.RSSI, and others)
+- Any function that uses a mutex to guard a resource (Log.info, SPI transactions, etc.)
+
+The problem with mutex guarded resources is a bit tricky. For example: Log.info uses a mutex to prevent multiple threads from trying to log at the same time, causing the messages to be mixed together. However the code runs with interrupts and thread swapping enabled. Say the system thread is logging and your user thread code swaps in. The system thread still holds the logging mutex. Your code enters a SINGLE_THREADED_BLOCK, then does Log.info. The system will deadlock at this point. Your Log.info in the user thread blocks on the logging mutex. However it will never become available because thread swapping has been disabled, so the system thread can never release it. All threads will stop running at this point.
+
+Because it's hard to know exactly what resources will be guarded by a mutex its best to minimize the use of SINGLE_THREADED_BLOCK.
 
 ### ATOMIC_BLOCK()
 

--- a/src/content/support/particle-tools-faq/jtag.md
+++ b/src/content/support/particle-tools-faq/jtag.md
@@ -623,6 +623,6 @@ To erase all of your configuration and start from scratch on Gen 2:
 -c "flash erase_sector 0 1 2 " \
 ```
 
-That's bank 0, sectors 1 and 2 (starting at 0x08004000 and 0x080008000).
+That's bank 0, sectors 1 and 2 (starting at 0x08004000 and 0x08008000).
 
 Note that when you erase the configuration flash your device ID is preserved but your device private key will be lost. This means you won't be able to connect to the cloud until you upload your keys using the CLI command [particle keys doctor](/reference/cli/#particle-keys-doctor).


### PR DESCRIPTION
- Document SOS 14 in 1.2.0 (ch34771)
- Wrong return type for Mesh.publish (ch34647)
- Typo on ending address in JTAG instructions (ch34571)
- Warning about listening mode for setup not complete (ch34506)
- Warning about SINGLE_THREADED_BLOCK (ch34473)
- Remove reference to OpenSignal web site (ch33483)