### PR TITLE
Add docs for Mesh.selectAntenna() and BLE.selectAntenna()

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -1004,26 +1004,6 @@ void setup() {
 
 After that version, all of the features in the Mesh object will be removed from the Device OS API. See [mesh deprecation](/reference/discontinued/mesh/) for more information.
 
-
-### Antenna selection
-
-At the time of writing (Device OS 0.8.0-rc.27), mesh antenna selection is not yet supported. Only the internal mesh antenna can be used at this time. However, you can use this function to select the external mesh antenna. The setting is not saved and the default is internal.
-
-```
-void selectExternalMeshAntenna() {
-
-#if (PLATFORM_ID == PLATFORM_ARGON)
-    digitalWrite(ANTSW1, 1);
-    digitalWrite(ANTSW2, 0);
-#elif (PLATFORM_ID == PLATFORM_BORON)
-    digitalWrite(ANTSW1, 0);
-#else
-    digitalWrite(ANTSW1, 0);
-    digitalWrite(ANTSW2, 1);
-#endif
-}
-```
-
 ### publish()
 
 On Mesh devices, there are two publish options: Particle.publish and Mesh.publish:
@@ -1210,6 +1190,37 @@ void setup() {
 void setup() {
   Serial.begin();
   Serial.printlnf("localIP: %s", Mesh.localIP().toString().c_str());
+}
+```
+
+### selectAntenna()
+
+{{since when="1.5.0"}}
+
+Selects which antenna is used by the mesh radio stack. This is a persistent setting.
+
+**Note:** On Gen 3 devices (Argon, Boron, Xenon), the mesh and BLE radio stacks share the same antenna and changing the antenna via `Mesh.selectAntenna()` also changes the antenna used by the BLE stack. SoM devices do not have an internal antenna.
+
+```cpp
+// Select the internal antenna
+Mesh.selectAntenna(MeshAntennaType::INTERNAL);
+// Select the external antenna
+Mesh.selectAntenna(MeshAntennaType::EXTERNAL);
+```
+
+The following function can be used to select the external antenna in older versions of Device OS. Note that, in this case, the setting is not saved, and the Device OS will select the default internal antenna after a reset.
+
+```cpp
+void selectExternalMeshAntenna() {
+#if (PLATFORM_ID == PLATFORM_ARGON)
+    digitalWrite(ANTSW1, 1);
+    digitalWrite(ANTSW2, 0);
+#elif (PLATFORM_ID == PLATFORM_BORON)
+    digitalWrite(ANTSW1, 0);
+#elif (PLATFORM_ID == PLATFORM_XENON)
+    digitalWrite(ANTSW1, 0);
+    digitalWrite(ANTSW2, 1);
+#endif
 }
 ```
 {{/if}}
@@ -7521,7 +7532,7 @@ Gen 3 devices (Argon, Boron, and Xenon) support Bluetooth LE (BLE) in both perip
 
 BLE is intended for low data rate sensor applications. Particle devices do not support Bluetooth A2DP and can't be used with Bluetooth headsets, speakers, and other audio devices. Particle devices do not support Bluetooth 5 mesh.
 
-The BLE protocol shares the same antenna as the mesh radio, and can use the built-in chip or trace antenna, or an external antenna if you have installed and configured one. 
+The BLE protocol shares the same antenna as the mesh radio, and can use the built-in chip or trace antenna, or an external antenna if you have installed and [configured](#ble-selectantenna-) one.
 
 The B Series  SoM (system-on-a-module) requires the external BLE/Mesh antenna connected to the **BT** connector. The SoMs do not have built-in antennas.
 
@@ -8277,6 +8288,21 @@ const BleAddress address() const;
 ```
 
 See [`BleAddress`](/reference/device-os/firmware/#bleaddress) for more information.
+
+#### BLE.selectAntenna()
+
+{{since when="1.3.1"}}
+
+Selects which antenna is used by the BLE radio stack. This is a persistent setting.
+
+**Note:** On Gen 3 devices (Argon, Boron, Xenon), the mesh and BLE radio stacks share the same antenna and changing the antenna via `BLE.selectAntenna()` also changes the antenna used by the mesh stack. SoM devices do not have an internal antenna.
+
+```cpp
+// Select the internal antenna
+BLE.selectAntenna(BleAntennaType::INTERNAL);
+// Select the external antenna
+BLE.selectAntenna(BleAntennaType::EXTERNAL);
+```
 
 ### BLE Services
 


### PR DESCRIPTION
This PR adds reference docs for `Mesh.selectAntenna()` and `BLE.selectAntenna()`. Note that Device OS 1.5.0, which will include `Mesh.selectAntenna()`, has not yet been released.
