### PR TITLE
Replace recommended uuid generator with open source version

### DIFF
--- a/config/crawler.json
+++ b/config/crawler.json
@@ -2,139 +2,139 @@
   "urls": {
     "https://community.particle.io/c/DT": {
       "url": "https://community.particle.io/c/DT",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://setup.particle.io/": {
       "url": "https://setup.particle.io/",
-      "time": 1582762627
+      "time": 1583203464
     },
     "https://community.particle.io/": {
       "url": "https://community.particle.io/",
-      "time": 1582762606
+      "time": 1583203450
     },
     "https://www.particle.io/": {
       "url": "https://www.particle.io/",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://console.particle.io/": {
       "url": "https://console.particle.io/",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/build": {
       "url": "https://build.particle.io/build",
-      "time": 1582762606
+      "time": 1583203445
     },
     "https://www.particle.io/iot-command-center/": {
       "url": "https://www.particle.io/iot-command-center/",
-      "time": 1582762648
+      "time": 1583203481
     },
     "https://www.analog.com/media/en/technical-documentation/application-notes/an88f.pdf": {
       "url": "https://www.analog.com/media/en/technical-documentation/application-notes/an88f.pdf",
-      "time": 1582762604
+      "time": 1583203448
     },
     "https://www.jedec.org/": {
       "url": "https://www.jedec.org/",
-      "time": 1582762605
+      "time": 1583203448
     },
     "https://en.wikipedia.org/wiki/UL_%28safety_organization%29": {
       "url": "https://en.wikipedia.org/wiki/UL_%28safety_organization%29",
-      "time": 1582762604
+      "time": 1583203447
     },
     "https://docs.particle.io/support/": {
       "url": "https://docs.particle.io/support/",
-      "time": 1582762606
+      "time": 1583203448
     },
     "https://semver.org/": {
       "url": "https://semver.org/",
-      "time": 1582762607
+      "time": 1583203449
     },
     "https://community.particle.io/c/troubleshooting": {
       "url": "https://community.particle.io/c/troubleshooting",
-      "time": 1582762606
+      "time": 1583203450
     },
     "https://powerbi.microsoft.com/en-us/": {
       "url": "https://powerbi.microsoft.com/en-us/",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://www.particle.io/pricing/": {
       "url": "https://www.particle.io/pricing/",
-      "time": 1582762612
+      "time": 1583203454
     },
     "https://www.particle.io/sales/": {
       "url": "https://www.particle.io/sales/",
-      "time": 1582762612
+      "time": 1583203450
     },
     "https://www.openssl.org/": {
       "url": "https://www.openssl.org/",
-      "time": 1582762613
+      "time": 1583203454
     },
     "https://community.particle.io/t/tutorial-particle-cli-on-windows-07-jun-2015/3112": {
       "url": "https://community.particle.io/t/tutorial-particle-cli-on-windows-07-jun-2015/3112",
-      "time": 1582762612
+      "time": 1583203457
     },
     "https://www.w3schools.com/js/js_json_intro.asp": {
       "url": "https://www.w3schools.com/js/js_json_intro.asp",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://en.wikipedia.org/wiki/POST_%28HTTP%29": {
       "url": "https://en.wikipedia.org/wiki/POST_%28HTTP%29",
-      "time": 1582762613
+      "time": 1583203454
     },
     "https://docs.particle.io/guide/tools-and-features/dev/": {
       "url": "https://docs.particle.io/guide/tools-and-features/dev/",
-      "time": 1582762617
+      "time": 1583203458
     },
     "https://github.com/technobly/Particle-NeoPixel": {
       "url": "https://github.com/technobly/Particle-NeoPixel",
-      "time": 1582762860
+      "time": 1583203689
     },
     "http://wiki.seeedstudio.com/Grove-TemperatureAndHumidity_Sensor/": {
       "url": "http://wiki.seeedstudio.com/Grove-TemperatureAndHumidity_Sensor/",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://apps.apple.com/us/app/particle-build-iot-projects-wifi-or-cellular/id991459054": {
       "url": "https://apps.apple.com/us/app/particle-build-iot-projects-wifi-or-cellular/id991459054",
-      "time": 1582762626
+      "time": 1583203464
     },
     "https://www.opensignal.com/": {
       "url": "https://www.opensignal.com/",
-      "time": 1582762627
+      "time": 1583203464
     },
     "https://status.particle.io/": {
       "url": "https://status.particle.io/",
-      "time": 1582762620
+      "time": 1583203458
     },
     "https://en.wikipedia.org/wiki/Industry_Canada": {
       "url": "https://en.wikipedia.org/wiki/Industry_Canada",
-      "time": 1582762627
+      "time": 1583203464
     },
     "https://en.wikipedia.org/wiki/CE_marking": {
       "url": "https://en.wikipedia.org/wiki/CE_marking",
-      "time": 1582762627
+      "time": 1583203464
     },
     "https://www.fcc.gov/": {
       "url": "https://www.fcc.gov/",
-      "time": 1582762628
+      "time": 1583203464
     },
     "https://www.ecfr.gov/cgi-bin/text-idx?c=ecfr&SID=a9f9d244cc20be8b56099003689d6cc3&rgn=div5&view=text&node=47%3A1.0.1.1.16&idno=47": {
       "url": "https://www.ecfr.gov/cgi-bin/text-idx?c=ecfr&SID=a9f9d244cc20be8b56099003689d6cc3&rgn=div5&view=text&node=47%3A1.0.1.1.16&idno=47",
-      "time": 1582762627
+      "time": 1583203464
     },
     "https://ec.europa.eu/environment/waste/rohs_eee/index_en.htm": {
       "url": "https://ec.europa.eu/environment/waste/rohs_eee/index_en.htm",
-      "time": 1582762628
+      "time": 1583203465
     },
     "https://www.sparkfun.com/products/13855": {
       "url": "https://www.sparkfun.com/products/13855",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://www.telec.co.jp/": {
       "url": "https://www.telec.co.jp/",
-      "time": 1582762629
+      "time": 1583203470
     },
     "https://www.globalcertificationforum.org/": {
       "url": "https://www.globalcertificationforum.org/",
-      "time": 1582762629
+      "time": 1583203465
     },
     "https://github.com/particle-iot/uber-library-example": {
       "url": "https://github.com/particle-iot/uber-library-example",
@@ -142,63 +142,63 @@
     },
     "https://github.com/particle-iot/internetbutton": {
       "url": "https://github.com/particle-iot/internetbutton",
-      "time": 1582762648
+      "time": 1583203482
     },
     "https://www.tele.soumu.go.jp/e/index.htm": {
       "url": "https://www.tele.soumu.go.jp/e/index.htm",
-      "time": 1582762629
+      "time": 1583203466
     },
     "https://github.com/particle-iot/PowerShield": {
       "url": "https://github.com/particle-iot/PowerShield",
-      "time": 1582762860
+      "time": 1583203689
     },
     "https://www.particle.io/workbench/": {
       "url": "https://www.particle.io/workbench/",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://github.com/particle-iot/google-maps-device-locator": {
       "url": "https://github.com/particle-iot/google-maps-device-locator",
-      "time": 1582762860
+      "time": 1583203689
     },
     "https://ifttt.com/": {
       "url": "https://ifttt.com/",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://circuitpython.org/board/particle_xenon/": {
       "url": "https://circuitpython.org/board/particle_xenon/",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://github.com/particle-iot/particle-api-js/tree/master/examples": {
       "url": "https://github.com/particle-iot/particle-api-js/tree/master/examples",
-      "time": 1582762649
+      "time": 1583203482
     },
     "https://www.learncpp.com/cpp-tutorial/header-files/": {
       "url": "https://www.learncpp.com/cpp-tutorial/header-files/",
-      "time": 1582762648
+      "time": 1583203482
     },
     "https://nodejs.org/en/": {
       "url": "https://nodejs.org/en/",
-      "time": 1582762858
+      "time": 1583203688
     },
     "https://cloud.google.com/free/": {
       "url": "https://cloud.google.com/free/",
-      "time": 1582762649
+      "time": 1583203482
     },
     "https://community.particle.io/t/tutorial-particle-cli-on-mac-osx-26-sep-2015/5225": {
       "url": "https://community.particle.io/t/tutorial-particle-cli-on-mac-osx-26-sep-2015/5225",
-      "time": 1582762858
+      "time": 1583203689
     },
     "https://en.wikipedia.org/wiki/Representational_State_Transfer": {
       "url": "https://en.wikipedia.org/wiki/Representational_State_Transfer",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://jsonapi.org/": {
       "url": "https://jsonapi.org/",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://github.com/particle-iot/particle-android": {
       "url": "https://github.com/particle-iot/particle-android",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://github.com/particle-iot/softap-setup-js": {
       "url": "https://github.com/particle-iot/softap-setup-js",
@@ -206,251 +206,247 @@
     },
     "https://github.com/particle-iot/device-os/releases/tag/v1.4.4": {
       "url": "https://github.com/particle-iot/device-os/releases/tag/v1.4.4",
-      "time": 1582762870
+      "time": 1583203698
     },
     "https://kk.org/cooltools/zach-supalla-ceo-of-particle/": {
       "url": "https://kk.org/cooltools/zach-supalla-ceo-of-particle/",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://embedded.fm/episodes/222": {
       "url": "https://embedded.fm/episodes/222",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://github.com/hirotakaster/MQTT": {
       "url": "https://github.com/hirotakaster/MQTT",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://github.com/kegnet/photon-thermistor": {
       "url": "https://github.com/kegnet/photon-thermistor",
-      "time": 1582762860
+      "time": 1583203689
     },
     "https://github.com/eliteio/DS18B20": {
       "url": "https://github.com/eliteio/DS18B20",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://github.com/menan/adafruit_st7735": {
       "url": "https://github.com/menan/adafruit_st7735",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://github.com/nmattisson/httpclient": {
       "url": "https://github.com/nmattisson/httpclient",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://github.com/greiman/SdFat-Particle": {
       "url": "https://github.com/greiman/SdFat-Particle",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://github.com/sparkfun/sparkfun_max17043_particle_library": {
       "url": "https://github.com/sparkfun/sparkfun_max17043_particle_library",
-      "time": 1582762860
+      "time": 1583203691
     },
     "https://github.com/focalintent/fastled-sparkcore": {
       "url": "https://github.com/focalintent/fastled-sparkcore",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://build.particle.io/shared_apps/5bc52086cb4e858acf001098": {
       "url": "https://build.particle.io/shared_apps/5bc52086cb4e858acf001098",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://en.wikipedia.org/wiki/Electrolytic_capacitor": {
       "url": "https://en.wikipedia.org/wiki/Electrolytic_capacitor",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://en.wikipedia.org/wiki/Ceramic_capacitor": {
       "url": "https://en.wikipedia.org/wiki/Ceramic_capacitor",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://en.wikipedia.org/wiki/1N4004": {
       "url": "https://en.wikipedia.org/wiki/1N4004",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://en.wikipedia.org/wiki/Flyback_diode": {
       "url": "https://en.wikipedia.org/wiki/Flyback_diode",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://en.wikipedia.org/wiki/Transistor": {
       "url": "https://en.wikipedia.org/wiki/Transistor",
-      "time": 1582762860
-    },
-    "https://www.seeedstudio.com/Grove-Button.html": {
-      "url": "https://www.seeedstudio.com/Grove-Button.html",
-      "time": 1582302692
+      "time": 1583203690
     },
     "https://www3.panasonic.biz/ac/e_download/control/relay/power/catalog/mech_eng_js.pdf?f_cd=300182": {
       "url": "https://www3.panasonic.biz/ac/e_download/control/relay/power/catalog/mech_eng_js.pdf?f_cd=300182",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://www.digikey.com/en/resources/conversion-calculators/conversion-calculator-resistor-color-code-4-band": {
       "url": "https://www.digikey.com/en/resources/conversion-calculators/conversion-calculator-resistor-color-code-4-band",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://en.wikipedia.org/wiki/Hirose_U.FL": {
       "url": "https://en.wikipedia.org/wiki/Hirose_U.FL",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://en.wikipedia.org/wiki/Thermistor": {
       "url": "https://en.wikipedia.org/wiki/Thermistor",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://en.wikipedia.org/wiki/Potentiometer": {
       "url": "https://en.wikipedia.org/wiki/Potentiometer",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://media.digikey.com/pdf/Data%20Sheets/Interlink%20Electronics.PDF/FSR400_Series.pdf": {
       "url": "https://media.digikey.com/pdf/Data%20Sheets/Interlink%20Electronics.PDF/FSR400_Series.pdf",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://en.wikipedia.org/wiki/H_bridge": {
       "url": "https://en.wikipedia.org/wiki/H_bridge",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://www.adafruit.com/product/1298": {
       "url": "https://www.adafruit.com/product/1298",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://www.adafruit.com/product/960": {
       "url": "https://www.adafruit.com/product/960",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://www.adafruit.com/product/381": {
       "url": "https://www.adafruit.com/product/381",
-      "time": 1582762861
+      "time": 1583203691
     },
     "https://rickkas7.github.io/ble-imu/": {
       "url": "https://rickkas7.github.io/ble-imu/",
-      "time": 1582762862
+      "time": 1583203692
     },
     "https://www.oshstencils.com/": {
       "url": "https://www.oshstencils.com/",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://rickkas7.github.io/ble-livegraph/": {
       "url": "https://rickkas7.github.io/ble-livegraph/",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://rickkas7.github.io/ble-powersource/": {
       "url": "https://rickkas7.github.io/ble-powersource/",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://apps.apple.com/us/app/authy/id494168017": {
       "url": "https://apps.apple.com/us/app/authy/id494168017",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://www.particle.io/iot-connectivity/": {
       "url": "https://www.particle.io/iot-connectivity/",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://tools.ietf.org/html/rfc6749": {
       "url": "https://tools.ietf.org/html/rfc6749",
-      "time": 1582762649
+      "time": 1583203688
     },
     "https://apps.apple.com/us/app/google-authenticator/id388497605": {
       "url": "https://apps.apple.com/us/app/google-authenticator/id388497605",
-      "time": 1582762863
+      "time": 1583203691
     },
     "https://www.dfrobot.com/index.php?route=product%2Fproduct&product_id=69": {
       "url": "https://www.dfrobot.com/index.php?route=product%2Fproduct&product_id=69",
-      "time": 1582762864
+      "time": 1583203693
     },
     "https://www.dfrobot.com/index.php?route=product%2Fproduct&path=37_111&product_id=65": {
       "url": "https://www.dfrobot.com/index.php?route=product%2Fproduct&path=37_111&product_id=65",
-      "time": 1582762864
+      "time": 1583203693
     },
     "https://build.particle.io/shared_apps/58fe450fb77e5bb68f0018a3": {
       "url": "https://build.particle.io/shared_apps/58fe450fb77e5bb68f0018a3",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://particle.hackster.io/": {
       "url": "https://particle.hackster.io/",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://www.particle.io/products/hardware/asset-tracker/": {
       "url": "https://www.particle.io/products/hardware/asset-tracker/",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5babb9b33242a939e300171a": {
       "url": "https://build.particle.io/shared_apps/5babb9b33242a939e300171a",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5babbaa43242a990ac0015b5": {
       "url": "https://build.particle.io/shared_apps/5babbaa43242a990ac0015b5",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://www.dfrobot.com/index.php?route=product%2Fproduct&filter_name=battery&product_id=489": {
       "url": "https://www.dfrobot.com/index.php?route=product%2Fproduct&filter_name=battery&product_id=489",
-      "time": 1582762864
+      "time": 1583203693
     },
     "https://www.particle.io/iot-rules-engine/": {
       "url": "https://www.particle.io/iot-rules-engine/",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5babbae73242a9571a00172f": {
       "url": "https://build.particle.io/shared_apps/5babbae73242a9571a00172f",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://accounts.google.com/ServiceLogin?passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.firebase.google.com%2F&followup=https%3A%2F%2Fconsole.firebase.google.com%2F": {
       "url": "https://accounts.google.com/ServiceLogin?passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.firebase.google.com%2F&followup=https%3A%2F%2Fconsole.firebase.google.com%2F",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://www.influxdata.com/": {
       "url": "https://www.influxdata.com/",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://api.slack.com/messaging/webhooks": {
       "url": "https://api.slack.com/messaging/webhooks",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://www.influxdata.com/products/influxdb-overview/": {
       "url": "https://www.influxdata.com/products/influxdb-overview/",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5babbb363242a9ea27001621": {
       "url": "https://build.particle.io/shared_apps/5babbb363242a9ea27001621",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5babba3d3242a9571a001728": {
       "url": "https://build.particle.io/shared_apps/5babba3d3242a9571a001728",
-      "time": 1582762865
+      "time": 1583203692
     },
     "https://www.twilio.com/login?g=%2Fconsole%3F&t=2b1c98334b25c1a785ef15b6556396290e3c704a9b57fc40687cbccd79c46a8c": {
       "url": "https://www.twilio.com/login?g=%2Fconsole%3F&t=2b1c98334b25c1a785ef15b6556396290e3c704a9b57fc40687cbccd79c46a8c",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/about-iot-hub": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/about-iot-hub",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-routing?WT.mc_id=7061727469636c65": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/tutorial-routing?WT.mc_id=7061727469636c65",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging?WT.mc_id=7061727469636c65": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-vscode-iot-toolkit-cloud-device-messaging?WT.mc_id=7061727469636c65",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-get-started-physical": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-get-started-physical",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fcloudpubsub%2FtopicList%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F&followup=https%3A%2F%2Fconsole.cloud.google.com%2Fdatastore%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-cloud-platform%2F",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests": {
       "url": "https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-management-iot-extension-azure-cli-2-0?WT.mc_id=7061727469636c65": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-device-management-iot-extension-azure-cli-2-0?WT.mc_id=7061727469636c65",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/request": {
       "url": "https://developer.mozilla.org/en-US/docs/Archive/Add-ons/Add-on_SDK/High-Level_APIs/request",
@@ -458,59 +454,59 @@
     },
     "https://cloud.google.com/ai-platform": {
       "url": "https://cloud.google.com/ai-platform",
-      "time": 1582762867
+      "time": 1583203694
     },
     "https://docs.particle.io/air-quality-monitoring-kit/": {
       "url": "https://docs.particle.io/air-quality-monitoring-kit/",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://raw.githubusercontent.com/SeeedDocument/Grove_Dust_Sensor/master/resource/Grove_-_Dust_sensor.pdf": {
       "url": "https://raw.githubusercontent.com/SeeedDocument/Grove_Dust_Sensor/master/resource/Grove_-_Dust_sensor.pdf",
-      "time": 1582762867
+      "time": 1583203694
     },
     "https://www.particle.io/for-good/": {
       "url": "https://www.particle.io/for-good/",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://zadig.akeo.ie/": {
       "url": "https://zadig.akeo.ie/",
-      "time": 1582762858
+      "time": 1583203688
     },
     "https://github.com/gnu-mcu-eclipse/eclipse-plugins/releases": {
       "url": "https://github.com/gnu-mcu-eclipse/eclipse-plugins/releases",
-      "time": 1582762867
+      "time": 1583203695
     },
     "https://docs.google.com/a/particle.io/forms/d/e/1FAIpQLScvu-08mbw0CFSf9V0Xb2QaFn2pWNLGQy5mZcT0FZ2UnSSBTw/viewform": {
       "url": "https://docs.google.com/a/particle.io/forms/d/e/1FAIpQLScvu-08mbw0CFSf9V0Xb2QaFn2pWNLGQy5mZcT0FZ2UnSSBTw/viewform",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://codeload.github.com/particle-iot/particle-cloud-sdk-ios/zip/master": {
       "url": "https://codeload.github.com/particle-iot/particle-cloud-sdk-ios/zip/master",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://github.com/ilg-archived/openocd/releases": {
       "url": "https://github.com/ilg-archived/openocd/releases",
-      "time": 1582762867
+      "time": 1583203695
     },
     "https://github.com/particle-iot/particle-android/tree/master/cloudsdk": {
       "url": "https://github.com/particle-iot/particle-android/tree/master/cloudsdk",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://cocoapods.org/": {
       "url": "https://cocoapods.org/",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus": {
       "url": "https://en.wikipedia.org/wiki/Serial_Peripheral_Interface_Bus",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://en.wikipedia.org/wiki/Twos_complement": {
       "url": "https://en.wikipedia.org/wiki/Twos_complement",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://www.putty.org/": {
       "url": "https://www.putty.org/",
-      "time": 1582762866
+      "time": 1583203694
     },
     "https://www.papertrail.com/": {
       "url": "https://www.papertrail.com/",
@@ -518,271 +514,271 @@
     },
     "https://github.com/particle-iot/makerkit": {
       "url": "https://github.com/particle-iot/makerkit",
-      "time": 1582762860
+      "time": 1583203689
     },
     "https://github.com/particle-iot/AssetTracker": {
       "url": "https://github.com/particle-iot/AssetTracker",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://en.wikipedia.org/wiki/Hello_world_program": {
       "url": "https://en.wikipedia.org/wiki/Hello_world_program",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://build.particle.io/shared_apps/5be2de1e88096abb6e00094f": {
       "url": "https://build.particle.io/shared_apps/5be2de1e88096abb6e00094f",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://build.particle.io/shared_apps/5be2dec088096a588500095e": {
       "url": "https://build.particle.io/shared_apps/5be2dec088096a588500095e",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://build.particle.io/shared_apps/5be2dfca88096afd2a0009c1": {
       "url": "https://build.particle.io/shared_apps/5be2dfca88096afd2a0009c1",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://build.particle.io/shared_apps/5be2df6f88096a97af0008d6": {
       "url": "https://build.particle.io/shared_apps/5be2df6f88096a97af0008d6",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://build.particle.io/shared_apps/5be2df2588096afd2a0009b5": {
       "url": "https://build.particle.io/shared_apps/5be2df2588096afd2a0009b5",
-      "time": 1582762861
+      "time": 1583203690
     },
     "https://mxcl.dev/homebrew/": {
       "url": "https://mxcl.dev/homebrew/",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://www.analog.com/media/en/technical-documentation/data-sheets/TMP35_36_37.pdf": {
       "url": "https://www.analog.com/media/en/technical-documentation/data-sheets/TMP35_36_37.pdf",
-      "time": 1582762868
+      "time": 1583203696
     },
     "https://www.u-blox.com/en/product-resources/property_file_product_filter/2432": {
       "url": "https://www.u-blox.com/en/product-resources/property_file_product_filter/2432",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://raw.githubusercontent.com/particle-iot/core/master/Datasheets/MicrochipTech_SST25VF016B-75-4I-S2AF-T.pdf": {
       "url": "https://raw.githubusercontent.com/particle-iot/core/master/Datasheets/MicrochipTech_SST25VF016B-75-4I-S2AF-T.pdf",
-      "time": 1582762869
+      "time": 1583203696
     },
     "https://docs.particle.io/guide/tools-and-features/cli/": {
       "url": "https://docs.particle.io/guide/tools-and-features/cli/",
-      "time": 1582762867
+      "time": 1583203695
     },
     "https://wiki.dfrobot.com/https___www.dfrobot.com_wiki_index.php?title=Arduino_Motor_Shield_%28L298N%29_%28SKU%3ADRI0009%29": {
       "url": "https://wiki.dfrobot.com/https___www.dfrobot.com_wiki_index.php?title=Arduino_Motor_Shield_%28L298N%29_%28SKU%3ADRI0009%29",
-      "time": 1582762868
+      "time": 1583203697
     },
     "https://wiki.dfrobot.com/3PA_Assembly_Guide_%28SKU_ROB0005%29": {
       "url": "https://wiki.dfrobot.com/3PA_Assembly_Guide_%28SKU_ROB0005%29",
-      "time": 1582762868
+      "time": 1583203697
     },
     "https://www.onsemi.com/": {
       "url": "https://www.onsemi.com/",
-      "time": 1582762871
+      "time": 1583203697
     },
     "https://apps.apple.com/us/app/particle-build-photon-electron/id991459054?ls=1": {
       "url": "https://apps.apple.com/us/app/particle-build-photon-electron/id991459054?ls=1",
-      "time": 1582762870
+      "time": 1583203696
     },
     "https://www.particle.io/sales/?utm_campaign=fleet-health-enterprise-contact&utm_source=docs&utm_medium=link": {
       "url": "https://www.particle.io/sales/?utm_campaign=fleet-health-enterprise-contact&utm_source=docs&utm_medium=link",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://www.nuget.org/packages/Particle.SDK": {
       "url": "https://www.nuget.org/packages/Particle.SDK",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://community.particle.io/users/rickkas7/activity": {
       "url": "https://community.particle.io/users/rickkas7/activity",
-      "time": 1582762859
+      "time": 1583203689
     },
     "https://ec.europa.eu/growth/sectors/electrical-engineering/red-directive_en": {
       "url": "https://ec.europa.eu/growth/sectors/electrical-engineering/red-directive_en",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F&followup=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F": {
       "url": "https://accounts.google.com/ServiceLogin?service=cloudconsole&passive=1209600&osid=1&continue=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F&followup=https%3A%2F%2Fconsole.developers.google.com%2Fapis%2Fcredentials%3Fref%3Dhttp%3A%2F%2Flocalhost%3A8081%2Ftutorials%2Fintegrations%2Fgoogle-maps%2F",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://www.particle.io/resources/iot-revolutionizing-supply-chain-management/": {
       "url": "https://www.particle.io/resources/iot-revolutionizing-supply-chain-management/",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://codeload.github.com/particle-iot/particle-windows-sdk/zip/master": {
       "url": "https://codeload.github.com/particle-iot/particle-windows-sdk/zip/master",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://brew.sh/": {
       "url": "https://brew.sh/",
-      "time": 1582762858
+      "time": 1583203688
     },
     "https://codeload.github.com/particle-iot/particle-windows-devicesetup/zip/master": {
       "url": "https://codeload.github.com/particle-iot/particle-windows-devicesetup/zip/master",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5a1d9d7910c40ebfeb0012ea": {
       "url": "https://build.particle.io/shared_apps/5a1d9d7910c40ebfeb0012ea",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://www.nuget.org/packages/Particle.Setup": {
       "url": "https://www.nuget.org/packages/Particle.Setup",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5a1d9dea10c40ebfeb0012ee": {
       "url": "https://build.particle.io/shared_apps/5a1d9dea10c40ebfeb0012ee",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5a1d9e5310c40e5c02001232": {
       "url": "https://build.particle.io/shared_apps/5a1d9e5310c40e5c02001232",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://hackaday.com/2017/01/03/humidity-sensor-shootout/": {
       "url": "https://hackaday.com/2017/01/03/humidity-sensor-shootout/",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5a1d9f2710c40e5dbb001314": {
       "url": "https://build.particle.io/shared_apps/5a1d9f2710c40e5dbb001314",
-      "time": 1582762864
+      "time": 1583203692
     },
     "https://build.particle.io/shared_apps/5a1da51910c40e5dbb00139d": {
       "url": "https://build.particle.io/shared_apps/5a1da51910c40e5dbb00139d",
-      "time": 1582762864
+      "time": 1583203693
     },
     "https://build.particle.io/shared_apps/5a1d9fa810c40eb719001392": {
       "url": "https://build.particle.io/shared_apps/5a1d9fa810c40eb719001392",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://www.adafruit.com/product/1120": {
       "url": "https://www.adafruit.com/product/1120",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://curl.haxx.se/docs/caextract.html": {
       "url": "https://curl.haxx.se/docs/caextract.html",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://www.adafruit.com/product/879": {
       "url": "https://www.adafruit.com/product/879",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://www.adafruit.com/product/871": {
       "url": "https://www.adafruit.com/product/871",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://www.adafruit.com/product/1714": {
       "url": "https://www.adafruit.com/product/1714",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://www.adafruit.com/product/1604": {
       "url": "https://www.adafruit.com/product/1604",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://www.adafruit.com/product/2652": {
       "url": "https://www.adafruit.com/product/2652",
-      "time": 1582762865
+      "time": 1583203693
     },
     "https://www.dhl.com/content/dam/downloads/g0/express/shipping/lithium_batteries/lithium_ion_batteries_regulations.pdf": {
       "url": "https://www.dhl.com/content/dam/downloads/g0/express/shipping/lithium_batteries/lithium_ion_batteries_regulations.pdf",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://www.dhl.com/en/express/shipping/shipping_advice/lithium_batteries.html": {
       "url": "https://www.dhl.com/en/express/shipping/shipping_advice/lithium_batteries.html",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://www.particle.io/distributors/": {
       "url": "https://www.particle.io/distributors/",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://www.eclipse.org/downloads/packages/": {
       "url": "https://www.eclipse.org/downloads/packages/",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html": {
       "url": "https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html",
-      "time": 1582762869
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5c33b28b2872bdbc4300028f": {
       "url": "https://build.particle.io/shared_apps/5c33b28b2872bdbc4300028f",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5c349834e1b63bd1fc000e77": {
       "url": "https://build.particle.io/shared_apps/5c349834e1b63bd1fc000e77",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5c34bcb6e1b63bd1fc0010bf": {
       "url": "https://build.particle.io/shared_apps/5c34bcb6e1b63bd1fc0010bf",
-      "time": 1582762871
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5c34bfcfe1b63be846000fc2": {
       "url": "https://build.particle.io/shared_apps/5c34bfcfe1b63be846000fc2",
-      "time": 1582762871
+      "time": 1583203697
     },
     "https://www.adafruit.com/product/159": {
       "url": "https://www.adafruit.com/product/159",
-      "time": 1582762870
+      "time": 1583203698
     },
     "https://www.adafruit.com/product/2717": {
       "url": "https://www.adafruit.com/product/2717",
-      "time": 1582762865
+      "time": 1583203694
     },
     "https://build.particle.io/shared_apps/5c2f372ae71c123a8b00125e": {
       "url": "https://build.particle.io/shared_apps/5c2f372ae71c123a8b00125e",
-      "time": 1582762871
+      "time": 1583203697
     },
     "http://tools.android.com/tech-docs/support-annotations#TOC-Threading-Annotations:-UiThread-WorkerThread-...": {
       "url": "http://tools.android.com/tech-docs/support-annotations#TOC-Threading-Annotations:-UiThread-WorkerThread-...",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://cylonjs.com/documentation/platforms/particle/": {
       "url": "https://cylonjs.com/documentation/platforms/particle/",
-      "time": 1582762867
+      "time": 1583203695
     },
     "https://build.particle.io/shared_apps/5bfefd038bf964af88000409": {
       "url": "https://build.particle.io/shared_apps/5bfefd038bf964af88000409",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://playground.arduino.cc/Code/BitMath/": {
       "url": "https://playground.arduino.cc/Code/BitMath/",
-      "time": 1582762870
+      "time": 1583203697
     },
     "https://build.particle.io/shared_apps/5d7bb4fe1abb3a0016bd4127": {
       "url": "https://build.particle.io/shared_apps/5d7bb4fe1abb3a0016bd4127",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://github.com/harrisonhjones/phpParticle": {
       "url": "https://github.com/harrisonhjones/phpParticle",
-      "time": 1582762867
+      "time": 1583203695
     },
     "https://build.particle.io/shared_apps/5d40aec2279e1e000b9ad57b": {
       "url": "https://build.particle.io/shared_apps/5d40aec2279e1e000b9ad57b",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://github.com/particle-iot/particle-tinker-app-ios": {
       "url": "https://github.com/particle-iot/particle-tinker-app-ios",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://github.com/harrisonhjones/phpParticleDashboard": {
       "url": "https://github.com/harrisonhjones/phpParticleDashboard",
-      "time": 1582762868
+      "time": 1583203695
     },
     "https://www.arduino.cc/reference/en/": {
       "url": "https://www.arduino.cc/reference/en/",
-      "time": 1582762870
+      "time": 1583203698
     },
     "https://build.particle.io/shared_apps/5b84477c9a93dd475a0002fa": {
       "url": "https://build.particle.io/shared_apps/5b84477c9a93dd475a0002fa",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://developer.apple.com/documentation/swift#2984801": {
       "url": "https://developer.apple.com/documentation/swift#2984801",
-      "time": 1582762870
+      "time": 1583203698
     },
     "https://build.particle.io/shared_apps/5b85708299b6c19f4f00008e": {
       "url": "https://build.particle.io/shared_apps/5b85708299b6c19f4f00008e",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-dotnet": {
       "url": "https://docs.microsoft.com/en-us/azure/iot-hub/quickstart-send-telemetry-dotnet",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://support.microsoft.com/en-us/help/827218/how-to-determine-whether-a-computer-is-running-a-32-bit-version-or-64": {
       "url": "https://support.microsoft.com/en-us/help/827218/how-to-determine-whether-a-computer-is-running-a-32-bit-version-or-64",
@@ -790,111 +786,39 @@
     },
     "https://developer.apple.com/documentation/foundation/nsurlsessiondatatask": {
       "url": "https://developer.apple.com/documentation/foundation/nsurlsessiondatatask",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://help.github.com/en/github/getting-started-with-github/fork-a-repo": {
       "url": "https://help.github.com/en/github/getting-started-with-github/fork-a-repo",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://azure.microsoft.com/en-us/": {
       "url": "https://azure.microsoft.com/en-us/",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://store.arduino.cc/usa/arduino-pro-mini": {
       "url": "https://store.arduino.cc/usa/arduino-pro-mini",
-      "time": 1582762871
+      "time": 1583203698
     },
     "https://www.richtek.com/Products/Switching%20Regulators/DC_DC%20StepDown%20Convertor/RT8259?sc_lang=en&specid=RT8259&ActiveTab=Documents": {
       "url": "https://www.richtek.com/Products/Switching%20Regulators/DC_DC%20StepDown%20Convertor/RT8259?sc_lang=en&specid=RT8259&ActiveTab=Documents",
-      "time": 1582762873
+      "time": 1583203700
     },
     "https://github.com/particle-iot/serial_lcd_library": {
       "url": "https://github.com/particle-iot/serial_lcd_library",
-      "time": 1582762860
+      "time": 1583203690
     },
     "https://www.postman.com/": {
       "url": "https://www.postman.com/",
-      "time": 1582762871
+      "time": 1583203698
     },
     "http://ww17.swiftalicio.us/2014/11/using-cocoapods-from-swift/": {
       "url": "http://ww17.swiftalicio.us/2014/11/using-cocoapods-from-swift/",
-      "time": 1582757503
+      "time": 1583203694
     },
     "https://www.instructables.com/account/login/?nxtPg=%2Fhowto%2FParticle%2F": {
       "url": "https://www.instructables.com/account/login/?nxtPg=%2Fhowto%2FParticle%2F",
-      "time": 1582762867
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=36168e2a9b979c742f092d01bef3": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=36168e2a9b979c742f092d01bef3",
-      "time": 1582215306
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T161814Z&X-Amz-Expires=300&X-Amz-Signature=68002e21491f2dacb149dc7cbb7358636f4898e20519e881c94383fa6f1f76ee&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T161814Z&X-Amz-Expires=300&X-Amz-Signature=68002e21491f2dacb149dc7cbb7358636f4898e20519e881c94383fa6f1f76ee&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582215502
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T161819Z&X-Amz-Expires=300&X-Amz-Signature=914d2f1ab63c635797d5df533e514991be8963754a7b15f8edeb69e173489d93&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T161819Z&X-Amz-Expires=300&X-Amz-Signature=914d2f1ab63c635797d5df533e514991be8963754a7b15f8edeb69e173489d93&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582215503
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T161819Z&X-Amz-Expires=300&X-Amz-Signature=325d02b78f199a19290b1a13b4fdf074f93a90b0f990e0fdc5f71f3d7c441572&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T161819Z&X-Amz-Expires=300&X-Amz-Signature=325d02b78f199a19290b1a13b4fdf074f93a90b0f990e0fdc5f71f3d7c441572&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582215503
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=3ace5fb3ba83b6a8b51ff46ec5b2": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=3ace5fb3ba83b6a8b51ff46ec5b2",
-      "time": 1582220253
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T174045Z&X-Amz-Expires=300&X-Amz-Signature=067828e65917613006917e132fed5fd40cef289699e26dd7a2d343280bc48eaa&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T174045Z&X-Amz-Expires=300&X-Amz-Signature=067828e65917613006917e132fed5fd40cef289699e26dd7a2d343280bc48eaa&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582220455
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T174052Z&X-Amz-Expires=300&X-Amz-Signature=69179f6d47731d892cf6fbf555eb6aad1fb850a7bfbd0097f974732814fcc75c&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T174052Z&X-Amz-Expires=300&X-Amz-Signature=69179f6d47731d892cf6fbf555eb6aad1fb850a7bfbd0097f974732814fcc75c&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582220456
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T174052Z&X-Amz-Expires=300&X-Amz-Signature=aeffd32369e39f0a19362b162199c9e8390c7d48de0f1e18ecc518e1f995eb34&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200220%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200220T174052Z&X-Amz-Expires=300&X-Amz-Signature=aeffd32369e39f0a19362b162199c9e8390c7d48de0f1e18ecc518e1f995eb34&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582220456
-    },
-    "https://store.particle.io/collections/cellular": {
-      "url": "https://store.particle.io/collections/cellular",
-      "time": 1582297005
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=840484cac8cb88450b559f73843b": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=840484cac8cb88450b559f73843b",
-      "time": 1582297020
-    },
-    "https://cloud.google.com/free": {
-      "url": "https://cloud.google.com/free",
-      "time": 1582302535
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T145943Z&X-Amz-Expires=300&X-Amz-Signature=1e9c1b23864f83eb6e9318a88ca4924864c515fad854b1168179ce36747664f7&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T145943Z&X-Amz-Expires=300&X-Amz-Signature=1e9c1b23864f83eb6e9318a88ca4924864c515fad854b1168179ce36747664f7&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582297191
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T145948Z&X-Amz-Expires=300&X-Amz-Signature=5a1bb0936bcca420f550a11055e0cdb58f6f8ca695b9756949d6c87a2fd8a030&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T145948Z&X-Amz-Expires=300&X-Amz-Signature=5a1bb0936bcca420f550a11055e0cdb58f6f8ca695b9756949d6c87a2fd8a030&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582297192
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T145948Z&X-Amz-Expires=300&X-Amz-Signature=1bbff1969cc3a08049775261099aa300ee36d2d8562d55d9c083f4ffd58e48f3&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T145948Z&X-Amz-Expires=300&X-Amz-Signature=1bbff1969cc3a08049775261099aa300ee36d2d8562d55d9c083f4ffd58e48f3&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582297192
-    },
-    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=894155fcc88bbe3d7dee4bc291bb": {
-      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=894155fcc88bbe3d7dee4bc291bb",
-      "time": 1582302512
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T163133Z&X-Amz-Expires=300&X-Amz-Signature=bb0cd321845321f210efdf313796828fa2d9d2aa225e771c4c46a6c75018da5d&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T163133Z&X-Amz-Expires=300&X-Amz-Signature=bb0cd321845321f210efdf313796828fa2d9d2aa225e771c4c46a6c75018da5d&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582302699
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T163136Z&X-Amz-Expires=300&X-Amz-Signature=8f3512f3a3d0808609d340ea3d2623b94d42d601238ea4eba712cf033e0d0f21&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T163136Z&X-Amz-Expires=300&X-Amz-Signature=8f3512f3a3d0808609d340ea3d2623b94d42d601238ea4eba712cf033e0d0f21&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582302700
-    },
-    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T163136Z&X-Amz-Expires=300&X-Amz-Signature=05a8872ec61476c0b29edabf6c2641a25365f08c529caa48882c0aa300646f0f&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
-      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200221T163136Z&X-Amz-Expires=300&X-Amz-Signature=05a8872ec61476c0b29edabf6c2641a25365f08c529caa48882c0aa300646f0f&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
-      "time": 1582302700
+      "time": 1583203695
     },
     "https://docs.particle.io/assets/images/shields/prog-shield/prog-shield.png": {
       "url": "https://docs.particle.io/assets/images/shields/prog-shield/prog-shield.png",
@@ -2100,10 +2024,6 @@
       "url": "https://learn.adafruit.com/introduction-to-bluetooth-low-energy/introduction",
       "time": 1582757231
     },
-    "https://www.uuidgenerator.net/": {
-      "url": "https://www.uuidgenerator.net/",
-      "time": 1582757231
-    },
     "https://www.bluetooth.com/specifications/gatt/services/": {
       "url": "https://www.bluetooth.com/specifications/gatt/services/",
       "time": 1582757231
@@ -3034,7 +2954,7 @@
     },
     "https://www.seeedstudio.com/Grove-Button-p-2809.html": {
       "url": "https://www.seeedstudio.com/Grove-Button-p-2809.html",
-      "time": 1582762862
+      "time": 1583203691
     },
     "https://github.com/particle-iot/argon-ncp-firmware/releases/tag/v0.0.5": {
       "url": "https://github.com/particle-iot/argon-ncp-firmware/releases/tag/v0.0.5",
@@ -3050,7 +2970,7 @@
     },
     "https://github.com/particle-iot-archived/particle-dev-app": {
       "url": "https://github.com/particle-iot-archived/particle-dev-app",
-      "time": 1582762863
+      "time": 1583203692
     },
     "https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry": {
       "url": "https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry",
@@ -3206,7 +3126,7 @@
     },
     "https://www.seeedstudio.com/Grove-Water-Sensor.html": {
       "url": "https://www.seeedstudio.com/Grove-Water-Sensor.html",
-      "time": 1582762866
+      "time": 1583203695
     },
     "https://github.com/rickkas7/Adafruit_DotStarMatrix_RK": {
       "url": "https://github.com/rickkas7/Adafruit_DotStarMatrix_RK",
@@ -3426,7 +3346,7 @@
     },
     "https://github.com/particle-iot-archived/particle-dev": {
       "url": "https://github.com/particle-iot-archived/particle-dev",
-      "time": 1582762871
+      "time": 1583203698
     },
     "http://www.cplusplus.com/reference/cstdio/sscanf/": {
       "url": "http://www.cplusplus.com/reference/cstdio/sscanf/",
@@ -3495,15 +3415,59 @@
     "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200227%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200227T002106Z&X-Amz-Expires=300&X-Amz-Signature=f2c53f93777b92de0e7bc852428b4218b505cf5f5b2327347b61c8a040030b3c&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
       "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200227%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200227T002106Z&X-Amz-Expires=300&X-Amz-Signature=f2c53f93777b92de0e7bc852428b4218b505cf5f5b2327347b61c8a040030b3c&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
       "time": 1582762870
+    },
+    "https://store.particle.io/collections/cellular": {
+      "url": "https://store.particle.io/collections/cellular",
+      "time": 1583203442
+    },
+    "https://www.digikey.com/product-detail/en/bourns-inc/CVH252009-4R7M/CVH252009-4R7MCT-ND/3440080": {
+      "url": "https://www.digikey.com/product-detail/en/bourns-inc/CVH252009-4R7M/CVH252009-4R7MCT-ND/3440080",
+      "time": 1583203448
+    },
+    "https://www.digikey.com/product-detail/en/PRPC040SAAN-RC/S1011EC-40-ND/2775214": {
+      "url": "https://www.digikey.com/product-detail/en/PRPC040SAAN-RC/S1011EC-40-ND/2775214",
+      "time": 1583203448
+    },
+    "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=e4764a9ed69f02a3eee6f5404098": {
+      "url": "https://www.mathworks.com/help/thingspeak/writedata.html;jsessionid=e4764a9ed69f02a3eee6f5404098",
+      "time": 1583203458
+    },
+    "https://www.uuidtools.com/": {
+      "url": "https://www.uuidtools.com/",
+      "time": 1583203465
+    },
+    "https://www.digikey.com/product-detail/en/c-k/PTS645SH50SMTR92-LFS/CKN9085CT-ND/1146817": {
+      "url": "https://www.digikey.com/product-detail/en/c-k/PTS645SH50SMTR92-LFS/CKN9085CT-ND/1146817",
+      "time": 1583203473
+    },
+    "https://cocoapods.org/pods/Particle-SDK": {
+      "url": "https://cocoapods.org/pods/Particle-SDK",
+      "time": 1583203485
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200303T024811Z&X-Amz-Expires=300&X-Amz-Signature=a3f4884342ba237cd1b10c79d037ebe426bb1c822f55857bebb0474c3bc18767&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/144668320/ecf31b00-d66b-11e8-8169-c4043dbf7b0e?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200303T024811Z&X-Amz-Expires=300&X-Amz-Signature=a3f4884342ba237cd1b10c79d037ebe426bb1c822f55857bebb0474c3bc18767&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dargon-ncp-firmware-0.0.5-ota.bin&response-content-type=application%2Foctet-stream",
+      "time": 1583203696
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200303T024814Z&X-Amz-Expires=300&X-Amz-Signature=20a8d2282721c945c278124f96a78687f551fd7b54746d3905a5d330b5be6c3b&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-98e7-1f562d7af6ad?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200303T024814Z&X-Amz-Expires=300&X-Amz-Signature=20a8d2282721c945c278124f96a78687f551fd7b54746d3905a5d330b5be6c3b&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-tinker%401.2.1.bin&response-content-type=application%2Foctet-stream",
+      "time": 1583203697
+    },
+    "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200303T024814Z&X-Amz-Expires=300&X-Amz-Signature=78453ef534f6630f9326b98dc6c13e5153326bf2af03d516d0eac54b4d14b6dc&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream": {
+      "url": "https://github-production-release-asset-2e65be.s3.amazonaws.com/8720130/242f7500-a411-11e9-940f-ebaa17e8f1d5?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20200303%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20200303T024814Z&X-Amz-Expires=300&X-Amz-Signature=78453ef534f6630f9326b98dc6c13e5153326bf2af03d516d0eac54b4d14b6dc&X-Amz-SignedHeaders=host&actor_id=0&response-content-disposition=attachment%3B+filename%3Dboron-system-part1%401.2.1.bin&response-content-type=application%2Foctet-stream",
+      "time": 1583203697
+    },
+    "https://support.microsoft.com/en-us/help/15056/windows-32-64-bit-faq": {
+      "url": "https://support.microsoft.com/en-us/help/15056/windows-32-64-bit-faq",
+      "time": 1583203697
     }
   },
   "stats": {
-    "kept": 858,
-    "removed": 0,
-    "inCache": 8692,
-    "fetchAttempt": 2569,
-    "crawled": 249,
+    "kept": 855,
+    "removed": 19,
+    "inCache": 8170,
+    "fetchAttempt": 2551,
+    "crawled": 248,
     "errors": 0
   },
