### PR TITLE
Fix internal links to gen3 accessories

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -55,7 +55,7 @@
     "/datasheets/photon-shields": "/datasheets/accessories/legacy-accessories",
     "/datasheets/raspberrypi-datasheet": "/raspberry-pi",
     "/dev": "/tutorials/developer-tools/dev",
-    "/ethernet-featherwing": "/datasheets/accessories/mesh-accessories/#ethernet-featherwing",
+    "/ethernet-featherwing": "/datasheets/accessories/gen3-accessories/#ethernet-featherwing",
     "/examples": "/tutorials",
     "/faq": "/support/particle-devices-faq/finding-device-id",
     "/faq/discontinued-products/raspberry-pi": "/raspberry-pi",

--- a/src/content/air-quality-monitoring-kit.md
+++ b/src/content/air-quality-monitoring-kit.md
@@ -44,6 +44,6 @@ For technical documentation on each of the included components, please see the l
 - **Grove FeatherWing Adapter** (3)
 - **Grove modules:**
   - **[Water sensor](https://www.seeedstudio.com/Grove-Water-Sensor-p-748.html)** (2)
-  - **[Button](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button)** 
+  - **[Button](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button)** 
 - **Grove wires** (3)
 {{box op="end"}}

--- a/src/content/iot-starter-kit.md
+++ b/src/content/iot-starter-kit.md
@@ -43,13 +43,13 @@ For technical documentation on each of the included components, please see the l
   * [LiPo battery](https://docs.particle.io/tutorials/learn-more/batteries/)
 * Grove FeatherWing Adapter
 * Grove modules:
-  * [Button](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button) 
-  * [Rotary encoder](https://docs.particle.io/datasheets/accessories/mesh-accessories/#rotary-angle-sensor)
-  * [Ultrasonic range finder](https://docs.particle.io/datasheets/accessories/mesh-accessories/#ultrasonic-ranger) 
-  * [Temperature and humidity sensor](https://docs.particle.io/datasheets/accessories/mesh-accessories/#temperature-and-humidity-sensor)
-  * [Light sensor](https://docs.particle.io/datasheets/accessories/mesh-accessories/#light-sensor-v1-2) 
-  * [RGB LED (chainable)](https://docs.particle.io/datasheets/accessories/mesh-accessories/#chainable-rgb-led)
-  * [Buzzer](https://docs.particle.io/datasheets/accessories/mesh-accessories/#buzzer) 
-  * [4-Digit display](https://docs.particle.io/datasheets/accessories/mesh-accessories/#4-digit-display)
+  * [Button](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button) 
+  * [Rotary encoder](https://docs.particle.io/datasheets/accessories/gen3-accessories/#rotary-angle-sensor)
+  * [Ultrasonic range finder](https://docs.particle.io/datasheets/accessories/gen3-accessories/#ultrasonic-ranger) 
+  * [Temperature and humidity sensor](https://docs.particle.io/datasheets/accessories/gen3-accessories/#temperature-and-humidity-sensor)
+  * [Light sensor](https://docs.particle.io/datasheets/accessories/gen3-accessories/#light-sensor-v1-2) 
+  * [RGB LED (chainable)](https://docs.particle.io/datasheets/accessories/gen3-accessories/#chainable-rgb-led)
+  * [Buzzer](https://docs.particle.io/datasheets/accessories/gen3-accessories/#buzzer) 
+  * [4-Digit display](https://docs.particle.io/datasheets/accessories/gen3-accessories/#4-digit-display)
 * Grove wire (8) 
 {{box op="end"}}

--- a/src/content/leak-detection-kit.md
+++ b/src/content/leak-detection-kit.md
@@ -47,6 +47,6 @@ For technical documentation on each of the included components, please see the l
 - **Grove FeatherWing Adapter** (3)
 - **Grove modules:**
   - **[Water sensor](https://www.seeedstudio.com/Grove-Water-Sensor-p-748.html)** (2)
-  - * [Button](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button) 
+  - * [Button](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button) 
 - **Grove wires** (3)
 {{box op="end"}}

--- a/src/content/quickstart/isk-project.md
+++ b/src/content/quickstart/isk-project.md
@@ -17,9 +17,9 @@ For this project you'll need the following parts from you kit:
   * [LiPo battery](https://docs.particle.io/tutorials/learn-more/batteries/)
 * Grove FeatherWing Adapter
 * Grove modules:
-  * [Temperature and humidity sensor](https://docs.particle.io/datasheets/accessories/mesh-accessories/#temperature-and-humidity-sensor)
-  * [Light sensor](https://docs.particle.io/datasheets/accessories/mesh-accessories/#light-sensor-v1-2) 
-  * [RGB LED (chainable)](https://docs.particle.io/datasheets/accessories/mesh-accessories/#chainable-rgb-led)
+  * [Temperature and humidity sensor](https://docs.particle.io/datasheets/accessories/gen3-accessories/#temperature-and-humidity-sensor)
+  * [Light sensor](https://docs.particle.io/datasheets/accessories/gen3-accessories/#light-sensor-v1-2) 
+  * [RGB LED (chainable)](https://docs.particle.io/datasheets/accessories/gen3-accessories/#chainable-rgb-led)
 * Grove wire (3) 
 {{box op="end"}}
 
@@ -301,52 +301,52 @@ This section contains links and resources for the Grove sensors included in the 
 ### Button
 
 - Sensor Type: Digital
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button)
 - [Seeed Studio Documentation](https://www.seeedstudio.com/Grove-Button-p-766.html)
 
 ### Rotary Angle Sensor
 
 - Sensor Type: Analog
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#rotary-angle-sensor)
-- [Seeed Studio Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#rotary-angle-sensor)
+- [Seeed Studio Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button)
 
 
 ### Ultrasonic Ranger
 
 - Sensor Type: Digital
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_Ultrasonic_Ranger/1.0.0/tab/Ultrasonic.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#ultrasonic-ranger)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#ultrasonic-ranger)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Ultrasonic_Ranger/)
 
 ### Temperature and Humidity Sensor
 
 - Sensor Type: Digital
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_Temperature_And_Humidity_Sensor/1.0.6/tab/Seeed_DHT11.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#temperature-and-humidity-sensor)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#temperature-and-humidity-sensor)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-TemperatureAndHumidity_Sensor/)
 
 ### Light sensor
 
 - Sensor Type: Analog
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#light-sensor-v1-2)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#light-sensor-v1-2)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Light_Sensor/)
 
 ### Chainable LED
 
 - Sensor Type: Serial
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_ChainableLED/1.0.1/tab/ChainableLED.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#chainable-rgb-led)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#chainable-rgb-led)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Chainable_RGB_LED/)
 
 ### Buzzer
 
 - Sensor Type: Digital
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#buzzer)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#buzzer)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Buzzer/)
 
 ### 4-Digit Display
 
 - Sensor Type: Digital
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_4Digit_Display/1.0.1/tab/TM1637.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#4-digit-display)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#4-digit-display)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-4-Digit_Display/)

--- a/src/content/quickstart/ldk-project.md
+++ b/src/content/quickstart/ldk-project.md
@@ -23,7 +23,7 @@ Low-power, cheap, and Mesh-capable Xenons will be used with water sensors to det
 - **Grove FeatherWing Adapter** (3)
 - **Grove modules:**
   - **[Water sensor](https://www.seeedstudio.com/Grove-Water-Sensor-p-748.html)** (2)
-  - * [Button](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button) 
+  - * [Button](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button) 
 - **Grove wires** (3)
 ---
 

--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -1227,7 +1227,7 @@ void setup() {
 {{#if has-ethernet}}
 ## Ethernet
 
-Ethernet is available on the Argon and Boron when used with the [Ethernet FeatherWing](/datasheets/accessories/mesh-accessories/#ethernet-featherwing).
+Ethernet is available on the Argon and Boron when used with the [Ethernet FeatherWing](/datasheets/accessories/gen3-accessories/#ethernet-featherwing).
 
 By default, Ethernet detection is not done because it will toggle GPIO that may affect circuits that are not using Ethernet. When you select Ethernet during mobile app setup, it is enabled and the setting stored in configuration flash.
 

--- a/src/content/tutorials/developer-tools/workbench.md
+++ b/src/content/tutorials/developer-tools/workbench.md
@@ -301,7 +301,7 @@ _Note: There are a handful of limitation around debugging 3rd-generation hardwar
 
 For this tutorial, you'll use the [TinkerBreak source](/assets/files/eclipse-debug/tinkerbreak.cpp). This is the same application used in the [Eclipse Debug Tutorial](/support/particle-tools-faq/eclipse-debug/). As you'll see, this is way easier in Workbench! 
 
-- You'll need two USB connections to your computer: Your device, connected by a micro USB cable, and the Particle debugger, either directly plugged into a USB A port, or into a USB A extension cable. The Particle Debugger also needs to connect to your device using the included ribbon cable as described in the [Particle Debugger](/datasheets/accessories/mesh-accessories/#debugger) documentation.
+- You'll need two USB connections to your computer: Your device, connected by a micro USB cable, and the Particle debugger, either directly plugged into a USB A port, or into a USB A extension cable. The Particle Debugger also needs to connect to your device using the included ribbon cable as described in the [Particle Debugger](/datasheets/accessories/gen3-accessories/#debugger) documentation.
 
 ![Debugger](/assets/images/debugger3.jpg)
 
@@ -401,7 +401,7 @@ That is just a brief introduction to debugging. For more information, see the [V
 
 ### Debugging (2nd-generation with Particle Debugger)
 
-- You'll need two USB connections to your computer: Your device, connected by a micro USB cable, and the Particle debugger, either directly plugged into a USB A port, or into a USB A extension cable. The Particle Debugger also needs to connect to your device's D6 and D7 pins as described in the [Particle Debugger](/datasheets/accessories/mesh-accessories/#debugger) documentation.
+- You'll need two USB connections to your computer: Your device, connected by a micro USB cable, and the Particle debugger, either directly plugged into a USB A port, or into a USB A extension cable. The Particle Debugger also needs to connect to your device's D6 and D7 pins as described in the [Particle Debugger](/datasheets/accessories/gen3-accessories/#debugger) documentation.
 
 - Create a new project using the Command Palette and **Particle: Create New Project**. If you already created a project for the 3rd-generation device, you can just reuse that one.
 - Rename TinkerBreak.ino to TinkerBreak.cpp. Paste in the [TinkerBreak source](/assets/files/eclipse-debug/tinkerbreak.cpp) into TinkerBreak.cpp.

--- a/src/content/workshops/particle-101-workshop/primitives.md
+++ b/src/content/workshops/particle-101-workshop/primitives.md
@@ -66,7 +66,7 @@ You're now ready to program your Argon with Particle Workbench. Let's get the de
 
 ## Unboxing the Grove Starter Kit
 
-The Grove Starter Kit for Particle Mesh comes with seven different components that work out-of-the-box with Particle Mesh devices, and a Grove Shield that allows you to plug in your Feather-compatible Mesh devices for quick prototyping. The shield houses eight Grove ports that support all types of Grove accessories. For more information about the kit, [click here](https://docs.particle.io/datasheets/accessories/mesh-accessories/#grove-starter-kit-for-particle-mesh).
+The Grove Starter Kit for Particle Mesh comes with seven different components that work out-of-the-box with Particle Mesh devices, and a Grove Shield that allows you to plug in your Feather-compatible Mesh devices for quick prototyping. The shield houses eight Grove ports that support all types of Grove accessories. For more information about the kit, [click here](https://docs.particle.io/datasheets/accessories/gen3-accessories/#grove-starter-kit-for-particle-mesh).
 
 For this lab, you'll need the following items from the kit:
 
@@ -363,52 +363,52 @@ This section contains links and resources for the Grove sensors included in the 
 ### Button
 
 - Sensor Type: Digital
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button)
 - [Seeed Studio Documentation](https://www.seeedstudio.com/Grove-Button-p-766.html)
 
 ### Rotary Angle Sensor
 
 - Sensor Type: Analog
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#rotary-angle-sensor)
-- [Seeed Studio Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#button)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#rotary-angle-sensor)
+- [Seeed Studio Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#button)
 
 
 ### Ultrasonic Ranger
 
 - Sensor Type: Digital
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_Ultrasonic_Ranger/1.0.0/tab/Ultrasonic.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#ultrasonic-ranger)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#ultrasonic-ranger)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Ultrasonic_Ranger/)
 
 ### Temperature and Humidity Sensor
 
 - Sensor Type: Digital
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_Temperature_And_Humidity_Sensor/1.0.6/tab/Seeed_DHT11.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#temperature-and-humidity-sensor)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#temperature-and-humidity-sensor)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-TemperatureAndHumidity_Sensor/)
 
 ### Light sensor
 
 - Sensor Type: Analog
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#light-sensor-v1-2)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#light-sensor-v1-2)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Light_Sensor/)
 
 ### Chainable LED
 
 - Sensor Type: Serial
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_ChainableLED/1.0.1/tab/ChainableLED.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#chainable-rgb-led)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#chainable-rgb-led)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Chainable_RGB_LED/)
 
 ### Buzzer
 
 - Sensor Type: Digital
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#buzzer)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#buzzer)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-Buzzer/)
 
 ### 4-Digit Display
 
 - Sensor Type: Digital
 - [Particle Firmware Library](https://build.particle.io/libs/Grove_4Digit_Display/1.0.1/tab/TM1637.cpp)
-- [Particle Documentation](https://docs.particle.io/datasheets/accessories/mesh-accessories/#4-digit-display)
+- [Particle Documentation](https://docs.particle.io/datasheets/accessories/gen3-accessories/#4-digit-display)
 - [Seeed Studio Documentation](http://wiki.seeedstudio.com/Grove-4-Digit_Display/)


### PR DESCRIPTION
Redirect doesn't maintain the anchor so links to accessories went to the top of the page. Change the internal links to point to the new page

Rick, can you please merge when Travis passes?