### PR TITLE
Core and platform selector changes

### DIFF
--- a/config/crawler.json
+++ b/config/crawler.json
@@ -2,971 +2,831 @@
   "urls": {
     "https://community.particle.io/c/DT": {
       "url": "https://community.particle.io/c/DT",
-      "time": 1580943760
+      "time": 1581074264
     },
     "https://setup.particle.io/": {
       "url": "https://setup.particle.io/",
-      "time": 1580943571
+      "time": 1581074113
     },
     "https://community.particle.io/": {
       "url": "https://community.particle.io/",
-      "time": 1580943543
+      "time": 1581074100
     },
     "https://www.particle.io/": {
       "url": "https://www.particle.io/",
-      "time": 1580943734
+      "time": 1581074253
     },
     "https://console.particle.io/": {
       "url": "https://console.particle.io/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://build.particle.io/build": {
       "url": "https://build.particle.io/build",
-      "time": 1580943536
+      "time": 1581074097
     },
     "https://www.particle.io/iot-command-center/": {
       "url": "https://www.particle.io/iot-command-center/",
-      "time": 1580943536
+      "time": 1581074097
     },
     "https://www.analog.com/media/en/technical-documentation/application-notes/an88f.pdf": {
       "url": "https://www.analog.com/media/en/technical-documentation/application-notes/an88f.pdf",
-      "time": 1580943536
+      "time": 1581074097
     },
     "https://www.jedec.org/": {
       "url": "https://www.jedec.org/",
-      "time": 1580943536
+      "time": 1581074098
     },
     "https://en.wikipedia.org/wiki/UL_%28safety_organization%29": {
       "url": "https://en.wikipedia.org/wiki/UL_%28safety_organization%29",
-      "time": 1580943539
+      "time": 1581074098
     },
     "https://docs.particle.io/support/": {
       "url": "https://docs.particle.io/support/",
-      "time": 1580943542
+      "time": 1581074099
     },
     "https://semver.org/": {
       "url": "https://semver.org/",
-      "time": 1580943543
+      "time": 1581074099
     },
     "https://community.particle.io/c/troubleshooting": {
       "url": "https://community.particle.io/c/troubleshooting",
-      "time": 1580943543
+      "time": 1581074100
     },
     "https://powerbi.microsoft.com/en-us/": {
       "url": "https://powerbi.microsoft.com/en-us/",
-      "time": 1580943762
+      "time": 1581074264
     },
     "https://www.particle.io/pricing/": {
       "url": "https://www.particle.io/pricing/",
-      "time": 1580943549
+      "time": 1581074103
     },
     "https://www.particle.io/sales/": {
       "url": "https://www.particle.io/sales/",
-      "time": 1580943549
+      "time": 1581074103
     },
     "https://www.openssl.org/": {
       "url": "https://www.openssl.org/",
-      "time": 1580943552
+      "time": 1581074103
     },
     "https://community.particle.io/t/tutorial-particle-cli-on-windows-07-jun-2015/3112": {
       "url": "https://community.particle.io/t/tutorial-particle-cli-on-windows-07-jun-2015/3112",
-      "time": 1580943552
-    },
-    "https://docs.particle.io/tutorials/developer-tools/cli/": {
-      "url": "https://docs.particle.io/tutorials/developer-tools/cli/",
-      "time": 1580389227
+      "time": 1581074104
     },
     "https://www.w3schools.com/js/js_json_intro.asp": {
       "url": "https://www.w3schools.com/js/js_json_intro.asp",
-      "time": 1580943734
+      "time": 1581074253
     },
     "https://en.wikipedia.org/wiki/POST_%28HTTP%29": {
       "url": "https://en.wikipedia.org/wiki/POST_%28HTTP%29",
-      "time": 1580943554
+      "time": 1581074104
     },
     "https://docs.particle.io/guide/tools-and-features/dev/": {
       "url": "https://docs.particle.io/guide/tools-and-features/dev/",
-      "time": 1580943556
+      "time": 1581074106
     },
     "https://github.com/technobly/Particle-NeoPixel": {
       "url": "https://github.com/technobly/Particle-NeoPixel",
-      "time": 1580943735
-    },
-    "https://docs.particle.io/datasheets/kits/": {
-      "url": "https://docs.particle.io/datasheets/kits/",
-      "time": 1580389225
+      "time": 1581074254
     },
     "http://wiki.seeedstudio.com/Grove-TemperatureAndHumidity_Sensor/": {
       "url": "http://wiki.seeedstudio.com/Grove-TemperatureAndHumidity_Sensor/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://apps.apple.com/us/app/particle-build-iot-projects-wifi-or-cellular/id991459054": {
       "url": "https://apps.apple.com/us/app/particle-build-iot-projects-wifi-or-cellular/id991459054",
-      "time": 1580943569
+      "time": 1581074112
     },
     "https://www.opensignal.com/": {
       "url": "https://www.opensignal.com/",
-      "time": 1580943571
+      "time": 1581074112
     },
     "https://status.particle.io/": {
       "url": "https://status.particle.io/",
-      "time": 1580943565
+      "time": 1581074109
     },
     "https://en.wikipedia.org/wiki/Industry_Canada": {
       "url": "https://en.wikipedia.org/wiki/Industry_Canada",
-      "time": 1580943571
+      "time": 1581074113
     },
     "https://en.wikipedia.org/wiki/CE_marking": {
       "url": "https://en.wikipedia.org/wiki/CE_marking",
-      "time": 1580943571
+      "time": 1581074113
     },
     "https://www.fcc.gov/": {
       "url": "https://www.fcc.gov/",
-      "time": 1580943571
+      "time": 1581074113
     },
     "https://www.ecfr.gov/cgi-bin/text-idx?c=ecfr&SID=a9f9d244cc20be8b56099003689d6cc3&rgn=div5&view=text&node=47%3A1.0.1.1.16&idno=47": {
       "url": "https://www.ecfr.gov/cgi-bin/text-idx?c=ecfr&SID=a9f9d244cc20be8b56099003689d6cc3&rgn=div5&view=text&node=47%3A1.0.1.1.16&idno=47",
-      "time": 1580943571
+      "time": 1581074113
     },
     "https://ec.europa.eu/environment/waste/rohs_eee/index_en.htm": {
       "url": "https://ec.europa.eu/environment/waste/rohs_eee/index_en.htm",
-      "time": 1580943572
+      "time": 1581074113
     },
     "https://www.sparkfun.com/products/13855": {
       "url": "https://www.sparkfun.com/products/13855",
-      "time": 1580943737
+      "time": 1581074256
     },
     "https://www.telec.co.jp/": {
       "url": "https://www.telec.co.jp/",
-      "time": 1580943573
+      "time": 1581074117
     },
     "https://www.globalcertificationforum.org/": {
       "url": "https://www.globalcertificationforum.org/",
-      "time": 1580943572
+      "time": 1581074114
     },
     "https://github.com/particle-iot/uber-library-example": {
       "url": "https://github.com/particle-iot/uber-library-example",
-      "time": 1580943734
+      "time": 1581074253
     },
     "https://github.com/particle-iot/internetbutton": {
       "url": "https://github.com/particle-iot/internetbutton",
-      "time": 1580943589
+      "time": 1581074126
     },
     "https://www.tele.soumu.go.jp/e/index.htm": {
       "url": "https://www.tele.soumu.go.jp/e/index.htm",
-      "time": 1580943572
+      "time": 1581074117
     },
     "https://github.com/particle-iot/PowerShield": {
       "url": "https://github.com/particle-iot/PowerShield",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://www.particle.io/workbench/": {
       "url": "https://www.particle.io/workbench/",
-      "time": 1580943736
+      "time": 1581074254
     },
     "https://github.com/particle-iot/google-maps-device-locator": {
       "url": "https://github.com/particle-iot/google-maps-device-locator",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://ifttt.com/": {
       "url": "https://ifttt.com/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://circuitpython.org/board/particle_xenon/": {
       "url": "https://circuitpython.org/board/particle_xenon/",
-      "time": 1580943741
+      "time": 1581074259
     },
     "https://github.com/particle-iot/particle-api-js/tree/master/examples": {
       "url": "https://github.com/particle-iot/particle-api-js/tree/master/examples",
-      "time": 1580943592
+      "time": 1581074126
     },
     "https://www.learncpp.com/cpp-tutorial/header-files/": {
       "url": "https://www.learncpp.com/cpp-tutorial/header-files/",
-      "time": 1580943592
+      "time": 1581074127
     },
     "https://nodejs.org/en/": {
       "url": "https://nodejs.org/en/",
-      "time": 1580943732
+      "time": 1581074253
     },
     "https://cloud.google.com/free/": {
       "url": "https://cloud.google.com/free/",
-      "time": 1580943592
+      "time": 1581074127
     },
     "https://community.particle.io/t/tutorial-particle-cli-on-mac-osx-26-sep-2015/5225": {
       "url": "https://community.particle.io/t/tutorial-particle-cli-on-mac-osx-26-sep-2015/5225",
-      "time": 1580943733
+      "time": 1581074253
     },
     "https://en.wikipedia.org/wiki/Representational_State_Transfer": {
       "url": "https://en.wikipedia.org/wiki/Representational_State_Transfer",
-      "time": 1580943734
+      "time": 1581074253
     },
     "https://jsonapi.org/": {
       "url": "https://jsonapi.org/",
-      "time": 1580943734
+      "time": 1581074253
     },
     "https://github.com/particle-iot/particle-android": {
       "url": "https://github.com/particle-iot/particle-android",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://github.com/particle-iot/softap-setup-js": {
       "url": "https://github.com/particle-iot/softap-setup-js",
-      "time": 1580943734
+      "time": 1581074254
     },
     "https://github.com/particle-iot/device-os/releases/tag/v1.4.4": {
       "url": "https://github.com/particle-iot/device-os/releases/tag/v1.4.4",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://www.instructables.com/howto/Particle/": {
       "url": "https://www.instructables.com/howto/Particle/",
-      "time": 1580943734
+      "time": 1581074254
     },
     "https://kk.org/cooltools/zach-supalla-ceo-of-particle/": {
       "url": "https://kk.org/cooltools/zach-supalla-ceo-of-particle/",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://embedded.fm/episodes/222": {
       "url": "https://embedded.fm/episodes/222",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://github.com/hirotakaster/MQTT": {
       "url": "https://github.com/hirotakaster/MQTT",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://github.com/kegnet/photon-thermistor": {
       "url": "https://github.com/kegnet/photon-thermistor",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://github.com/eliteio/DS18B20": {
       "url": "https://github.com/eliteio/DS18B20",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://github.com/menan/adafruit_st7735": {
       "url": "https://github.com/menan/adafruit_st7735",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://github.com/nmattisson/httpclient": {
       "url": "https://github.com/nmattisson/httpclient",
-      "time": 1580943736
+      "time": 1581074254
     },
     "https://github.com/greiman/SdFat-Particle": {
       "url": "https://github.com/greiman/SdFat-Particle",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://github.com/sparkfun/sparkfun_max17043_particle_library": {
       "url": "https://github.com/sparkfun/sparkfun_max17043_particle_library",
-      "time": 1580943735
+      "time": 1581074255
     },
     "https://github.com/focalintent/fastled-sparkcore": {
       "url": "https://github.com/focalintent/fastled-sparkcore",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://build.particle.io/shared_apps/5bc52086cb4e858acf001098": {
       "url": "https://build.particle.io/shared_apps/5bc52086cb4e858acf001098",
-      "time": 1580943737
+      "time": 1581074255
     },
     "https://en.wikipedia.org/wiki/Electrolytic_capacitor": {
       "url": "https://en.wikipedia.org/wiki/Electrolytic_capacitor",
-      "time": 1580943736
+      "time": 1581074254
     },
     "https://en.wikipedia.org/wiki/Ceramic_capacitor": {
       "url": "https://en.wikipedia.org/wiki/Ceramic_capacitor",
-      "time": 1580943736
+      "time": 1581074254
     },
     "https://en.wikipedia.org/wiki/1N4004": {
       "url": "https://en.wikipedia.org/wiki/1N4004",
-      "time": 1580943736
+      "time": 1581074254
     },
     "https://en.wikipedia.org/wiki/Flyback_diode": {
       "url": "https://en.wikipedia.org/wiki/Flyback_diode",
-      "time": 1580943736
+      "time": 1581074254
     },
     "https://en.wikipedia.org/wiki/Transistor": {
       "url": "https://en.wikipedia.org/wiki/Transistor",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://www.seeedstudio.com/Grove-Button.html": {
       "url": "https://www.seeedstudio.com/Grove-Button.html",
-      "time": 1580943738
+      "time": 1581074256
     },
     "https://www3.panasonic.biz/ac/e_download/control/relay/power/catalog/mech_eng_js.pdf?f_cd=300182": {
       "url": "https://www3.panasonic.biz/ac/e_download/control/relay/power/catalog/mech_eng_js.pdf?f_cd=300182",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://www.digikey.com/en/resources/conversion-calculators/conversion-calculator-resistor-color-code-4-band": {
       "url": "https://www.digikey.com/en/resources/conversion-calculators/conversion-calculator-resistor-color-code-4-band",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://en.wikipedia.org/wiki/Hirose_U.FL": {
       "url": "https://en.wikipedia.org/wiki/Hirose_U.FL",
-      "time": 1580943737
+      "time": 1581074255
     },
     "https://en.wikipedia.org/wiki/Thermistor": {
       "url": "https://en.wikipedia.org/wiki/Thermistor",
-      "time": 1580943737
+      "time": 1581074256
     },
     "https://en.wikipedia.org/wiki/Potentiometer": {
       "url": "https://en.wikipedia.org/wiki/Potentiometer",
-      "time": 1580943737
+      "time": 1581074256
     },
     "https://media.digikey.com/pdf/Data%20Sheets/Interlink%20Electronics.PDF/FSR400_Series.pdf": {
       "url": "https://media.digikey.com/pdf/Data%20Sheets/Interlink%20Electronics.PDF/FSR400_Series.pdf",
-      "time": 1580943738
+      "time": 1581074256
     },
     "https://en.wikipedia.org/wiki/H_bridge": {
       "url": "https://en.wikipedia.org/wiki/H_bridge",
-      "time": 1580943738
+      "time": 1581074256
     },
     "https://www.adafruit.com/product/1298": {
       "url": "https://www.adafruit.com/product/1298",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://www.adafruit.com/product/960": {
       "url": "https://www.adafruit.com/product/960",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://www.adafruit.com/product/381": {
       "url": "https://www.adafruit.com/product/381",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://rickkas7.github.io/ble-imu/": {
       "url": "https://rickkas7.github.io/ble-imu/",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://www.oshstencils.com/": {
       "url": "https://www.oshstencils.com/",
-      "time": 1580943739
+      "time": 1581074257
     },
     "https://rickkas7.github.io/ble-livegraph/": {
       "url": "https://rickkas7.github.io/ble-livegraph/",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://rickkas7.github.io/ble-powersource/": {
       "url": "https://rickkas7.github.io/ble-powersource/",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://apps.apple.com/us/app/authy/id494168017": {
       "url": "https://apps.apple.com/us/app/authy/id494168017",
-      "time": 1580943740
+      "time": 1581074256
     },
     "https://www.particle.io/iot-connectivity/": {
       "url": "https://www.particle.io/iot-connectivity/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://tools.ietf.org/html/rfc6749": {
       "url": "https://tools.ietf.org/html/rfc6749",
-      "time": 1580943594
+      "time": 1581074132
     },
     "https://apps.apple.com/us/app/google-authenticator/id388497605": {
       "url": "https://apps.apple.com/us/app/google-authenticator/id388497605",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://www.dfrobot.com/index.php?route=product%2Fproduct&product_id=69": {
       "url": "https://www.dfrobot.com/index.php?route=product%2Fproduct&product_id=69",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://www.dfrobot.com/index.php?route=product%2Fproduct&path=37_111&product_id=65": {
       "url": "https://www.dfrobot.com/index.php?route=product%2Fproduct&path=37_111&product_id=65",
-      "time": 1580943739
+      "time": 1581074257
     },
     "https://build.particle.io/shared_apps/58fe450fb77e5bb68f0018a3": {
       "url": "https://build.particle.io/shared_apps/58fe450fb77e5bb68f0018a3",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://particle.hackster.io/": {
       "url": "https://particle.hackster.io/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://www.particle.io/products/hardware/asset-tracker/": {
       "url": "https://www.particle.io/products/hardware/asset-tracker/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://build.particle.io/shared_apps/5babb9b33242a939e300171a": {
       "url": "https://build.particle.io/shared_apps/5babb9b33242a939e300171a",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://build.particle.io/shared_apps/5babbaa43242a990ac0015b5": {
       "url": "https://build.particle.io/shared_apps/5babbaa43242a990ac0015b5",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://www.dfrobot.com/index.php?route=product%2Fproduct&filter_name=battery&product_id=489": {
       "url": "https://www.dfrobot.com/index.php?route=product%2Fproduct&filter_name=battery&product_id=489",
-      "time": 1580943740
+      "time": 1581074258
     },
     "https://www.particle.io/iot-rules-engine/": {
       "url": "https://www.particle.io/iot-rules-engine/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://build.particle.io/shared_apps/5babbae73242a9571a00172f": {
       "url": "https://build.particle.io/shared_apps/5babbae73242a9571a00172f",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://accounts.google.com/ServiceLogin?passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.firebase.google.com%2F&followup=https%3A%2F%2Fconsole.firebase.google.com%2F": {
       "url": "https://accounts.google.com/ServiceLogin?passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.firebase.google.com%2F&followup=https%3A%2F%2Fconsole.firebase.google.com%2F",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://www.influxdata.com/": {
       "url": "https://www.influxdata.com/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://api.slack.com/messaging/webhooks": {
       "url": "https://api.slack.com/messaging/webhooks",
-      "time": 1580943740
+      "time": 1581074258
     },
     "https://www.influxdata.com/products/influxdb-overview/": {
       "url": "https://www.influxdata.com/products/influxdb-overview/",
-      "time": 1580943740
+      "time": 1581074257
     },
     "https://build.particle.io/shared_apps/5babbb363242a9ea27001621": {
       "url": "https://build.particle.io/shared_apps/5babbb363242a9ea27001621",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://build.particle.io/shared_apps/5babba3d3242a9571a001728": {
       "url": "https://build.particle.io/shared_apps/5babba3d3242a9571a001728",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://www.twilio.com/login?g=%2Fconsole%3F&t=2b1c98334b25c1a785ef15b6556396290e3c704a9b57fc40687cbccd79c46a8c": {
       "url": "https://www.twilio.com/login?g=%2Fconsole%3F&t=2b1c98334b25c1a785ef15b6556396290e3c704a9b57fc40687cbccd79c46a8c",
-      "time": 1580943740
+      "time": 1581074258
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/about-iot-hub": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/about-iot-hub",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-routing?WT.mc_id=7061727469636c65": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-routing?WT.mc_id=7061727469636c65",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging?WT.mc_id=7061727469636c65": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging?WT.mc_id=7061727469636c65",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-get-started-physical": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-get-started-physical",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests": {
       "url": "https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-management-iot-extension-azure-cli-2-0?WT.mc_id=7061727469636c65": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-management-iot-extension-azure-cli-2-0?WT.mc_id=7061727469636c65",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/request": {
       "url": "https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/request",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://cloud.google.com/ai-platform": {
       "url": "https://cloud.google.com/ai-platform",
-      "time": 1580943745
+      "time": 1581074261
     },
     "https://docs.particle.io/air-quality-monitoring-kit/": {
       "url": "https://docs.particle.io/air-quality-monitoring-kit/",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://raw.githubusercontent.com/SeeedDocument/Grove_Dust_Sensor/master/resource/Grove_-_Dust_sensor.pdf": {
       "url": "https://raw.githubusercontent.com/SeeedDocument/Grove_Dust_Sensor/master/resource/Grove_-_Dust_sensor.pdf",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://www.particle.io/for-good/": {
       "url": "https://www.particle.io/for-good/",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://zadig.akeo.ie/": {
       "url": "https://zadig.akeo.ie/",
-      "time": 1580943594
+      "time": 1581074253
     },
     "https://github.com/gnu-mcu-eclipse/eclipse-plugins/releases": {
       "url": "https://github.com/gnu-mcu-eclipse/eclipse-plugins/releases",
-      "time": 1580943746
-    },
-    "http://ww11.swiftalicio.us/2014/11/using-cocoapods-from-swift/": {
-      "url": "http://ww11.swiftalicio.us/2014/11/using-cocoapods-from-swift/",
-      "time": 1580407020
+      "time": 1581074261
     },
     "https://docs.google.com/a/particle.io/forms/d/e/1FAIpQLScvu-08mbw0CFSf9V0Xb2QaFn2pWNLGQy5mZcT0FZ2UnSSBTw/viewform": {
       "url": "https://docs.google.com/a/particle.io/forms/d/e/1FAIpQLScvu-08mbw0CFSf9V0Xb2QaFn2pWNLGQy5mZcT0FZ2UnSSBTw/viewform",
-      "time": 1580943744
+      "time": 1581074260
     },
     "https://codeload.github.com/particle-iot/particle-cloud-sdk-ios/zip/master": {
       "url": "https://codeload.github.com/particle-iot/particle-cloud-sdk-ios/zip/master",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://github.com/ilg-archived/openocd/releases": {
       "url": "https://github.com/ilg-archived/openocd/releases",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://github.com/particle-iot/particle-android/tree/master/cloudsdk": {
       "url": "https://github.com/particle-iot/particle-android/tree/master/cloudsdk",
-      "time": 1580943746
+      "time": 1581074260
     },
     "https://cocoapods.org/": {
       "url": "https://cocoapods.org/",
-      "time": 1580943744
+      "time": 1581074259
     },
     "https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus": {
       "url": "https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus",
-      "time": 1580943746
+      "time": 1581074260
     },
     "https://en.wikipedia.org/wiki/Twos_complement": {
       "url": "https://en.wikipedia.org/wiki/Twos_complement",
-      "time": 1580943746
+      "time": 1581074260
     },
     "https://www.putty.org/": {
       "url": "https://www.putty.org/",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://www.papertrail.com/": {
       "url": "https://www.papertrail.com/",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://github.com/particle-iot/makerkit": {
       "url": "https://github.com/particle-iot/makerkit",
-      "time": 1580943735
-    },
-    "https://github.com/particle-iot/Serial_LCD_Library": {
-      "url": "https://github.com/particle-iot/Serial_LCD_Library",
-      "time": 1580389405
+      "time": 1581074254
     },
     "https://github.com/particle-iot/AssetTracker": {
       "url": "https://github.com/particle-iot/AssetTracker",
-      "time": 1580943735
+      "time": 1581074254
     },
     "https://en.wikipedia.org/wiki/Hello_world_program": {
       "url": "https://en.wikipedia.org/wiki/Hello_world_program",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://build.particle.io/shared_apps/5be2de1e88096abb6e00094f": {
       "url": "https://build.particle.io/shared_apps/5be2de1e88096abb6e00094f",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://build.particle.io/shared_apps/5be2dec088096a588500095e": {
       "url": "https://build.particle.io/shared_apps/5be2dec088096a588500095e",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://build.particle.io/shared_apps/5be2dfca88096afd2a0009c1": {
       "url": "https://build.particle.io/shared_apps/5be2dfca88096afd2a0009c1",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://build.particle.io/shared_apps/5be2df6f88096a97af0008d6": {
       "url": "https://build.particle.io/shared_apps/5be2df6f88096a97af0008d6",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://build.particle.io/shared_apps/5be2df2588096afd2a0009b5": {
       "url": "https://build.particle.io/shared_apps/5be2df2588096afd2a0009b5",
-      "time": 1580943736
+      "time": 1581074255
     },
     "https://mxcl.dev/homebrew/": {
       "url": "https://mxcl.dev/homebrew/",
-      "time": 1580943739
+      "time": 1581074256
     },
     "https://www.analog.com/media/en/technical-documentation/data-sheets/TMP35_36_37.pdf": {
       "url": "https://www.analog.com/media/en/technical-documentation/data-sheets/TMP35_36_37.pdf",
-      "time": 1580943759
+      "time": 1581074262
     },
     "https://www.u-blox.com/en/product-resources/property_file_product_filter/2432": {
       "url": "https://www.u-blox.com/en/product-resources/property_file_product_filter/2432",
-      "time": 1580943761
+      "time": 1581074263
     },
     "https://raw.githubusercontent.com/particle-iot/core/master/Datasheets/MicrochipTech_SST25VF016B-75-4I-S2AF-T.pdf": {
       "url": "https://raw.githubusercontent.com/particle-iot/core/master/Datasheets/MicrochipTech_SST25VF016B-75-4I-S2AF-T.pdf",
-      "time": 1580943759
+      "time": 1581074263
     },
     "https://docs.particle.io/guide/tools-and-features/cli/": {
       "url": "https://docs.particle.io/guide/tools-and-features/cli/",
-      "time": 1580943757
+      "time": 1581074261
     },
     "https://wiki.dfrobot.com/https___www.dfrobot.com_wiki_index.php?title=Arduino_Motor_Shield_%28L298N%29_%28SKU%3ADRI0009%29": {
       "url": "https://wiki.dfrobot.com/https___www.dfrobot.com_wiki_index.php?title=Arduino_Motor_Shield_%28L298N%29_%28SKU%3ADRI0009%29",
-      "time": 1580943759
+      "time": 1581074263
     },
     "https://wiki.dfrobot.com/3PA_Assembly_Guide_%28SKU_ROB0005%29": {
       "url": "https://wiki.dfrobot.com/3PA_Assembly_Guide_%28SKU_ROB0005%29",
-      "time": 1580943759
+      "time": 1581074263
     },
     "https://www.onsemi.com/": {
       "url": "https://www.onsemi.com/",
-      "time": 1580943761
+      "time": 1581074263
     },
     "https://apps.apple.com/us/app/particle-build-photon-electron/id991459054?ls=1": {
       "url": "https://apps.apple.com/us/app/particle-build-photon-electron/id991459054?ls=1",
-      "time": 1580943760
+      "time": 1581074262
     },
     "https://www.particle.io/sales/?utm_campaign=fleet-health-enterprise-contact&utm_source=docs&utm_medium=link": {
       "url": "https://www.particle.io/sales/?utm_campaign=fleet-health-enterprise-contact&utm_source=docs&utm_medium=link",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://www.nuget.org/packages/Particle.SDK": {
       "url": "https://www.nuget.org/packages/Particle.SDK",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://community.particle.io/users/rickkas7/activity": {
       "url": "https://community.particle.io/users/rickkas7/activity",
-      "time": 1580943734
+      "time": 1581074253
     },
     "https://ec.europa.eu/growth/sectors/electrical-engineering/red-directive_en": {
       "url": "https://ec.europa.eu/growth/sectors/electrical-engineering/red-directive_en",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F&followup=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F&followup=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://www.particle.io/resources/iot-revolutionizing-supply-chain-management/": {
       "url": "https://www.particle.io/resources/iot-revolutionizing-supply-chain-management/",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://codeload.github.com/particle-iot/particle-windows-sdk/zip/master": {
       "url": "https://codeload.github.com/particle-iot/particle-windows-sdk/zip/master",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://brew.sh/": {
       "url": "https://brew.sh/",
-      "time": 1580943594
+      "time": 1581074253
     },
     "https://codeload.github.com/particle-iot/particle-windows-devicesetup/zip/master": {
       "url": "https://codeload.github.com/particle-iot/particle-windows-devicesetup/zip/master",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://build.particle.io/shared_apps/5a1d9d7910c40ebfeb0012ea": {
       "url": "https://build.particle.io/shared_apps/5a1d9d7910c40ebfeb0012ea",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://www.nuget.org/packages/Particle.Setup": {
       "url": "https://www.nuget.org/packages/Particle.Setup",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://build.particle.io/shared_apps/5a1d9dea10c40ebfeb0012ee": {
       "url": "https://build.particle.io/shared_apps/5a1d9dea10c40ebfeb0012ee",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://build.particle.io/shared_apps/5a1d9e5310c40e5c02001232": {
       "url": "https://build.particle.io/shared_apps/5a1d9e5310c40e5c02001232",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://hackaday.com/2017/01/03/humidity-sensor-shootout/": {
       "url": "https://hackaday.com/2017/01/03/humidity-sensor-shootout/",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://build.particle.io/shared_apps/5a1d9f2710c40e5dbb001314": {
       "url": "https://build.particle.io/shared_apps/5a1d9f2710c40e5dbb001314",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://build.particle.io/shared_apps/5a1da51910c40e5dbb00139d": {
       "url": "https://build.particle.io/shared_apps/5a1da51910c40e5dbb00139d",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://build.particle.io/shared_apps/5a1d9fa810c40eb719001392": {
       "url": "https://build.particle.io/shared_apps/5a1d9fa810c40eb719001392",
-      "time": 1580943741
+      "time": 1581074258
     },
     "https://www.adafruit.com/product/1120": {
       "url": "https://www.adafruit.com/product/1120",
-      "time": 1580943743
+      "time": 1581074259
     },
     "https://curl.haxx.se/docs/caextract.html": {
       "url": "https://curl.haxx.se/docs/caextract.html",
-      "time": 1580943761
+      "time": 1581074263
     },
     "https://www.adafruit.com/product/879": {
       "url": "https://www.adafruit.com/product/879",
-      "time": 1580943743
+      "time": 1581074258
     },
     "https://www.adafruit.com/product/871": {
       "url": "https://www.adafruit.com/product/871",
-      "time": 1580943743
+      "time": 1581074258
     },
     "https://www.adafruit.com/product/1714": {
       "url": "https://www.adafruit.com/product/1714",
-      "time": 1580943743
+      "time": 1581074259
     },
     "https://www.adafruit.com/product/1604": {
       "url": "https://www.adafruit.com/product/1604",
-      "time": 1580943743
+      "time": 1581074259
     },
     "https://www.adafruit.com/product/2652": {
       "url": "https://www.adafruit.com/product/2652",
-      "time": 1580943743
+      "time": 1581074259
     },
     "https://www.dhl.com/content/dam/downloads/g0/express/shipping/lithium_batteries/lithium_ion_batteries_regulations.pdf": {
       "url": "https://www.dhl.com/content/dam/downloads/g0/express/shipping/lithium_batteries/lithium_ion_batteries_regulations.pdf",
-      "time": 1580943760
+      "time": 1581074264
     },
     "https://www.dhl.com/en/express/shipping/shipping_advice/lithium_batteries.html": {
       "url": "https://www.dhl.com/en/express/shipping/shipping_advice/lithium_batteries.html",
-      "time": 1580943760
+      "time": 1581074264
     },
     "https://www.particle.io/distributors/": {
       "url": "https://www.particle.io/distributors/",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://www.eclipse.org/downloads/packages/": {
       "url": "https://www.eclipse.org/downloads/packages/",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html": {
       "url": "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html",
-      "time": 1580943760
+      "time": 1581074263
     },
     "https://build.particle.io/shared_apps/5c33b28b2872bdbc4300028f": {
       "url": "https://build.particle.io/shared_apps/5c33b28b2872bdbc4300028f",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://build.particle.io/shared_apps/5c349834e1b63bd1fc000e77": {
       "url": "https://build.particle.io/shared_apps/5c349834e1b63bd1fc000e77",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://build.particle.io/shared_apps/5c34bcb6e1b63bd1fc0010bf": {
       "url": "https://build.particle.io/shared_apps/5c34bcb6e1b63bd1fc0010bf",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://build.particle.io/shared_apps/5c34bfcfe1b63be846000fc2": {
       "url": "https://build.particle.io/shared_apps/5c34bfcfe1b63be846000fc2",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://www.adafruit.com/product/159": {
       "url": "https://www.adafruit.com/product/159",
-      "time": 1580943762
+      "time": 1581074264
     },
     "https://www.adafruit.com/product/2717": {
       "url": "https://www.adafruit.com/product/2717",
-      "time": 1580943743
+      "time": 1581074259
     },
     "https://build.particle.io/shared_apps/5c2f372ae71c123a8b00125e": {
       "url": "https://build.particle.io/shared_apps/5c2f372ae71c123a8b00125e",
-      "time": 1580943761
+      "time": 1581074264
     },
     "http://tools.android.com/tech-docs/support-annotations#TOC-Threading-Annotations:-UiThread-WorkerThread-...": {
       "url": "http://tools.android.com/tech-docs/support-annotations#TOC-Threading-Annotations:-UiThread-WorkerThread-...",
-      "time": 1580943761
+      "time": 1581074263
     },
     "https://cylonjs.com/documentation/platforms/particle/": {
       "url": "https://cylonjs.com/documentation/platforms/particle/",
-      "time": 1580943757
+      "time": 1581074261
     },
     "https://build.particle.io/shared_apps/5bfefd038bf964af88000409": {
       "url": "https://build.particle.io/shared_apps/5bfefd038bf964af88000409",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://playground.arduino.cc/Code/BitMath/": {
       "url": "https://playground.arduino.cc/Code/BitMath/",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://build.particle.io/shared_apps/5d7bb4fe1abb3a0016bd4127": {
       "url": "https://build.particle.io/shared_apps/5d7bb4fe1abb3a0016bd4127",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://github.com/harrisonhjones/phpParticle": {
       "url": "https://github.com/harrisonhjones/phpParticle",
-      "time": 1580943757
+      "time": 1581074262
     },
     "https://build.particle.io/shared_apps/5d40aec2279e1e000b9ad57b": {
       "url": "https://build.particle.io/shared_apps/5d40aec2279e1e000b9ad57b",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://github.com/particle-iot/particle-tinker-app-ios": {
       "url": "https://github.com/particle-iot/particle-tinker-app-ios",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://github.com/harrisonhjones/phpParticleDashboard": {
       "url": "https://github.com/harrisonhjones/phpParticleDashboard",
-      "time": 1580943757
+      "time": 1581074261
     },
     "https://www.arduino.cc/reference/en/": {
       "url": "https://www.arduino.cc/reference/en/",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://build.particle.io/shared_apps/5b84477c9a93dd475a0002fa": {
       "url": "https://build.particle.io/shared_apps/5b84477c9a93dd475a0002fa",
-      "time": 1580943761
+      "time": 1581074264
     },
     "https://developer.apple.com/documentation/swift#2984801": {
       "url": "https://developer.apple.com/documentation/swift#2984801",
-      "time": 1580943760
+      "time": 1581074264
     },
     "https://build.particle.io/shared_apps/5b85708299b6c19f4f00008e": {
       "url": "https://build.particle.io/shared_apps/5b85708299b6c19f4f00008e",
-      "time": 1580943762
+      "time": 1581074264
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-dotnet": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-dotnet",
-      "time": 1580943762
+      "time": 1581074264
     },
     "https://support.microsoft.com/en-us/help/827218/how-to-determine-whether-a-computer-is-running-a-32-bit-version-or-64": {
       "url": "https://support.microsoft.com/en-us/help/827218/how-to-determine-whether-a-computer-is-running-a-32-bit-version-or-64",
-      "time": 1580943746
+      "time": 1581074261
     },
     "https://developer.apple.com/documentation/foundation/nsurlsessiondatatask": {
       "url": "https://developer.apple.com/documentation/foundation/nsurlsessiondatatask",
-      "time": 1580943762
+      "time": 1581074265
     },
     "https://help.github.com/en/github/getting-started-with-github/fork-a-repo": {
       "url": "https://help.github.com/en/github/getting-started-with-github/fork-a-repo",
-      "time": 1580943762
+      "time": 1581074264
     },
     "https://azure.microsoft.com/en-us/": {
       "url": "https://azure.microsoft.com/en-us/",
-      "time": 1580943762
+      "time": 1581074265
     },
     "https://store.arduino.cc/usa/arduino-pro-mini": {
       "url": "https://store.arduino.cc/usa/arduino-pro-mini",
-      "time": 1580943762
+      "time": 1581074265
     },
     "https://www.richtek.com/Products/Switching%20Regulators/DC_DC%20StepDown%20Convertor/RT8259?sc_lang=en&specid=RT8259&ActiveTab=Documents": {
       "url": "https://www.richtek.com/Products/Switching%20Regulators/DC_DC%20StepDown%20Convertor/RT8259?sc_lang=en&specid=RT8259&ActiveTab=Documents",
-      "time": 1580943763
+      "time": 1581074266
     },
     "https://apps.apple.com/us/app/spark-core/id760157884": {
       "url": "https://apps.apple.com/us/app/spark-core/id760157884",
       "time": 1580943767
     },
-    "https://github.com/particle-iot/InternetButton": {
-      "url": "https://github.com/particle-iot/InternetButton",
-      "time": 1580406022
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=5d2eb9b6e404025cf07fed3f033d": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=5d2eb9b6e404025cf07fed3f033d",
-      "time": 1580377251
-    },
-    "https://www.digikey.com/product-detail/en/jst-sales-america-inc/B2B-PH-K-S-LF-SN/455-1704-ND/926611": {
-      "url": "https://www.digikey.com/product-detail/en/jst-sales-america-inc/B2B-PH-K-S-LF-SN/455-1704-ND/926611",
-      "time": 1580377263
-    },
     "http://ww17.swiftalicio.us/2014/11/using-cocoapods-from-swift/": {
       "url": "http://ww17.swiftalicio.us/2014/11/using-cocoapods-from-swift/",
-      "time": 1580943745
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T094351Z&X-Amz-Expires=300&X-Amz-Signature=2a9ddfe18c5ff5d8e951076c34b02e9395ab5dabc3e3229b1e8b901e0824cf02&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T094351Z&X-Amz-Expires=300&X-Amz-Signature=2a9ddfe18c5ff5d8e951076c34b02e9395ab5dabc3e3229b1e8b901e0824cf02&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580377439
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T094356Z&X-Amz-Expires=300&X-Amz-Signature=19e57e5a596ae6fbe9fd98b97fd835f8e949f07ea5059ab62b80cbc46a51719f&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T094356Z&X-Amz-Expires=300&X-Amz-Signature=19e57e5a596ae6fbe9fd98b97fd835f8e949f07ea5059ab62b80cbc46a51719f&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580377442
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T094356Z&X-Amz-Expires=300&X-Amz-Signature=1e3b80b9b216646d275b9244cccc47b4fd85400fb73f6429d7109e194582155d&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T094356Z&X-Amz-Expires=300&X-Amz-Signature=1e3b80b9b216646d275b9244cccc47b4fd85400fb73f6429d7109e194582155d&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580377442
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=5e02fc75a881607513cfaa71f1bf": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=5e02fc75a881607513cfaa71f1bf",
-      "time": 1580378119
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T095806Z&X-Amz-Expires=300&X-Amz-Signature=6c3c5cb8bb002a8d78c32786473a7b3b5e44a92e3435aa6ef7a606f883af27aa&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T095806Z&X-Amz-Expires=300&X-Amz-Signature=6c3c5cb8bb002a8d78c32786473a7b3b5e44a92e3435aa6ef7a606f883af27aa&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580378293
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T095810Z&X-Amz-Expires=300&X-Amz-Signature=5f4ffdb5e0034f74ef7d665b89cc18f4e739240ffdf7f2197e55dcb71d4d520e&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T095810Z&X-Amz-Expires=300&X-Amz-Signature=5f4ffdb5e0034f74ef7d665b89cc18f4e739240ffdf7f2197e55dcb71d4d520e&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580378295
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T095810Z&X-Amz-Expires=300&X-Amz-Signature=1e974ddb5e062d809b820a9b9768b1eb8694f684a09e34d4080c7a682201f84c&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T095810Z&X-Amz-Expires=300&X-Amz-Signature=1e974ddb5e062d809b820a9b9768b1eb8694f684a09e34d4080c7a682201f84c&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580378295
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=689a3a7b956a464af93b8315531e": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=689a3a7b956a464af93b8315531e",
-      "time": 1580389225
+      "time": 1581074259
     },
     "http://ww1.swiftalicio.us/2014/11/using-cocoapods-from-swift/": {
       "url": "http://ww1.swiftalicio.us/2014/11/using-cocoapods-from-swift/",
       "time": 1580810232
     },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T130318Z&X-Amz-Expires=300&X-Amz-Signature=a4a44b1a07ef2dc253d345c83580e870bdfb7f83d044e4a2eec2aacbf11cdfbf&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T130318Z&X-Amz-Expires=300&X-Amz-Signature=a4a44b1a07ef2dc253d345c83580e870bdfb7f83d044e4a2eec2aacbf11cdfbf&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580389406
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T130322Z&X-Amz-Expires=300&X-Amz-Signature=637e3502e690df50c47b0b8df12d8ecae28caffa00ec0b7ae73f09a9c4e41373&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T130322Z&X-Amz-Expires=300&X-Amz-Signature=637e3502e690df50c47b0b8df12d8ecae28caffa00ec0b7ae73f09a9c4e41373&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580389407
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T130322Z&X-Amz-Expires=300&X-Amz-Signature=fa68de900f48cbe2860f74834efdcb31e0d9db201dd0d670670f0e12c659982e&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T130322Z&X-Amz-Expires=300&X-Amz-Signature=fa68de900f48cbe2860f74834efdcb31e0d9db201dd0d670670f0e12c659982e&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580389407
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=7815107c8299869ffcd693dd06d7": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=7815107c8299869ffcd693dd06d7",
-      "time": 1580405456
-    },
     "https://github.com/particle-iot/serial_lcd_library": {
       "url": "https://github.com/particle-iot/serial_lcd_library",
-      "time": 1580943735
-    },
-    "https://store.particle.io/products/xenon": {
-      "url": "https://store.particle.io/products/xenon",
-      "time": 1580405637
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T173353Z&X-Amz-Expires=300&X-Amz-Signature=abb1a6ebd98415e969b93ddf88093003940e61f7892497161b31b877f6803317&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T173353Z&X-Amz-Expires=300&X-Amz-Signature=abb1a6ebd98415e969b93ddf88093003940e61f7892497161b31b877f6803317&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580405641
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T173357Z&X-Amz-Expires=300&X-Amz-Signature=fdcc984bff6716bcd3c572ca272232c673aece64cd9836751695208facf43068&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T173357Z&X-Amz-Expires=300&X-Amz-Signature=fdcc984bff6716bcd3c572ca272232c673aece64cd9836751695208facf43068&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580405642
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T173357Z&X-Amz-Expires=300&X-Amz-Signature=ba5e3ac75be125f488b8d650d8771afecaa8b74f9b63964e55d962d5664151f4&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T173357Z&X-Amz-Expires=300&X-Amz-Signature=ba5e3ac75be125f488b8d650d8771afecaa8b74f9b63964e55d962d5664151f4&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580405642
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=7873cc094e31c9ba3db118f99e17": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=7873cc094e31c9ba3db118f99e17",
-      "time": 1580405844
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T174025Z&X-Amz-Expires=300&X-Amz-Signature=07d273a9b1ca00a37d9d5b3911ff135d1be7cc37da117b6e821877fe6cd26487&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T174025Z&X-Amz-Expires=300&X-Amz-Signature=07d273a9b1ca00a37d9d5b3911ff135d1be7cc37da117b6e821877fe6cd26487&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580406032
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T174029Z&X-Amz-Expires=300&X-Amz-Signature=6c253de07fbd9af6eb97ece47d293773accafc2add0aa07be1ddef674a9a4b81&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T174029Z&X-Amz-Expires=300&X-Amz-Signature=6c253de07fbd9af6eb97ece47d293773accafc2add0aa07be1ddef674a9a4b81&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580406033
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T174029Z&X-Amz-Expires=300&X-Amz-Signature=bbdad8c793d5ac7778e39f6e7b317dee3be4f98b68caee22373324b2e31a4d66&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T174029Z&X-Amz-Expires=300&X-Amz-Signature=bbdad8c793d5ac7778e39f6e7b317dee3be4f98b68caee22373324b2e31a4d66&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580406033
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=7968a9947b864b85e95a48d69cde": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=7968a9947b864b85e95a48d69cde",
-      "time": 1580406849
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T175656Z&X-Amz-Expires=300&X-Amz-Signature=978a585a19cd0f2c86ba080972268692001b97ddb7c150a5a71a74dd5e07f603&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T175656Z&X-Amz-Expires=300&X-Amz-Signature=978a585a19cd0f2c86ba080972268692001b97ddb7c150a5a71a74dd5e07f603&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580407023
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T175700Z&X-Amz-Expires=300&X-Amz-Signature=26087513befadbfa411ffcc1d1aabbcadb9232605e9a6dbf6828bc91e41c7cae&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T175700Z&X-Amz-Expires=300&X-Amz-Signature=26087513befadbfa411ffcc1d1aabbcadb9232605e9a6dbf6828bc91e41c7cae&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580407024
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T175700Z&X-Amz-Expires=300&X-Amz-Signature=659172a4e6c70b08263c6d279d864104efe4700af24246cde110bfafb04b570f&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200130%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200130T175700Z&X-Amz-Expires=300&X-Amz-Signature=659172a4e6c70b08263c6d279d864104efe4700af24246cde110bfafb04b570f&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580407024
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=b2f31a3038661188848cfa256180": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=b2f31a3038661188848cfa256180",
-      "time": 1580467185
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200131T104302Z&X-Amz-Expires=300&X-Amz-Signature=763e6acef3813e6737fa02d91ca94dc71cacdefab39b6694af8924a0f17fa5bc&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200131T104302Z&X-Amz-Expires=300&X-Amz-Signature=763e6acef3813e6737fa02d91ca94dc71cacdefab39b6694af8924a0f17fa5bc&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580467389
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200131T104306Z&X-Amz-Expires=300&X-Amz-Signature=35904e14dd2d89effbbf8ef8f8ec271a21adb0af0aff5ac595eb04050e94736d&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200131T104306Z&X-Amz-Expires=300&X-Amz-Signature=35904e14dd2d89effbbf8ef8f8ec271a21adb0af0aff5ac595eb04050e94736d&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580467390
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200131T104306Z&X-Amz-Expires=300&X-Amz-Signature=47589ac1991a7a32d973b5a74933c0605175748e04766ae7b996b6b1d77a83ac&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200131%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200131T104306Z&X-Amz-Expires=300&X-Amz-Signature=47589ac1991a7a32d973b5a74933c0605175748e04766ae7b996b6b1d77a83ac&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1580467390
+      "time": 1581074254
     },
     "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=caab93fe069223da68c90ea71659": {
       "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=caab93fe069223da68c90ea71659",
@@ -3582,16 +3442,116 @@
     },
     "https://www.postman.com/": {
       "url": "https://www.postman.com/",
-      "time": 1580943761
+      "time": 1581074264
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF1823V/P182KHCT-ND/198208": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF1823V/P182KHCT-ND/198208",
+      "time": 1581073774
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF1583V/P158KHCT-ND/198182": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF1583V/P158KHCT-ND/198182",
+      "time": 1581073774
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-PB3D1001V/P20283CT-ND/6214538": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-PB3D1001V/P20283CT-ND/6214538",
+      "time": 1581073774
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF8063V/P806KHCT-ND/198523": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF8063V/P806KHCT-ND/198523",
+      "time": 1581073775
+    },
+    "https://www.digikey.com/product-detail/en/bourns-inc/CVH252009-4R7M/CVH252009-4R7MCT-ND/3440080": {
+      "url": "https://www.digikey.com/product-detail/en/bourns-inc/CVH252009-4R7M/CVH252009-4R7MCT-ND/3440080",
+      "time": 1581073775
+    },
+    "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM219R61A226MEA0D/490-9951-1-ND/5026414": {
+      "url": "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM219R61A226MEA0D/490-9951-1-ND/5026414",
+      "time": 1581073775
+    },
+    "https://www.digikey.com/product-detail/en/PRPC040SAAN-RC/S1011EC-40-ND/2775214": {
+      "url": "https://www.digikey.com/product-detail/en/PRPC040SAAN-RC/S1011EC-40-ND/2775214",
+      "time": 1581073775
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-PA3J103V/P10KBZCT-ND/5036237": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-PA3J103V/P10KBZCT-ND/5036237",
+      "time": 1581073775
+    },
+    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=f572d44ea08f18eeaf2cdb7a01d5": {
+      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=f572d44ea08f18eeaf2cdb7a01d5",
+      "time": 1581073785
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF68R0V/P68.0HCT-ND/1746805": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3EKF68R0V/P68.0HCT-ND/1746805",
+      "time": 1581073799
+    },
+    "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3GEYJ101V/P100GCT-ND/134714": {
+      "url": "https://www.digikey.com/product-detail/en/panasonic-electronic-components/ERJ-3GEYJ101V/P100GCT-ND/134714",
+      "time": 1581073799
+    },
+    "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM188R71C104KA01D/490-1532-1-ND/587771": {
+      "url": "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM188R71C104KA01D/490-1532-1-ND/587771",
+      "time": 1581073799
+    },
+    "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM188R60J475KE19J/490-6407-1-ND/3845604": {
+      "url": "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM188R60J475KE19J/490-6407-1-ND/3845604",
+      "time": 1581073799
+    },
+    "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM21BR61C106KE15L/490-3886-1-ND/965928": {
+      "url": "https://www.digikey.com/product-detail/en/murata-electronics-north-america/GRM21BR61C106KE15L/490-3886-1-ND/965928",
+      "time": 1581073799
+    },
+    "https://www.digikey.com/product-detail/en/c-k/PTS645SH50SMTR92-LFS/CKN9085CT-ND/1146817": {
+      "url": "https://www.digikey.com/product-detail/en/c-k/PTS645SH50SMTR92-LFS/CKN9085CT-ND/1146817",
+      "time": 1581073800
+    },
+    "https://store.particle.io/products/xenon": {
+      "url": "https://store.particle.io/products/xenon",
+      "time": 1581073952
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111227Z&X-Amz-Expires=300&X-Amz-Signature=75af055b52a386810473f1a7c3895d28dd8a522a05e269c169adac5b22964675&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111227Z&X-Amz-Expires=300&X-Amz-Signature=75af055b52a386810473f1a7c3895d28dd8a522a05e269c169adac5b22964675&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
+      "time": 1581073954
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111231Z&X-Amz-Expires=300&X-Amz-Signature=8b3d6e4e0806ad21e2474a0525fcc56400ba80ab2779a42dd8bc51c61fbdcfaf&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111231Z&X-Amz-Expires=300&X-Amz-Signature=8b3d6e4e0806ad21e2474a0525fcc56400ba80ab2779a42dd8bc51c61fbdcfaf&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
+      "time": 1581073956
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111231Z&X-Amz-Expires=300&X-Amz-Signature=47e15af7775215ccce61a6ba9ae784c4326eecf95abef3cbbc1b1918204790ef&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111231Z&X-Amz-Expires=300&X-Amz-Signature=47e15af7775215ccce61a6ba9ae784c4326eecf95abef3cbbc1b1918204790ef&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
+      "time": 1581073956
+    },
+    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=f5c226542cd2fba8198d53be80a4": {
+      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=f5c226542cd2fba8198d53be80a4",
+      "time": 1581074107
+    },
+    "https://www.digikey.com/product-detail/en/jst-sales-america-inc/B2B-PH-K-S-LF-SN/455-1704-ND/926611": {
+      "url": "https://www.digikey.com/product-detail/en/jst-sales-america-inc/B2B-PH-K-S-LF-SN/455-1704-ND/926611",
+      "time": 1581074121
+    },
+    "https://www.digikey.com/product-detail/en/microchip-technology/MCP1825ST-3302E-DB/MCP1825ST-3302E-DBCT-ND/5013522": {
+      "url": "https://www.digikey.com/product-detail/en/microchip-technology/MCP1825ST-3302E-DB/MCP1825ST-3302E-DBCT-ND/5013522",
+      "time": 1581074121
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111736Z&X-Amz-Expires=300&X-Amz-Signature=3adf9cca4fa80f0606be679b12138934da41f0882f6cfd2623f788e8e6c273ec&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111736Z&X-Amz-Expires=300&X-Amz-Signature=3adf9cca4fa80f0606be679b12138934da41f0882f6cfd2623f788e8e6c273ec&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
+      "time": 1581074263
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111740Z&X-Amz-Expires=300&X-Amz-Signature=1d013af688e135bf78130184aaade0335a29f0b8cf0685869a19960418a8afb0&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111740Z&X-Amz-Expires=300&X-Amz-Signature=1d013af688e135bf78130184aaade0335a29f0b8cf0685869a19960418a8afb0&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
+      "time": 1581074264
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111740Z&X-Amz-Expires=300&X-Amz-Signature=4eb51370839142cc8d158c23e94a44e9106b5c4d7fbf4697fa9b4e436f49fcd4&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200207%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200207T111740Z&X-Amz-Expires=300&X-Amz-Signature=4eb51370839142cc8d158c23e94a44e9106b5c4d7fbf4697fa9b4e436f49fcd4&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
+      "time": 1581074264
     }
   },
   "stats": {
-    "kept": 262,
-    "removed": 672,
-    "inCache": 6581,
-    "fetchAttempt": 3213,
-    "crawled": 252,
+    "kept": 880,
+    "removed": 0,
+    "inCache": 8545,
+    "fetchAttempt": 2563,
+    "crawled": 249,
     "errors": 0
   },
-  "success": 1580943767
+  "success": 1581074266
 }

--- a/config/redirects.json
+++ b/config/redirects.json
@@ -182,6 +182,7 @@
     "/reference/api": "/reference/device-cloud/api",
     "/reference/cli": "/reference/developer-tools/cli",
     "/reference/community": "/community/community",
+    "/reference/device-os/firmware/core":"/reference/discontinued/firmware-core",
     "/reference/device-os/firmware/raspberry-pi": "/raspberry-pi",
     "/reference/discontinued/particle-agent": "/raspberry-pi",
     "/reference/firmware": "/reference/device-os/firmware",

--- a/src/content/reference/discontinued/firmware-core.md
+++ b/src/content/reference/discontinued/firmware-core.md
@@ -1,19 +1,15 @@
 ---
-title: Device OS API
+title: Device OS API - Core
 layout: reference.hbs
 columns: three
-devices: [boron,photon,electron,xenon,argon]
+setdevice: core
 order: 20
 ---
 
 Device OS API - {{device}}
 ==========
 
-You are viewing the Device OS API documentation for the **{{device}}**. To view the documentation for other 
-devices, use the blue device selector below the Particle logo on the left side of the page.
-
-The Device OS API for discontinued devices such as the [Spark Core](/reference/discontinued/firmware-core/) 
-can be found in the Discontinued section.
+**This section is the Device OS API for the Spark Core only. The last version of Device OS that can be used with the Spark Core is 1.4.4.**
 
 ## Cloud Functions
 
@@ -59,6 +55,7 @@ void setup() {
 | Function Argument | 63 | 622 | |
 | Publish/Subscribe Event Name | 64 | 64 | |
 | Publish/Subscribe Event Data | 255 | 622 |  |
+**Note:** Spark Core limits remain as-is prior to 0.8.0
 
 ### Particle.variable()
 
@@ -98,7 +95,7 @@ void loop()
 }
 ```
 
-Up to 20 cloud variables may be registered and each variable name is limited to a maximum of 12 characters (_prior to 0.8.0_), 64 characters (_since 0.8.0_). 
+Up to 20 cloud variables may be registered and each variable name is limited to a maximum of 12 characters (_prior to 0.8.0_), 64 characters (_since 0.8.0_).  The Spark Core remains limited to 12 characters.
 
 **Note:** Only use letters, numbers, underscores and dashes in variable names. Spaces and special characters may be escaped by different tools and libraries causing unexpected results.
 
@@ -168,14 +165,14 @@ int funcName(String extra) {
 }
 ```
 
-Up to 15 cloud functions may be registered and each function name is limited to a maximum of 12 characters (_prior to 0.8.0_), 64 characters (_since 0.8.0_). 
+Up to 15 cloud functions may be registered and each function name is limited to a maximum of 12 characters (_prior to 0.8.0_), 64 characters (_since 0.8.0_). The Spark Core remains limited to 12 characters.
 
 **Note:** Only use letters, numbers, underscores and dashes in function names. Spaces and special characters may be escaped by different tools and libraries causing unexpected results.
 A function callback procedure needs to return as quickly as possible otherwise the cloud call will timeout.
 
 In order to register a cloud  function, the user provides the `funcKey`, which is the string name used to make a POST request and a `funcName`, which is the actual name of the function that gets called in your app. The cloud function has to return an integer; `-1` is commonly used for a failed function call.
 
-A cloud function is set up to take one argument of the [String](#string-class) datatype. This argument length is limited to a max of 63 characters (_prior to 0.8.0_), 622 characters (_since 0.8.0_). The String is UTF-8 encoded.
+A cloud function is set up to take one argument of the [String](#string-class) datatype. This argument length is limited to a max of 63 characters (_prior to 0.8.0_), 622 characters (_since 0.8.0_). The Spark Core remains limited to 63 characters. The String is UTF-8 encoded.
 
 When using [SYSTEM_THREAD(ENABLED)](/reference/device-os/firmware#system-thread) you must be careful of when you register your functions. At the beginning of setup(), before you do any lengthy operations, delays, or things like waiting for a key press, is best. The reason is that variable and function registrations are only sent up once, about 30 seconds after connecting to the cloud. Calling Particle.function after the registration information has been sent does not re-send the request and the function will not work.
 
@@ -277,7 +274,7 @@ Cloud events have the following properties:
 * PUBLIC/PRIVATE (prior to 0.8.0 default PUBLIC - thereafter it's a required parameter and PRIVATE is advisable)
 * ttl (time to live, 0–16777215 seconds, default 60)
   !! **NOTE:** TTL is not implemented, hence the ttl value has no effect. Events must be caught immediately; once sent they will be gone *immediately*.
-* optional data (up to 255 characters (_prior to 0.8.0_), 622 characters (_since 0.8.0_)).
+* optional data (up to 255 characters (_prior to 0.8.0_), 622 characters (_since 0.8.0_)).  The Spark Core remains limited to 255 characters.
 
 Anyone may subscribe to public events; think of them like tweets.
 Only the owner of the device will be able to subscribe to private events.
@@ -448,6 +445,16 @@ Unlike functions and variables, you typically call Particle.publish from loop() 
 
 {{since when="1.2.0"}}
 
+{{#if core}}
+```cpp
+// SYNTAX
+
+system_error_t Particle.publishVitals(system_tick_t period_s = particle::NOW)
+
+Particle.publishVitals();  // Publish vitals immmediately
+Particle.publishVitals(<any value>);  // Publish vitals immediately
+```
+{{/if}}{{#unless core}}
 ```cpp
 // SYNTAX
 
@@ -458,6 +465,7 @@ Particle.publishVitals(particle::NOW);  // Publish vitals immediately
 Particle.publishVitals(5);  // Publish vitals every 5 seconds, indefinitely
 Particle.publishVitals(0);  // Publish immediately and cancel periodic publishing
 ```
+{{/unless}} {{!-- unless core --}}
 
 Publish vitals information
 
@@ -465,11 +473,15 @@ Provides a mechanism to control the interval at which system diagnostic messages
 
 **Argument(s):**
 
+{{#if core}}
+_none._
+{{/if}}{{#unless core}}
 * `period_s` The period _(in seconds)_ at which vitals messages are to be sent to the cloud (default value: `particle::NOW`)
 
   * `particle::NOW` - A special value used to send vitals immediately
   * `0` - Publish a final message and disable periodic publishing
   * `s` - Publish an initial message and subsequent messages every `s` seconds thereafter
+{{/unless}} {{!-- unless core --}}
 
 **Returns:**
 
@@ -497,6 +509,7 @@ loop () {
 }
 ```
 
+{{#unless core}}
 ```cpp
 // EXAMPLE - Publish vitals periodically, indefinitely
 
@@ -524,7 +537,7 @@ loop () {
   }
 }
 ```
-
+{{/unless}} {{!-- unless core --}}
 
 >_**NOTE:** Diagnostic messages can be viewed in the [Console](https://console.particle.io/devices). Select the device in question, and view the messages under the "EVENTS" tab._
 
@@ -732,7 +745,7 @@ While this function will disconnect from the Cloud, it will keep the connection 
 **NOTE:* When the device is disconnected, many features are not possible, including over-the-air updates, reading Particle.variables, and calling Particle.functions.
 
 *If you disconnect from the Cloud, you will NOT BE ABLE to flash new firmware over the air. 
-Safe mode can be used to reconnect to the cloud.*
+{{#if core}}A factory reset should resolve the issue.{{/if}}{{#unless core}}Safe mode can be used to reconnect to the cloud.{{/unless}}*
 
 ### Particle.connected()
 
@@ -1559,7 +1572,7 @@ void loop() {
 ### listen()
 
 This will enter or exit listening mode, which opens a Serial connection to get Wi-Fi credentials over USB, and also listens for credentials over
-Soft AP on the Photon or BLE on the Argon.
+{{#if core}}Smart Config{{/if}}{{#if photon}}Soft AP{{/if}}.
 
 ```cpp
 // SYNTAX - enter listening mode
@@ -1586,6 +1599,10 @@ WiFi.listen(false);
 WiFi.listening();
 ```
 
+{{#unless has-threading}}
+Because listening mode blocks your application code on the {{device}}, this command is not useful on the Core.
+It will always return `false`.
+{{/unless}} {{!-- has-threading --}}
 {{#if has-threading}}
 This command is only useful in connection with `SYSTEM_THREAD(ENABLED)`, otherwise it will always return `false`, because listening mode blocks application code.
 With a dedicated system thread though `WiFi.listening()` will return `true` once `WiFi.listen()` has been called
@@ -1605,6 +1622,12 @@ WiFi.setListenTimeout(seconds);
 
 `WiFi.setListenTimeout(seconds)` is used to set a timeout value for Listening Mode.  Values are specified in `seconds`, and 0 disables the timeout.  By default, Wi-Fi devices do not have any timeout set (seconds=0).  As long as interrupts are enabled, a timer is started and running while the device is in listening mode (WiFi.listening()==true).  After the timer expires, listening mode will be exited automatically.  If WiFi.setListenTimeout() is called while the timer is currently in progress, the timer will be updated and restarted with the new value (e.g. updating from 10 seconds to 30 seconds, or 10 seconds to 0 seconds (disabled)).  {{#if has-threading}}**Note:** Enabling multi-threaded mode with SYSTEM_THREAD(ENABLED) will allow user code to update the timeout value while Listening Mode is active.{{/if}} 
 
+{{#if core}}
+Because listening mode blocks your application code on the Core, this command should be avoided in loop().  It can be used with the STARTUP() macro or in setup() on the Core.
+It will always return `false`.
+
+This setting is not persistent in memory if the {{device}} is rebooted.
+{{/if}}
 
 ```cpp
 // EXAMPLE
@@ -1648,6 +1671,7 @@ void setup() {
 Allows the application to set credentials for the Wi-Fi network from within the code. These credentials will be added to the device's memory, and the device will automatically attempt to connect to this network in the future.
 
 Your device can remember more than one set of credentials:
+- Core: remembers the 7 most recently set credentials
 - Photon: remembers the 5 most recently set credentials.
 - Argon: remembers the 10 most recently set credentials.
 
@@ -1770,6 +1794,11 @@ Lists the Wi-Fi networks with credentials stored on the device. Returns the numb
 
 Note that this returns details about the Wi-Fi networks, but not the actual password.
 
+{{#if core}}
+
+*Core: always returns 0 since Wi-Fi credentials cannot be read back from the CC3000 Wi-Fi module.*
+
+{{else}}
 
 ```cpp
 // EXAMPLE
@@ -1787,6 +1816,7 @@ for (int i = 0; i < found; i++) {
 }
 ```
 
+{{/if}}
 
 ### clearCredentials()
 
@@ -1833,6 +1863,9 @@ void setup() {
 ```cpp
 // EXAMPLE USAGE
 
+// Only for Spark Core using firmware < 0.4.0
+// Mac address is in the reversed order and
+// is fixed from v0.4.0 onwards
 
 byte mac[6];
 
@@ -3953,12 +3986,14 @@ void loop()
 ```
 
 {{#if has-stm32}}
+{{#if core}}- On the Core, this function works on pins D0, D1, A0, A1, A4, A5, A6, A7, RX and TX.{{/if}}
 - On the Photon, P1 and Electron, this function works on pins D0, D1, D2, D3, A4, A5, WKP, RX and TX with a caveat: PWM timer peripheral is duplicated on two pins (A5/D2) and (A4/D3) for 7 total independent PWM outputs. For example: PWM may be used on A5 while D2 is used as a GPIO, or D2 as a PWM while A5 is used as an analog input. However A5 and D2 cannot be used as independently controlled PWM outputs at the same time.
 - Additionally on the Electron, this function works on pins B0, B1, B2, B3, C4, C5.
 - Additionally on the P1, this function works on pins P1S0, P1S1, P1S6 (note: for P1S6, the WiFi Powersave Clock should be disabled for complete control of this pin. {{#if has-backup-ram}}See [System Features](#system-features)).{{/if}}
 
 The PWM frequency must be the same for pins in the same timer group.
 
+{{#if core}}- On the Core, the timer groups are D0/D1, A0/A1/RX/TX, A4/A5/A6/A7.{{/if}}
 - On the Photon, the timer groups are D0/D1, D2/D3/A4/A5, WKP, RX/TX.
 - On the P1, the timer groups are D0/D1, D2/D3/A4/A5/P1S0/P1S1, WKP, RX/TX/P1S6.
 - On the Electron, the timer groups are D0/D1/C4/C5, D2/D3/A4/A5/B2/B3, WKP, RX/TX, B0/B1.
@@ -4119,6 +4154,19 @@ void loop()
 ### setADCSampleTime()
 
 The function `setADCSampleTime(duration)` is used to change the default sample time for `analogRead()`.
+
+{{#if core}}
+On the Core, this parameter can be one of the following values (ADC clock = 18MHz or 55.6ns per cycle):
+
+ * ADC_SampleTime_1Cycles5: Sample time equal to 1.5 cycles, 83ns
+ * ADC_SampleTime_7Cycles5: Sample time equal to 7.5 cycles, 417ns
+ * ADC_SampleTime_13Cycles5: Sample time equal to 13.5 cycles, 750ns
+ * ADC_SampleTime_28Cycles5: Sample time equal to 28.5 cycles, 1.58us
+ * ADC_SampleTime_41Cycles5: Sample time equal to 41.5 cycles, 2.31us
+ * ADC_SampleTime_55Cycles5: Sample time equal to 55.5 cycles, 3.08us
+ * ADC_SampleTime_71Cycles5: Sample time equal to 71.5 cycles, 3.97us
+ * ADC_SampleTime_239Cycles5: Sample time equal to 239.5 cycles, 13.3us
+{{/if}}
 
  On the Photon and Electron, this parameter can be one of the following values (ADC clock = 30MHz or 33.3ns per cycle):
 
@@ -4282,6 +4330,9 @@ void loop()
 
 Generates a square wave of the specified frequency and duration (and 50% duty cycle) on a timer channel pin which supports PWM. Use of the tone() function will interfere with PWM output on the selected pin. tone() is generally used to make sounds or music on speakers or piezo buzzers.
 
+{{#if core}}
+- On the Core, this function works on pins D0, D1, A0, A1, A4, A5, A6, A7, RX and TX.
+{{/if}}
 
 {{#if has-stm32}}
 - On the Photon, P1 and Electron, this function works on pins D0, D1, D2, D3, A4, A5, WKP, RX and TX with a caveat: Tone timer peripheral is duplicated on two pins (A5/D2) and (A4/D3) for 7 total independent Tone outputs. For example: Tone may be used on A5 while D2 is used as a GPIO, or D2 for Tone while A5 is used as an analog input. However A5 and D2 cannot be used as independent Tone outputs at the same time.
@@ -4573,7 +4624,7 @@ loop() {
 
 Reads a pulse (either HIGH or LOW) on a pin. For example, if value is HIGH, pulseIn() waits for the pin to go HIGH, starts timing, then waits for the pin to go LOW and stops timing. Returns the length of the pulse in microseconds or 0 if no complete pulse was received within the timeout.
 
-The timing of this function is based on an internal hardware counter derived from the system tick clock.  Resolution is 1/120MHz for Photon/P1/Electron). Works on pulses from 10 microseconds to 3 seconds in length. Please note that if the pin is already reading the desired `value` when the function is called, it will wait for the pin to be the opposite state of the desired `value`, and then finally measure the duration of the desired `value`. This routine is blocking and does not use interrupts.  The `pulseIn()` routine will time out and return 0 after 3 seconds.
+The timing of this function is based on an internal hardware counter derived from the system tick clock.  Resolution is 1/Fosc (1/72MHz for Core, 1/120MHz for Photon/P1/Electron). Works on pulses from 10 microseconds to 3 seconds in length. Please note that if the pin is already reading the desired `value` when the function is called, it will wait for the pin to be the opposite state of the desired `value`, and then finally measure the duration of the desired `value`. This routine is blocking and does not use interrupts.  The `pulseIn()` routine will time out and return 0 after 3 seconds.
 
 ```cpp
 // SYNTAX
@@ -4921,6 +4972,10 @@ Hardware flow control for Serial1 is optionally available on pins D3(CTS) and D2
 
 {{#if has-serial2}}
 
+{{#if core}}
+`Serial2:` This channel is optionally available via the device's D1(TX) and D0(RX) pins.
+{{/if}}
+
 {{#if photon}}
 `Serial2:` This channel is optionally available via pins 28/29 (RGB LED Blue/Green). These pins are accessible via the pads on the bottom of the PCB [See PCB Land Pattern](/datasheets/wi-fi/photon-datasheet/#recommended-pcb-land-pattern-photon-without-headers-). The Blue and Green current limiting resistors should be removed.
 
@@ -4948,7 +5003,7 @@ To use Serial2, add `#include "Serial2/Serial2.h"` near the top of your app's ma
 `Serial5:` This channel is optionally available via the Electron's C1(TX) and C0(RX) pins. To use Serial5, add `#include "Serial5/Serial5.h"` near the top of your app's main code file.
 {{/if}}
 
-To use the Serial1{{#if has-serial2}} or Serial2{{/if}} pins to communicate with your personal computer, you will need an additional USB-to-serial adapter. To use them to communicate with an external TTL serial device, connect the TX pin to your device's RX pin, the RX to your device's TX pin, and ground.
+To use the Serial1{{#if has-serial2}} or Serial2{{/if}} pins to communicate with your personal computer, you will need an additional USB-to-serial adapter. To use them to communicate with an external TTL serial device, connect the TX pin to your device's RX pin, the RX to your device's TX pin, and the ground of your Core to your device's ground.
 
 ```cpp
 // EXAMPLE USAGE
@@ -5041,7 +5096,7 @@ Serial1.begin(9600, SERIAL_DATA_BITS_8 | SERIAL_STOP_BITS_1_5 | SERIAL_PARITY_EV
 
 {{#if has-serial2}}
 #include "Serial2/Serial2.h"
-Serial2.begin(speed);         // RGB-LED green(TX) and blue (RX) pins
+Serial2.begin(speed);         {{#if core}}// D1(TX) and D0(RX) pins{{else}}// RGB-LED green(TX) and blue (RX) pins{{/if}}
 Serial2.begin(speed, config); //  "
 
 Serial2.begin(9600);         // via RGB Green (TX) and Blue (RX) LED pins
@@ -5062,6 +5117,10 @@ Serial5.begin(speed, config); //  "
 Parameters:
 - `speed`: parameter that specifies the baud rate *(long)* _(optional for `Serial` {{#if has-usb-serial1}}and `USBSerial1`{{/if}})_ 
 - `config`: parameter that specifies the number of data bits used, parity and stop bits *(long)* _(not used with `Serial` {{#if has-usb-serial1}}and `USBSerial1`{{/if}})_
+
+{{#if core}}
+Hardware serial port baud rates are: 600, 1200, 2400, 4800, 9600, 19200, 38400, 57600, and 115200 on the {{device}}.
+{{/if}}
 
 {{#if has-stm32f2}}
 Hardware serial port baud rates are: 1200, 2400, 4800, 9600, 19200, 38400, 57600, 115200, and 230400 on the {{device}}.
@@ -5148,6 +5207,10 @@ Other options, including odd parity, and 7 and 9 bit modes, are not available on
 {{/if}} {{!-- has-nrf52 --}}
 
 
+{{#if core}}
+Hardware flow control, available only on Serial1 (`CTS` - `A0`, `RTS` - `A1`):
+{{/if}}
+
 {{#if has-stm32f2}} {{!-- photon and electron --}}
 Hardware flow control, available only on Serial2 (`CTS` - `A7`, `RTS` - `RGBR` ):
 {{/if}}
@@ -5204,10 +5267,12 @@ Disables serial channel.
 
 When used with hardware serial channels (Serial1, Serial2{{#if electron}}, Serial4, Serial5{{/if}}), disables serial communication, allowing channel's RX and TX pins to be used for general input and output. To re-enable serial communication, call `SerialX.begin()`.
 
+{{#unless core}}
 
 {{since when="0.6.0"}}
 
 When used with USB serial channels (`Serial`{{#if has-usb-serial1}} or `USBSerial1`{{/if}}), `end()` will cause the device to quickly disconnect from Host and connect back without the selected serial channel.
+{{/unless}}
 
 ```cpp
 // SYNTAX
@@ -5644,6 +5709,8 @@ _Since 0.5.3 Available on `Serial`._
 _Since 0.6.0 Available on `Serial`{{#if has-usb-serial1}} and `USBSerial1`{{/if}}._
 
 Used to check if host has serial port (virtual COM port) open.
+
+{{#if core}}***NOTE:*** This function always returns `true` on {{device}}.{{/if}}
 
 Returns:
 - `true` when Host has virtual COM port open.
@@ -6234,6 +6301,9 @@ This library allows you to communicate with SPI devices, with the {{device}} as 
 {{#if has-stm32}}_Since 0.5.0_ {{/if}}The {{device}} can function as a SPI slave.
 {{/if}}
 
+{{#if core}}
+![SPI](/assets/images/core-pin-spi.jpg)
+{{/if}}
 
 {{#if has-embedded}}
 
@@ -6319,6 +6389,9 @@ Where, the parameter `ss` is the `SPI` device slave-select pin to initialize.  I
 - Argon, Boron, Xenon: `A5 (D14)`
 - B Series SoM: `D8`
 - Photon, P1, Electron, and E Series: `A2`
+{{#if core}}
+- Gen 1 (Core): `A2`
+{{/if}} {{!-- core --}}
 {{#if has-multiple-spi}}
 For `SPI1`, the default `ss` pin is `D5`.
 {{#if electron}}
@@ -6357,6 +6430,9 @@ Parameters:
 - Argon, Boron, Xenon: `A5 (D14)`
 - B Series SoM: `D8`
 - Photon, P1, Electron, and E Series: `A2`
+{{#if core}}
+- Gen 1 (Core): `A2`
+{{/if}}
 {{#if has-multiple-spi}}
 For `SPI1`, the default `ss` pin is `D5`.
 {{#if electron}}
@@ -6479,6 +6555,9 @@ SPI.setClockDivider(SPI_CLK_DIV4);
 ```
 
 The default clock divider reference is the system clock.
+{{#if core}}
+On the Core, this is 72 MHz.
+{{else}}
 
 {{#if has-stm32}}
 On the Photon and Electron, the system clock speeds are:
@@ -6488,6 +6567,7 @@ On the Photon and Electron, the system clock speeds are:
 {{#if has-nrf52}}
 On Gen 3 devices (Argon, Boron, Xenon), system clock speed is 64 MHz.
 {{/if}} {{!-- has-nrf52 --}}
+{{/if}} {{!-- else core --}}
 
 
 
@@ -6518,13 +6598,17 @@ Where the parameter, `divider` can be:
 
 The clock reference varies depending on the device.
 
+{{#if core}}
+On the Core, the clock reference is 72 MHz.
+{{else}}
+
 {{#if has-stm32}}
 On the Photon and Electron, the clock reference is 120 MHz.
 {{/if}}
 {{#if has-nrf52}}
 On Gen 3 devices (Argon, Boron, Xenon), the clock reference is 64 MHz.
 {{/if}} {{!-- has-nrf52 --}}
-
+{{/if}} {{!-- else core --}}
 
 
 
@@ -6565,7 +6649,7 @@ SPI2.transfer(val);
 ```
 Where the parameter `val`, can is the byte to send out over the SPI bus.
 
-
+{{#unless core}}
 ### transfer(void\*, void\*, size_t, std::function)
 
 For transferring a large number of bytes, this form of transfer() uses DMA to speed up SPI data transfer and at the same time allows you to run code in parallel to the data transmission. The function initializes, configures and enables the DMA peripheral’s channel and stream for the selected SPI peripheral for both outgoing and incoming data and initiates the data transfer. If a user callback function is passed then it will be called after completion of the DMA transfer. This results in asynchronous filling of RX buffer after which the DMA transfer is disabled till the transfer function is called again. If NULL is passed as a callback then the result is synchronous i.e. the function will only return once the DMA transfer is complete.
@@ -6738,6 +6822,7 @@ SPI.available();
 
 Returns the number of bytes available.
 
+{{/unless}} {{!-- core --}}
 
 {{#if has-spi-settings}}
 ### SPISettings
@@ -6805,6 +6890,9 @@ Returns: Negative integer in case of an error.
 
 Releases the SPI peripheral.
 
+{{#if core}}
+**NOTE:** This function does nothing on {{device}}.
+{{/if}} {{!-- core --}}
 
 {{#if has-threading}}
 This function releases the SPI peripheral lock, allowing other threads to use it. See [Synchronizing Access to Shared System Resources](#synchronizing-access-to-shared-system-resources) section for additional information on shared resource locks.
@@ -6834,13 +6922,16 @@ Wire (I2C)
 ---
 (inherits from [`Stream`](#stream-class))
 
+{{#if core}}
+![I2C](/assets/images/core-pin-i2c.jpg)
+{{/if}}
 
 This library allows you to communicate with I2C / TWI (Two Wire Interface) devices.
 
 {{#if has-embedded}}
 
 {{#if has-stm32}}
-On the Photon/Electron, D0 is the Serial Data Line (SDA) and D1 is the Serial Clock (SCL). {{#if electron}}Additionally on the Electron, there is an alternate pin location for the I2C interface: C4 is the Serial Data Line (SDA) and C5 is the Serial Clock (SCL).{{/if}} Both SCL and SDA pins are open-drain outputs that only pull LOW and typically operate with 3.3V logic, but are tolerant to 5V. Connect a pull-up resistor(1.5k to 10k) on the SDA line to 3V3. Connect a pull-up resistor(1.5k to 10k) on the SCL line to 3V3.  If you are using a breakout board with an I2C peripheral, check to see if it already incorporates pull-up resistors.
+On the Core/Photon/Electron, D0 is the Serial Data Line (SDA) and D1 is the Serial Clock (SCL). {{#if electron}}Additionally on the Electron, there is an alternate pin location for the I2C interface: C4 is the Serial Data Line (SDA) and C5 is the Serial Clock (SCL).{{/if}} Both SCL and SDA pins are open-drain outputs that only pull LOW and typically operate with 3.3V logic, but are tolerant to 5V. Connect a pull-up resistor(1.5k to 10k) on the SDA line to 3V3. Connect a pull-up resistor(1.5k to 10k) on the SCL line to 3V3.  If you are using a breakout board with an I2C peripheral, check to see if it already incorporates pull-up resistors.
 {{/if}} {{!-- has-stm32 --}}
 
 {{#if has-nrf52}}
@@ -6848,7 +6939,7 @@ On the Argon/Boron/Xenon, D0 is the Serial Data Line (SDA) and D1 is the Serial 
 
 Both SCL and SDA pins are open-drain outputs that only pull LOW and typically operate with 3.3V logic. Connect a pull-up resistor(1.5k to 10k) on the SDA line to 3V3. Connect a pull-up resistor(1.5k to 10k) on the SCL line to 3V3.  If you are using a breakout board with an I2C peripheral, check to see if it already incorporates pull-up resistors.
 
-Note that unlike Gen 2 devices (Photon/P1/Electron), Gen 3 devices are not 5V tolerant.
+Note that unlike the Gen 1 (Core) and Gen 2 devices (Photon/P1/Electron), Gen 3 devices are not 5V tolerant.
 {{/if}} {{!-- has-nrf52 --}}
 
 
@@ -10139,6 +10230,9 @@ _Note that UDP does not guarantee that messages are always delivered, or that
 they are delivered in the order supplied. In cases where your application
 requires a reliable connection, `TCPClient` is a simpler alternative._
 
+{{#if core}}
+The UDP protocol implementation has known issues that will require extra consideration when programming with it. Please refer to the Known Issues category of the Community for details. The are also numerous working examples and workarounds in the searchable Community topics.
+{{/if}}
 
 There are two primary ways of working with UDP - buffered operation and unbuffered operation.
 
@@ -10583,6 +10677,7 @@ void loop()
 
 Set up a servo on a particular pin. Note that, Servo can only be attached to pins with a timer.
 
+- on the Core, Servo can be connected to A0, A1, A4, A5, A6, A7, D0, and D1.
 - on the Photon, Servo can be connected to A4, A5, WKP, RX, TX, D0, D1, D2, D3
 - on the P1, Servo can be connected to A4, A5, WKP, RX, TX, D0, D1, D2, D3, P1S0, P1S1
 - on the Electron, Servo can be connected to A4, A5, WKP, RX, TX, D0, D1, D2, D3, B0, B1, B2, B3, C4, C5
@@ -11310,8 +11405,12 @@ Applies theme settings.
 
 ```cpp
 // SYNTAX
+{{#unless core}}
 void LEDSystemTheme::apply(bool save = false);
-
+{{/unless}}
+{{#if core}}
+void LEDSystemTheme::apply();
+{{/if}}
 
 // EXAMPLE - applying theme settings
 LEDSystemTheme theme;
@@ -11319,9 +11418,11 @@ theme.setColor(LED_SIGNAL_NETWORK_ON, RGB_COLOR_BLUE);
 theme.apply();
 ```
 
+{{#unless core}}
 Parameters:
 
   * `save` : whether theme settings should be saved to a persistent storage (default value is `false`)
+{{/unless}}
 
 #### restoreDefault()
 
@@ -11351,10 +11452,15 @@ LED_SIGNAL_CLOUD_HANDSHAKE | Performing handshake with the Cloud | Normal | Fast
 LED_SIGNAL_CLOUD_CONNECTED | Connected to the Cloud | Background | Breathing cyan
 LED_SIGNAL_SAFE_MODE | Connected to the Cloud in safe mode | Background | Breathing magenta
 LED_SIGNAL_LISTENING_MODE | Listening mode | Normal | Slow blinking blue
+{{#unless core}}
 LED_SIGNAL_DFU_MODE * | DFU mode | Critical | Blinking yellow
+LED_SIGNAL_FIRMWARE_UPDATE * | Performing firmware update | Critical | Blinking magenta
+{{/unless}}
 LED_SIGNAL_POWER_OFF | Soft power down is pending | Critical | Solid gray
 
+{{#unless core}}
 **Note:** Signals marked with an asterisk (*) are implemented within the bootloader and currently don't support pattern type and speed customization due to flash memory constraints. This may be changed in future versions of the firmware.
+{{/unless}}
 
 ### LEDPriority Enum
 
@@ -11465,7 +11571,7 @@ void loop()
 }
 ```
 
-It overflows at the maximum 32-bit unsigned long value.
+In Device OS v0.4.3 and earlier this number will overflow (go back to zero), after exactly 59,652,323 microseconds (0 .. 59,652,322) on the Core and after exactly 35,791,394 microseconds (0 .. 35,791,394) on the Photon and Electron. In newer Device OS versions, it overflows at the maximum 32-bit unsigned long value.
 
 ### delay()
 
@@ -11872,6 +11978,10 @@ If you have set the time zone using Time.zone(), beginDST(), etc. the formatted 
 
 **Note:** The custom time provided to `Time.format()` needs to be UTC based and *not* contain the time zone offset (as `Time.local()` would), since the time zone correction is performed by the high level `Time` methods internally.
 
+{{#if core}}
+**Note:** On the Core the format function is implemented using `strftime()` which adds several kilobytes to the size of firmware.
+Application firmware that has limited space available may want to consider using simpler alternatives that consume less firmware space, such as `sprintf()`.
+{{/if}}
 
 ### setFormat()
 
@@ -12030,7 +12140,11 @@ Shared on the Electron/E series (only one pin for each bullet item can be used a
   - C3, TX
   - C4, RX
 
+{{#if core}}
+#### Spark Core
 
+Interrupts supported on D0, D1, D2, D3, D4, A0, A1, A3, A4, A5, A6, A7 only.
+{{/if}}
 {{/if}} {{!-- has-stm32 --}}
 
 Additional information on which pins can be used for interrupts is available on the [pin information page](/reference/hardware/pin-info).
@@ -12165,7 +12279,8 @@ noInterrupts();
 ## Software Timers
 
 {{#if has-stm32}}
-_Since 0.4.7. This feature is available on the Photon, P1 and Electron out the box.
+_Since 0.4.7. This feature is available on the Photon, P1 and Electron out the box. On the Core, the
+`freertos4core` Particle library <a href="https://build.particle.io/libs/freertos4core/0.2.0/tab/example/timers.ino" target="_blank">(Timers.ino example found here)</a> should be used to add FreeRTOS to the core._
 {{/if}}
 
 Software Timers provide a way to have timed actions in your program.  FreeRTOS provides the ability to have up to 10 Software Timers at a time with a minimum resolution of 1 millisecond.  It is common to use millis() based "timers" though exact timing is not always possible (due to other program delays).  Software timers are maintained by FreeRTOS and provide a more reliable method for running timed actions using callback functions.  Please note that Software Timers are "chained" and will be serviced sequentially when several timers trigger simultaneously, thus requiring special consideration when writing callback functions.
@@ -12686,6 +12801,7 @@ Returns the total number of bytes available in the emulated EEPROM.
 size_t length = EEPROM.length();
 ```
 
+- The Core has 127 bytes of emulated EEPROM.
 - The Gen 2 (Photon, P1, Electron, and E Series) have 2047 bytes of emulated EEPROM.
 - The Gen 3 (Argon, Boron, Xenon) devices have 4096 bytes of emulated EEPROM.
 
@@ -13598,7 +13714,7 @@ Firmware 0.4.7 has a version number 0x00040700
 
 {{since when="0.4.6"}}
 
-Can be used to determine how long the System button (SETUP on Photon, MODE on other devices) has been pushed.
+Can be used to determine how long the System button (MODE on Core/Electron, SETUP on Photon) has been pushed.
 
 Returns `uint16_t` as duration button has been held down in milliseconds.
 
@@ -13716,6 +13832,18 @@ Serial.println(freemem);
 ```
 
 
+{{#if core}}
+### factoryReset()
+
+This will perform a factory reset and do the following:
+- Restore factory reset firmware from external flash (tinker)
+- Erase Wi-Fi profiles
+- Enter Listening mode upon completion
+
+```cpp
+System.factoryReset()
+```
+{{/if}}
 ### dfu()
 
 The device will enter DFU-mode to allow new user firmware to be refreshed. DFU mode is cancelled by
@@ -13798,10 +13926,10 @@ System.sleep(SLEEP_MODE_DEEP,60);
 // The device LED will shut off during deep sleep
 
 // Since 0.8.0
-// Put the device into deep sleep for 60 seconds and disable WKP pin
+// Put the device into deep sleep for 60 seconds and disable {{#if core}}A7{{else}}WKP{{/if}} pin
 System.sleep(SLEEP_MODE_DEEP, 60, SLEEP_DISABLE_WKP_PIN);
 // The device LED will shut off during deep sleep
-// The device will not wake up if a rising edge signal is applied to WKP
+// The device will not wake up if a rising edge signal is applied to {{#if core}}A7{{else}}WKP{{/if}}
 ```
 
 {{/if}} {{!-- has-stm32 --}}
@@ -13831,10 +13959,10 @@ The standby mode is used to achieve the lowest power consumption.  After enterin
 For cellular devices, reconnecting to cellular after `SLEEP_MODE_DEEP` will generally use more power than using `SLEEP_NETWORK_STANDBY` for periods less than 15 minutes. You should definitely avoid using `SLEEP_MODE_DEEP` on cellular devices for periods of 5 minutes. Your SIM can be blocked by your mobile carrier for aggressive reconnection if you reconnect to cellular very frequently. Using `SLEEP_NETWORK_STANDBY` keeps the connection up, and supports sleeping for shorter intervals.
 
 {{#if has-stm32}}
-The device will automatically *wake up* after the specified number of seconds or by applying a rising edge signal to the WKP pin.
+The device will automatically *wake up* after the specified number of seconds or by applying a rising edge signal to the {{#if core}}A7{{else}}WKP{{/if}} pin.
 
 {{since when="0.8.0"}}
-Wake up by WKP pin may be disabled by passing `SLEEP_DISABLE_WKP_PIN` option to `System.sleep()`: `System.sleep(SLEEP_MODE_DEEP, long seconds, SLEEP_DISABLE_WKP_PIN)`.
+Wake up by {{#if core}}A7{{else}}WKP{{/if}} pin may be disabled by passing `SLEEP_DISABLE_WKP_PIN` option to `System.sleep()`: `System.sleep(SLEEP_MODE_DEEP, long seconds, SLEEP_DISABLE_WKP_PIN)`.
 
 {{#if has-fuel-gauge}}
 ---
@@ -13871,9 +13999,7 @@ System.sleep(SLEEP_MODE_SOFTPOWEROFF);
 
 ---
 
-`System.sleep(uint16_t wakeUpPin, uint16_t edgeTriggerMode)` can be used to put the entire device into a *stop* mode with *wakeup on interrupt*. In this particular mode, the device shuts down the network and puts the microcontroller in a stop mode with configurable wakeup pin and edge triggered interrupt. When the specific interrupt arrives, the device awakens from stop mode. 
-
-The {{device}} will not reset before going into stop mode so all the application variables are preserved after waking up from this mode. This mode achieves the lowest power consumption while retaining the contents of RAM and registers.
+`System.sleep(uint16_t wakeUpPin, uint16_t edgeTriggerMode)` can be used to put the entire device into a *stop* mode with *wakeup on interrupt*. In this particular mode, the device shuts down the network and puts the microcontroller in a stop mode with configurable wakeup pin and edge triggered interrupt. When the specific interrupt arrives, the device awakens from stop mode. {{#if core}}The Core is reset on entering stop mode and runs all user code from the beginning with no values being maintained in memory from before the stop mode. As such, it is recommended that stop mode be called only after all user code has completed.{{else}}The {{device}} will not reset before going into stop mode so all the application variables are preserved after waking up from this mode. This mode achieves the lowest power consumption while retaining the contents of RAM and registers.{{/if}}
 
 ```cpp
 // SYNTAX
@@ -13889,6 +14015,10 @@ System.sleep(D1,RISING);
 // The device LED will shut off during sleep
 ```
 
+{{#if core}}
+It is mandatory to update the *bootloader* (https://github.com/particle-iot/device-os/tree/bootloader-patch-update) for proper functioning of this mode.
+{{/if}}
+
 {{#if has-cellular}}
 The Electron and Boron maintain the cellular connection for the duration of the sleep when  `SLEEP_NETWORK_STANDBY` is given as the last parameter value. On wakeup, the device is able to reconnect to the cloud much quicker, at the expense of increased power consumption during sleep. Roughly speaking, for sleep periods of less than 15 minutes, `SLEEP_NETWORK_STANDBY` uses less power.
 
@@ -13901,7 +14031,11 @@ For sleep periods of less than 5 minutes you must use `SLEEP_NETWORK_STANDBY`. Y
 - `wakeUpPin`: the wakeup pin number. supports external interrupts on the following pins:
 {{#if has-stm32}}
     - supports external interrupts on the following pins:
+{{#unless core}}
       - D1, D2, D3, D4, A0, A1, A3, A4, A6, A7
+{{else}}
+      - D0, D1, D2, D3, D4, A0, A1, A3, A4, A5, A6, A7
+{{/unless}}
       - The same [pin limitations as `attachInterrupt`](#attachinterrupt-) apply
 {{else}}
     - all pins are allowed, but a maximum of 8 can be used at a time
@@ -13968,7 +14102,11 @@ Multiple wakeup pins may be specified for this mode.
     - a `pin_t` array. The length of the array needs to be provided in `wakeUpPinsCount` argument
 {{#if has-stm32}}
     - supports external interrupts on the following pins:
+{{#unless core}}
       - D1, D2, D3, D4, A0, A1, A3, A4, A6, A7
+{{else}}
+      - D0, D1, D2, D3, D4, A0, A1, A3, A4, A5, A6, A7
+{{/unless}}
       - The same [pin limitations as `attachInterrupt`](#attachinterrupt-) apply
 {{else}}
     - all pins are allowed, but a maximum of 8 can be used at a time
@@ -14001,14 +14139,20 @@ System.sleep(D1,RISING,60);
 // The device LED will shut off during sleep
 ```
 
-`System.sleep(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds)` can be used to put the entire device into a *stop* mode with *wakeup on interrupt* or *wakeup after specified seconds*. In this particular mode, the device shuts network subsystem and puts the microcontroller in a stop mode with configurable wakeup pin and edge triggered interrupt or wakeup after the specified seconds. When the specific interrupt arrives or upon reaching the configured timeout, the device awakens from stop mode. The device will not reset before going into stop mode so all the application variables are preserved after waking up from this mode. The voltage regulator is put in low-power mode. This mode achieves the lowest power consumption while retaining the contents of RAM and registers.
+`System.sleep(uint16_t wakeUpPin, uint16_t edgeTriggerMode, long seconds)` can be used to put the entire device into a *stop* mode with *wakeup on interrupt* or *wakeup after specified seconds*. In this particular mode, the device shuts network subsystem and puts the microcontroller in a stop mode with configurable wakeup pin and edge triggered interrupt or wakeup after the specified seconds. When the specific interrupt arrives or upon reaching the configured timeout, the device awakens from stop mode. {{#if core}}The Core is reset on entering stop mode and runs all user code from the beginning with no values being maintained in memory from before the stop mode. As such, it is recommended that stop mode be called only after all user code has completed.{{else}}The device will not reset before going into stop mode so all the application variables are preserved after waking up from this mode. The voltage regulator is put in low-power mode. This mode achieves the lowest power consumption while retaining the contents of RAM and registers.{{/if}}
+
+{{#if core}}On the Core, it is necessary to update the *bootloader* (https://github.com/particle-iot/device-os/tree/bootloader-patch-update) for proper functioning of this mode.{{/if}}
 
 *Parameters:*
 
 - `wakeUpPin`: the wakeup pin number. supports external interrupts on the following pins:
 {{#if has-stm32}}
     - supports external interrupts on the following pins:
+{{#unless core}}
       - D1, D2, D3, D4, A0, A1, A3, A4, A6, A7
+{{else}}
+      - D0, D1, D2, D3, D4, A0, A1, A3, A4, A5, A6, A7
+{{/unless}}
       - The same [pin limitations as `attachInterrupt`](#attachinterrupt-) apply
 {{else}}
     - all pins are allowed, but a maximum of 8 can be used at a time
@@ -14075,7 +14219,11 @@ Multiple wakeup pins may be specified for this mode.
     - a `pin_t` array. The length of the array needs to be provided in `wakeUpPinsCount` argument
 {{#if has-stm32}}
     - supports external interrupts on the following pins:
+{{#unless core}}
       - D1, D2, D3, D4, A0, A1, A3, A4, A6, A7
+{{else}}
+      - D0, D1, D2, D3, D4, A0, A1, A3, A4, A5, A6, A7
+{{/unless}}
       - The same [pin limitations as `attachInterrupt`](#attachinterrupt-) apply
 {{else}}
     - all pins are allowed, but a maximum of 8 can be used at a time
@@ -17492,7 +17640,7 @@ Note that the true and false constants are typed in lowercase unlike `HIGH, LOW,
 
 ### Data Types
 
-**Note:** The Photon/P1/Electron uses a 32-bit ARM based microcontroller and hence the datatype lengths are different from a standard 8-bit system (for e.g. Arduino Uno).
+**Note:** The Core/Photon/Electron uses a 32-bit ARM based microcontroller and hence the datatype lengths are different from a standard 8-bit system (for e.g. Arduino Uno).
 
 #### void
 
@@ -17582,7 +17730,7 @@ byte b = 0x11;
 
 #### int
 
-Integers are your primary data-type for number storage. On the Photon/Electron, an int stores a 32-bit (4-byte) value. This yields a range of -2,147,483,648 to 2,147,483,647 (minimum value of -2^31 and a maximum value of (2^31) - 1).
+Integers are your primary data-type for number storage. On the Core/Photon/Electron, an int stores a 32-bit (4-byte) value. This yields a range of -2,147,483,648 to 2,147,483,647 (minimum value of -2^31 and a maximum value of (2^31) - 1).
 int's store negative numbers with a technique called 2's complement math. The highest bit, sometimes referred to as the "sign" bit, flags the number as a negative number. The rest of the bits are inverted and 1 is added.
 
 Other variations:
@@ -17593,7 +17741,7 @@ Other variations:
 
 #### unsigned int
 
-The Photon/Electron stores a 4 byte (32-bit) value, ranging from 0 to 4,294,967,295 (2^32 - 1).
+The Core/Photon/Electron stores a 4 byte (32-bit) value, ranging from 0 to 4,294,967,295 (2^32 - 1).
 The difference between unsigned ints and (signed) ints, lies in the way the highest bit, sometimes referred to as the "sign" bit, is interpreted.
 
 Other variations:
@@ -17627,7 +17775,7 @@ Floating point math is also much slower than integer math in performing calculat
 
 #### double
 
-Double precision floating point number. On the Photon/Electron, doubles have 8-byte (64 bit) precision.
+Double precision floating point number. On the Core/Photon/Electron, doubles have 8-byte (64 bit) precision.
 
 #### string - char array
 
@@ -18098,7 +18246,7 @@ The following instructions are for upgrading to **Device OS v@FW_VER@** which re
 
 **Updating Device OS Automatically**
 
-To update your Photon or P1 Device OS version automatically, compile and flash your application in the [Build IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Photon, P1 and Electron can be found below.
+To update your Photon, P1 or Core Device OS version automatically, compile and flash your application in the [Build IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Core, Photon, P1 and Electron can be found below.
 
 ---
 
@@ -18249,6 +18397,9 @@ If your device is online, you can attempt to OTA (Over The Air) update these sys
 ```
 The OTA method using Particle CLI
 
+// Core
+particle flash YOUR_DEVICE_NAME tinker-@FW_VER@-core.bin
+
 // Photon
 particle flash YOUR_DEVICE_NAME system-part1-@FW_VER@-photon.bin
 particle flash YOUR_DEVICE_NAME system-part2-@FW_VER@-photon.bin
@@ -18270,6 +18421,8 @@ particle flash YOUR_DEVICE_NAME tinker (optional)
 ```
 The OTA method using Particle CLI
 
+// Core
+particle flash YOUR_DEVICE_NAME tinker-@FW_VER@-core.bin
 
 // Photon
 particle flash YOUR_DEVICE_NAME system-part1-@FW_VER@-photon.bin
@@ -18303,6 +18456,9 @@ To upgrade Device OS, make sure the device is in [DFU mode](/tutorials/device-os
 ```
 The local method over USB using Particle CLI
 
+// Core
+particle flash --usb tinker-@FW_VER@-core.bin
+
 // Photon
 particle flash --usb system-part1-@FW_VER@-photon.bin
 particle flash --usb system-part2-@FW_VER@-photon.bin
@@ -18323,6 +18479,9 @@ particle flash --usb tinker (optional)
 ##### @ELECTRON_PARTS@3if
 ```
 The local method over USB using Particle CLI
+
+// Core
+particle flash --usb tinker-@FW_VER@-core.bin
 
 // Photon
 particle flash --usb system-part1-@FW_VER@-photon.bin
@@ -18353,6 +18512,9 @@ can be applied to offline devices locally over USB using `dfu-util`
 ```
 The local DFU-UTIL method
 
+// Core
+dfu-util -d 1d50:607f -a 0 -s 0x8005000:leave -D tinker-@FW_VER@-core.bin
+
 // Photon
 dfu-util -d 2b04:d006 -a 0 -s 0x8020000 -D system-part1-@FW_VER@-photon.bin
 dfu-util -d 2b04:d006 -a 0 -s 0x8060000:leave -D system-part2-@FW_VER@-photon.bin
@@ -18371,6 +18533,8 @@ dfu-util -d 2b04:d00a -a 0 -s 0x8040000:leave -D system-part2-@FW_VER@-electron.
 ```
 The local DFU-UTIL method
 
+// Core
+dfu-util -d 1d50:607f -a 0 -s 0x8005000:leave -D tinker-@FW_VER@-core.bin
 
 // Photon
 dfu-util -d 2b04:d006 -a 0 -s 0x8020000 -D system-part1-@FW_VER@-photon.bin
@@ -18394,7 +18558,7 @@ dfu-util -d 2b04:d00a -a 0 -s 0x8040000:leave -D system-part3-@FW_VER@-electron.
 Current default Device OS would be the latest non-rc.x firmware version.  E.g. if the current list of default releases was 0.5.3, 0.6.0, **0.6.1** (would be the latest).
 
 ##### @FW_VER@0.5.1if
-**Caution:** After upgrading to 0.5.1, DO NOT downgrade Device OS via OTA remotely! This will cause Wi-Fi credentials to be erased on the Photon and P1.  This does not affect the Electron.  Feel free to downgrade locally with the understanding that you will have to re-enter Wi-Fi credentials.  Also note that 0.5.1 fixes several important bugs, so there should be no reason you'd normally want to downgrade.
+**Caution:** After upgrading to 0.5.1, DO NOT downgrade Device OS via OTA remotely! This will cause Wi-Fi credentials to be erased on the Photon and P1.  This does not affect the Core or Electron.  Feel free to downgrade locally with the understanding that you will have to re-enter Wi-Fi credentials.  Also note that 0.5.1 fixes several important bugs, so there should be no reason you'd normally want to downgrade.
 ##### @FW_VER@0.5.1endif
 
 ##### @FW_VER@0.5.2if

--- a/src/content/tutorials/developer-tools/tinker.md
+++ b/src/content/tutorials/developer-tools/tinker.md
@@ -2,11 +2,14 @@
 title: Tinker & Mobile App
 layout: tutorials.hbs
 columns: two
-devices: [ photon,electron,core,argon,boron,xenon]
+devices: [ photon,electron,argon,boron,xenon]
 order: 23
 ---
 
-# Tinkering with "Tinker"
+# Tinkering with "Tinker" - {{device}}
+
+You are viewing the Tinker documentation the **{{device}}**. To view the documentation for other 
+devices, use the blue device selector below the Particle logo on the left side of the page.
 
 ![Tinker selection](/assets/images/tinker.png)
 

--- a/src/content/tutorials/device-cloud/authentication.md
+++ b/src/content/tutorials/device-cloud/authentication.md
@@ -363,7 +363,7 @@ Once your mobile/web app has a claim code, it then must then send it to the devi
 ![Claim codes](/assets/images/claim-code-setup.png)
 <p class="caption">Your app will use the customer access token to generate a device claim code and send it to the device</p>
 
-This happens by connecting the customer's device to the *device's Wi-Fi access point*. When the photon is in [listening mode](/tutorials/device-os/led/core/#listening-mode), it is broadcasting a Wi-Fi network that the customer's computer or phone can connect to.
+This happens by connecting the customer's device to the *device's Wi-Fi access point*. When the photon is in [listening mode](/tutorials/device-os/led/photon/#listening-mode), it is broadcasting a Wi-Fi network that the customer's computer or phone can connect to.
 
 __Note__: When programmatically entering listening mode on the Photon, P1 or P0, care should be taken to conserve the memory utilized by user firmware. Listening Mode on these devices utilizes a number of threads to create short-lived HTTP server instances, a TCP server for SoftAP access, and associated resources. If the free memory available on a device at the time Listening Mode is triggered is less than 21.5K, the device will be unable to enter listening mode. In some cases, it may appear as though the device is in listening mode, but any attempt to configure access via the CLI or Particle Mobile App will time out or fail. None of the device's user firmware is lost or affected in either case, but the RAM in use will need to be optimized below 21.5k before re-attempting to enter listening mode.
 

--- a/src/content/tutorials/device-os/led.md
+++ b/src/content/tutorials/device-os/led.md
@@ -2,9 +2,14 @@
 title: Status LED and Device Modes
 layout: tutorials.hbs
 columns: two
-devices: [ photon,electron,core,argon,boron,xenon ]
+devices: [ boron,photon,electron,argon,xenon ]
 order: 2 
 ---
+
+# Status LED - {{device}}
+
+You are viewing the Status LED and Device Modes for the **{{device}}**. To view the documentation for other 
+devices, use the blue device selector below the Particle logo on the left side of the page.
 
 ## Standard Modes
 These modes are the typical behaviors you will see from your {{device}} on a regular basis. They are the light patterns of a healthy {{device}}.
@@ -65,9 +70,7 @@ If you are unable to get past blinking green, here are a few known working situa
 {{#if photon}}
 - If you are using a corporate or school network that uses WPA2 Enterprise, you will need to follow [special setup instructions](/support/particle-devices-faq/wpa2-enterprise/). If you require both a username and a password, or see a mention of 802.1(x), or RADIUS you're using WPA2 Enterprise.
 {{/if}} 
-{{#if core}}
-- If you are using a corporate or school network that uses WPA2 Enterprise, you cannot use a {{device}}. If you require both a username and a password, or see a mention of 802.1(x), or RADIUS you're using WPA2 Enterprise.
-{{/if}}
+
 
 - If you are using a network that takes you to a web page where you need to either sign in or agree to terms and service when you first connect, using the {{device}} directly will be difficult or impossible. This is the case in some hotels and public Wi-Fi networks and is often referred to as Captive Portal.
 
@@ -77,11 +80,9 @@ If you are unable to get past blinking green, here are a few known working situa
 - If your Wi-Fi network uses 802.11n only mode (does not support 802.11b, 802.11g, or a combination of b, g, and n), it's not currently possible to connect a Photon or P1 to the network if the device is running Device OS 0.7.0 or later.
 {{/if}} 
 
-{{#unless core}}
 For home users:
 
 - If your router uses WEP encryption, you should upgrade your router to something more secure. However it may be possible to connect your {{device}} with some difficulty by following the [WEP configuration instructions](http://rickkas7.github.io/wep/).
-{{/unless}}
 
 And the less common situations:
 
@@ -89,9 +90,7 @@ And the less common situations:
 
 - If your Wi-Fi network does not support DHCP, and only uses static IP addresses, it is possible, though somewhat difficult, to set up a {{device}}. You will need to flash a program by USB to set the IP address.
 
-{{#unless core}}
 - If the Wi-Fi network restricts access to known device Ethernet MAC addresses, you'll need to determine the MAC address and give it to the network administrator. Put the {{device}} in listening mode (blinking dark blue) by holding down the {{system-button}} button, then use the Particle CLI command `particle serial mac`.
-{{/unless}}
 
 {{collapse op="end"}}
 
@@ -322,16 +321,6 @@ To erase the stored Wi-Fi networks on your {{device}}, hold the `{{system-button
 
 {{/if}}
 
-{{#if core}}
-
-### Wi-Fi Network Reset
-
-{{vine "https://vine.co/v/eZU6expA5bA/embed/simple"}}
-
-To erase the stored Wi-Fi networks on your {{device}}, hold the `{{system-button}}` button for about ten seconds, until the RGB LED blinks blue rapidly.
-
-{{/if}}
-
 
 {{#if has-cellular}}
 ### Cellular Off
@@ -345,7 +334,7 @@ To erase the stored Wi-Fi networks on your {{device}}, hold the `{{system-button
 If your {{device}} is breathing white, the {{network-type}} module is off. You might see this mode if:
 
 - You have set your module to `MANUAL` or `SEMI_AUTOMATIC` in your user firmware
-- You have called {{#if electron}}`Cellular.off()`{{/if}}{{#if photon}}`WiFi.off()`{{/if}}{{#if core}}`WiFi.off()`{{/if}} in your user firmware
+- You have called `Cellular.off()` or `WiFi.off()` in your user firmware
 
 
 
@@ -388,7 +377,6 @@ And a usage guide [here.](/reference/developer-tools/cli/)
 
 To enter DFU Mode:
 
-{{#unless core}}
 
 1. Hold down BOTH buttons
 2. Release only the `{{reset-button}}` button, while holding down the `{{system-button}}` button.
@@ -399,18 +387,6 @@ To enter DFU Mode:
 {{vine "https://vine.co/v/eZUHnhaUD9Y/embed/simple"}}
 {{/if}}
 
-{{/unless}}
-
-{{#if core}}
-
-1. Hold down BOTH buttons
-2. Release only the `RST` button, while holding down the `{{system-button}}` button.
-3. Wait for the LED to start flashing yellow
-4. Release the `{{system-button}}` button
-"
-{{vine "https://vine.co/v/eZUgeu0r639/embed/simple"}}
-
-{{/if}}
 
 The {{device}} now is in the DFU mode.
 
@@ -418,7 +394,6 @@ DFU mode requires device drivers under Windows. These should automatically be in
 
 Some users have reported issues with dfu-util on a USB3 ports (typically the blue ones). Use a USB2 port if the USB3 port doesn't work.
 
-{{#unless core}}
 
 ### Firmware Reset
 
@@ -494,11 +469,8 @@ To enter Firmware Reset Mode:
 4. Release the `{{system-button}}` button
 {{/if}}
 
-{{/unless}}
-
 ### Factory Reset
 
-{{#unless core}}
 
 {{#if has-gen3}}
 
@@ -548,28 +520,6 @@ particle device doctor
 
 {{/if}} {{!-- has-gen3 --}}
 
-{{/unless}} {{!-- core --}}
-
-{{#if core}}
-
-{{vine "https://vine.co/v/eZU6XdrYbd5/embed/simple"}}
-
-A factory reset restores the firmware on the {{device}} to the default Tinker app and clears all your Wi-Fi credentials.
-
-Procedure:
-
-The procedure is same as the one described above (DFU Mode), but in this case you should continue holding down the `{{system-button}}` button until you see the {{device}} change from blinking yellow to blinking white. Then release the button.  The {{device}} should begin after the factory reset is complete.
-
-1. Hold down BOTH buttons
-2. Release only the `RST` button, while holding down the `{{system-button}}` button.
-3. Wait for the LED to start blinking yellow (continue to hold the `{{system-button}}` button)
-4. The LED will turn solid white (continue to hold the `{{system-button}}` button)
-5. Finally, the LED will turn blink white rapidly
-6. Release the `{{system-button}}` button
-
-
-You can reset Wi-Fi credentials by performing a [Wi-Fi Network Reset](#wi-fi-network-reset).
-{{/if}}
 
 
 
@@ -593,13 +543,6 @@ If the Cellular module is on but not connected to a cellular tower, your {{devic
 If the Wi-Fi module is on but not connected to a network, your {{device}} will be breathing blue. Note that this will be dark blue and not cyan.
 {{/if}}
 
-{{#if core}}
-### Wi-Fi Module Not Connected
-
-{{device-animation device "breathe" "blue" }}
-
-If the Wi-Fi module is on but not connected to a network, your {{device}} will be breathing blue. Note that this will be dark blue and not cyan.
-{{/if}}
 
 ### Cloud Not Connected
 
@@ -657,7 +600,6 @@ void waitForSwitch() {
 
 In general it's better to structure your code so it always returns from loop(), but if that's not a viable solution, you can sprinkle some Particle.process() calls in your code.
 
-{{#unless core}}
 #### Solution 2: Enable SYSTEM_THREAD
 
 The other solution is to use [SYSTEM_THREAD](/reference/device-os/firmware/#system-thread) mode.
@@ -681,7 +623,6 @@ if (Particle.connected()) {
     Particle.publish("myEvent", PRIVATE);
 }
 ```
-{{/unless}}
 
 {{#if has-wifi}}
 #### Side note: Wi-Fi only mode
@@ -769,9 +710,7 @@ A pattern of more than 10 red blinks is caused by the firmware crashing. The pat
 {{#if electron}}
 [Enter safe mode](#safe-mode), tweak your firmware and try again!
 {{/if}}
-{{#if core}}
-[Perform a factory reset](#factory-reset), tweak your firmware and try again!
-{{/if}}
+
 
 There are a number of other red blink codes that may be expressed after the SOS blinks:
 
@@ -858,13 +797,8 @@ Things you should not do from an ISR:
 ### Solid colors
 
 
-{{#if core}}
-Solid colors are rare. There are two expected situations:
-- Solid white if you are in the middle of a factory reset.
-{{/if}}
-{{#unless core}}
 Solid colors are rare. There only expected situation is:
-{{/unless}}
+
 - Solid magenta if you are loading code in ymodem serial mode.
 
 

--- a/src/content/tutorials/hardware-projects/hardware-examples.md
+++ b/src/content/tutorials/hardware-projects/hardware-examples.md
@@ -2,13 +2,16 @@
 title: Hardware Examples
 layout: tutorials.hbs
 columns: two
-devices: [photon,electron,core,xenon,argon,boron]
+devices: [photon,electron,xenon,argon,boron]
 order: 90
 ---
 
-# Hardware Examples
+# Hardware Examples - {{device}}
 
-Here you will find a bunch of examples to get you started with your new Particle device! {{#unless electron}}The diagrams here show the Photon, but these examples will work with either the Photon or the Core.{{/unless}}
+You are viewing the Hardware Examples for the **{{device}}**. To view the documentation for other 
+devices, use the blue device selector below the Particle logo on the left side of the page.
+
+Here you will find a bunch of examples to get you started with your new Particle device! {{#unless electron}}The diagrams here show the Photon, but these examples will work with either the Photon.{{/unless}}
 
 These examples are also listed in the online IDE in the Code menu.
 
@@ -140,7 +143,7 @@ int led1 = D6; // Instead of writing D0 over and over again, we'll write led1
 // You'll need to wire an LED to this one to see it blink.
 
 int led2 = D7; // Instead of writing D7 over and over again, we'll write led2
-// This one is the little blue LED on your board. On the Photon it is next to D7, and on the Core it is next to the USB jack.
+// This one is the little blue LED on your board. On the Photon it is next to D7.
 
 // Having declared these variables, let's move on to the setup function.
 // The setup function is a standard part of any microcontroller program.
@@ -896,7 +899,7 @@ void myHandler(const char *event, const char *data)
 
 In the previous example, we sent a private publish. This publish went to you alone; it was just for you and your own apps, programs, integrations, and devices. We can also send a public publish, though, which allows anyone anywhere to see and subscribe to our event in the cloud. All they need is our event name.
 
-Go find a buddy who has a Core, Photon, or Electron. Your buddy does not have to be next to you--she or he can be across the world if you like! All you need is a connection.
+Go find a buddy who has a Photon, or Electron. Your buddy does not have to be next to you--she or he can be across the world if you like! All you need is a connection.
 
 Connect your device and copy the firmware on the right into a new app. Pick a weird name for your event. {{#unless electron}}If your device were named `starfish` for example, you could make your event name something like `starfish_special_event_20150515`. Have your buddy pick a name for their event as well. No more than 63 ASCII characters, and no spaces!{{/unless}}{{#if electron}}Keep it short for data efficiency, but unique so no one else will be using it.{{/if}}
 

--- a/templates/redirector.html.hbs
+++ b/templates/redirector.html.hbs
@@ -27,6 +27,15 @@
             if (lastDevice && fork) {
                 window.location.replace(fork.path + window.location.hash);
             }
+            else {
+                // 2020-02: Skip the device selection interstitial if the
+                // last device is not set and instead jump to the first device
+                // in the list. 
+                if (devices.length >= 1) {
+                    var fork = forkLocations[devices[0]];
+                    window.location.replace(fork.path + window.location.hash);
+                }
+            }
         }
     </script>
     <script src="/assets/js/docs.js"></script>

--- a/test/crawler.js
+++ b/test/crawler.js
@@ -24,7 +24,7 @@ var ignoreHosts = [
   'www.st.com', // randomly returns 403 errors
   '192.168.0.1',
 ];
-var devices = ['photon', 'electron', 'core', 'argon', 'boron', 'xenon'];
+var devices = ['photon', 'electron', 'argon', 'boron', 'xenon'];
 var isPullRequest = process.env.TRAVIS_PULL_REQUEST && process.env.TRAVIS_PULL_REQUEST !== 'false';
 
 var stats = {


### PR DESCRIPTION
- Spark Core Device OS API is now in the Discontinued section. It's basically a fork of firmware.md at 1.4.4 with the platform selector removed and pinned to Core.
- All of the {{if core}} stuff has been removed from firmware.md. I previous removed Raspberry Pi. It's much easier to edit now!
- Core is no longer in the device selector
- There are now only 4 pages with a platform selector (Device OS API, Status LED, Tinker, Hardware Examples).
- The pages more explicitly say what platform you're on and how to get to other platforms.
- The device selection interstitial is gone! Now if you have't selected a device, the first device is selected. Once you've selected a device, that will be the default.