-  "success": 1582762873
+  "success": 1583203700
 }

--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -8675,7 +8675,7 @@ BleUuid healthThermometerService(0x1809);
 
 The value 0x1809 is from the assigned list of service IDs.
 
-The 128-bit UUIDs are used for your own custom services and characteristics. These are not assigned by any group. You can use any UUID generator, such as the [online UUID generator](https://www.uuidgenerator.net/) or tools that you run on your computer. There is no central registry; they are statistically unlikely to ever conflict.
+The 128-bit UUIDs are used for your own custom services and characteristics. These are not assigned by any group. You can use any UUID generator, such as the [online UUID generator](https://www.uuidtools.com/) or tools that you run on your computer. There is no central registry; they are statistically unlikely to ever conflict.
 
 A 128-bit (16 byte) UUID is often written like this: `240d5183-819a-4627-9ca9-1aa24df29f18`. It's a series of 32 hexadecimal digits (0-9, a-f) written in a 8-4-4-4-12 pattern. 
 

--- a/src/content/reference/discontinued/firmware-core.md
+++ b/src/content/reference/discontinued/firmware-core.md
@@ -8664,7 +8664,7 @@ BleUuid healthThermometerService(0x1809);
 
 The value 0x1809 is from the assigned list of service IDs.
 
-The 128-bit UUIDs are used for your own custom services and characteristics. These are not assigned by any group. You can use any UUID generator, such as the [online UUID generator](https://www.uuidgenerator.net/) or tools that you run on your computer. There is no central registry; they are statistically unlikely to ever conflict.
+The 128-bit UUIDs are used for your own custom services and characteristics. These are not assigned by any group. You can use any UUID generator, such as the [online UUID generator](https://www.uuidtools.com/) or tools that you run on your computer. There is no central registry; they are statistically unlikely to ever conflict.
 
 A 128-bit (16 byte) UUID is often written like this: `240d5183-819a-4627-9ca9-1aa24df29f18`. It's a series of 32 hexadecimal digits (0-9, a-f) written in a 8-4-4-4-12 pattern. 
 

--- a/src/content/tutorials/device-os/bluetooth-le.md
+++ b/src/content/tutorials/device-os/bluetooth-le.md
@@ -158,7 +158,7 @@ The data received handler has this prototype:
 void onDataReceived(const uint8_t* data, size_t len, const BlePeerDevice& peer, void* context)
 ```
 
-The 128-bit UUIDs are used for your own custom services and characteristics. These are not assigned by any group. You can use any UUID generator, such as the [online UUID generator](https://www.uuidgenerator.net/) or tools that you run on your computer. There is no central registry; they are statistically unlikely to ever conflict.
+The 128-bit UUIDs are used for your own custom services and characteristics. These are not assigned by any group. You can use any UUID generator, such as the [online UUID generator](https://www.uuidtools.com/) or tools that you run on your computer. There is no central registry; they are statistically unlikely to ever conflict.
 
 A 128-bit (16 byte) UUID is often written like this: `240d5183-819a-4627-9ca9-1aa24df29f18`. It's a series of 32 hexadecimal digits (0-9, a-f) written in a 8-4-4-4-12 pattern. The A-F can be uppercase or lowercase, they are not case-sensitive.
 

--- a/src/content/workshops/particle-101-workshop/ble.md
+++ b/src/content/workshops/particle-101-workshop/ble.md
@@ -45,7 +45,7 @@ const unsigned long UPDATE_INTERVAL = 2000;
 unsigned long lastUpdate = 0;
 ```
 <br />
-6. Now, add a UUID for the service, and three characteristic objects to represent uptime, signal strength, and free memory. <br /><br />The service UUID is arbitrary and you should change it from the default below using a UUID generator like the one [here](https://www.uuidgenerator.net/).
+6. Now, add a UUID for the service, and three characteristic objects to represent uptime, signal strength, and free memory. <br /><br />The service UUID is arbitrary and you should change it from the default below using a UUID generator like the one [here](https://www.uuidtools.com/).
 <br /><br />
 Keep track of the UUID you create here  because you'll need it in the next section as well. The Service UUIDs should remain unchanged.
   ```cpp


### PR DESCRIPTION
Replace link to uuid generator with link to open source version. The sites do the same thing but uuidtools.com is open source.