### PR TITLE
Web IDE Search Broken

### DIFF
--- a/src/content/community/forum.md
+++ b/src/content/community/forum.md
@@ -56,7 +56,7 @@ Stop by and join on of the best places online meet other people using Particle t
 
 ## Tools and SDKs
 
-- [Web IDE (Particle Build)](https://build.particle.io)
+- [Particle Web IDE](https://build.particle.io)
 - [Particle Console](https://console.particle.io)
 - [Desktop IDE (Particle Dev)](/tutorials/developer-tools/dev/)
 - [Particle Mobile App](/tutorials/developer-tools/tinker/)

--- a/src/content/datasheets/accessories/legacy-accessories.md
+++ b/src/content/datasheets/accessories/legacy-accessories.md
@@ -633,7 +633,7 @@ Note: The Ground pin may vary as Brown or Black, +5V pin may vary as Orange or R
 This is a 128x64 pixel graphic OLED screen that can be either controlled via the SPI (default) or I2C.
 
 **Sample code**
-- [Adafruit SSD1306 in the Particle Build Library](https://build.particle.io/libs/5397d8d028979ed3cc000731)
+- [Adafruit SSD1306 in the Particle Web IDE Library](https://build.particle.io/libs/5397d8d028979ed3cc000731)
 - https://github.com/pkourany/Adafruit_SSD1306
 
 **Specifications:**
@@ -722,7 +722,7 @@ The shield also has an on-board accelerometer, the LIS3DH. It's extremely low po
 The waterproof box includes two M4 screws for mounting the shield securely into the box. Screw the shield down in the enclosure, then plug the Electron into the shield with the USB connector facing inward. You can also look at the silkscreen Electron outline on the board for the correct orientation. The battery and antenna can be fixed in the box using the foam adhesive tape if you want to keep them from moving around.
 
 ### Asset tracker library
-We've put together a great library for you to start building from! If you're already logged into Build then you can just click on [AssetTracker library](https://build.particle.io/libs/AssetTracker/0.0.5/tab/example/1_GPS_Features.cpp) and you can always open the "Libraries" view in Build, and AssetTracker will show up under the Official Libraries. This library is especially good for learning about the Electron because it implements a couple of useful features, like a Particle.function for checking the battery level!
+We've put together a great library for you to start building from! If you're already logged into the Web IDE then you can just click on [AssetTracker library](https://build.particle.io/libs/AssetTracker/0.0.5/tab/example/1_GPS_Features.cpp) and you can always open the "Libraries" view in the Web IDE, and AssetTracker will show up under the Official Libraries. This library is especially good for learning about the Electron because it implements a couple of useful features, like a Particle.function for checking the battery level!
 
 Examples:
 1. __GPS Features__ - How to use the GPS efficiently, and some nice Electron functions
@@ -822,7 +822,7 @@ You can choose to mount the asset tracker board inside the provided enclosure as
 ![atv2](/assets/images/shields/asset-tracker-shield-v2/asset-enclosure.png)
 
 ### Electron Asset Tracker Library
-We've put together a great library for you to start building from! If you're already logged into Build then you can just click on [AssetTracker library](https://build.particle.io/libs/AssetTracker/0.0.10/tab/example/1_GPS_Features.ino) and you can always open the "Libraries" view in Build, and AssetTracker will show up under the Official Libraries. This library is especially good for learning about the Electron because it implements a couple of useful features, like a Particle.function for checking the battery level!
+We've put together a great library for you to start building from! If you're already logged into the Web IDE then you can just click on [AssetTracker library](https://build.particle.io/libs/AssetTracker/0.0.10/tab/example/1_GPS_Features.ino) and you can always open the "Libraries" view in the Web IDE, and AssetTracker will show up under the Official Libraries. This library is especially good for learning about the Electron because it implements a couple of useful features, like a Particle.function for checking the battery level!
 
 Examples:
 

--- a/src/content/datasheets/electron/e-series-datasheet.md
+++ b/src/content/datasheets/electron/e-series-datasheet.md
@@ -557,7 +557,7 @@ The E series comes pre-programmed with a bootloader and a user application calle
 
 The bootloader allows you to easily update the user application via several different methods, USB, OTA, Serial Y-Modem, and also internally via the Factory Reset procedure.  All of these methods have multiple tools associated with them as well.
 
-You may use the online Web IDE [Particle Build](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
+You may use the [Particle Web IDE](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
 
 ## Glossary
 |Term|Definition |

--- a/src/content/datasheets/electron/electron-datasheet.md
+++ b/src/content/datasheets/electron/electron-datasheet.md
@@ -624,7 +624,7 @@ The Electron comes pre-programmed with a bootloader and a user application calle
 
 The bootloader allows you to easily update the user application via several different methods, USB, OTA, Serial Y-Modem, and also internally via the Factory Reset procedure.  All of these methods have multiple tools associated with them as well.
 
-You may use the online Web IDE [Particle Build](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
+You may use the [Particle Web IDE](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
 
 ## Glossary
 |Term|Definition |

--- a/src/content/datasheets/wi-fi/p1-datasheet.md
+++ b/src/content/datasheets/wi-fi/p1-datasheet.md
@@ -563,7 +563,7 @@ The P1 module comes pre-programmed with a bootloader and a user application call
 
 The bootloader allows you to easily update the user application via several different methods, USB, OTA, Serial Y-Modem, and also internally via the Factory Reset procedure.  All of these methods have multiple tools associated with them as well.
 
-You may use the online Web IDE [Particle Build](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
+You may use the [Particle Web IDE](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
 
 ## Glossary
 

--- a/src/content/datasheets/wi-fi/photon-datasheet.md
+++ b/src/content/datasheets/wi-fi/photon-datasheet.md
@@ -568,7 +568,7 @@ The Photon comes preprogrammed with a bootloader and a user application called T
 
 The bootloader allows you to easily update the user application via several different methods, USB, OTA, Serial Y-Modem, and also internally via the Factory Reset procedure.  All of these methods have multiple tools associated with them as well.
 
-You may use the online Web IDE [Particle Build](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
+You may use the [Particle Web IDE](https://build.particle.io) to code, compile and flash a user application OTA (Over The Air). [Particle Workbench](/quickstart/workbench/) is a full-featured desktop IDE for Windows, Mac, and Linux based on VSCode and supports both cloud-based and local gcc-arm compiles. The [Particle CLI](/tutorials/developer-tools/cli/) provides a command-line interface for cloud-based compiles and flashing code over USB.
 
 
 ## Glossary

--- a/src/content/quickstart/aqmk-project.md
+++ b/src/content/quickstart/aqmk-project.md
@@ -71,7 +71,7 @@ Note: To operate effectively, the dust sensor must be placed in a vertical orien
 
 ## Creating a new project
 
-Now, let’s create a new project for the application firmware. The steps below assume you’re using Particle Workbench, though you can do all of the following using Particle Build.
+Now, let’s create a new project for the application firmware. The steps below assume you’re using Particle Workbench, though you can do all of the following using the Particle Web IDE.
 
 1. Open Particle Workbench. 
 

--- a/src/content/quickstart/button.md
+++ b/src/content/quickstart/button.md
@@ -45,9 +45,9 @@ Plug in your Photon and go through the [setup process](/quickstart/photon/).
 
 ## Examples
 
-You can find examples on how to use your Internet Button in the [official Internet Button library under the Libraries tab on Particle Build](https://build.particle.io/libs/InternetButton/0.1.11/tab/example/1_Blink_An_LED.cpp). You can also access them via [this GitHub repo](https://github.com/particle-iot/InternetButton/tree/master/examples), or by checking out the text below.
+You can find examples on how to use your Internet Button in the [official Internet Button library under the Libraries tab on the Particle Web IDE](https://build.particle.io/libs/InternetButton/0.1.11/tab/example/1_Blink_An_LED.cpp). You can also access them via [this GitHub repo](https://github.com/particle-iot/InternetButton/tree/master/examples), or by checking out the text below.
 
-You should be able to fork the examples from Particle Build or copy and paste the code from the GitHub repo or from this page. We recommend going through these examples in order for the best understanding of how the Internet Button works. If you haven't used Particle Build before, read the [Particle Build guide](/tutorials/developer-tools/build/).
+You should be able to fork the examples from the Particle Web IDE or copy and paste the code from the GitHub repo or from this page. We recommend going through these examples in order for the best understanding of how the Internet Button works. If you haven't used Particle Build before, read the [Particle Web IDE guide](/tutorials/developer-tools/build/).
 
 **If you copy and paste these examples, make sure that you include the official Internet Button library before flashing the code.** Instructions on how to include a library can be found [here](/tutorials/device-os/libraries/).
 

--- a/src/content/reference/device-cloud/api.md
+++ b/src/content/reference/device-cloud/api.md
@@ -140,7 +140,7 @@ curl -d access_token=38bb7b318cc6898c80317decb34525844bc9db55 \
 ## OAuth Clients
 
 An OAuth client generally represents an app.
-The Particle CLI is a client, as are Particle Build, the Particle iOS app, and
+The Particle CLI is a client, as are the Particle Web IDE, the Particle iOS app, and
 the Particle Android app. You too can create your own clients.
 You should create separate clients for each of your web and mobile apps that hit
 the Particle API.

--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -18021,8 +18021,8 @@ Parameters:
 
 The log handlers below are written by the community and are not considered "Official" Particle-supported log handlers. If you have any issues with them please raise an issue in the forums or, ideally, in the online repo for the handler.
 
-- [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Build](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
-- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Build](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
+- [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Web IDE](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
+- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Web IDE](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
 - More to come (feel free to add your own by editing the docs on GitHub)
 
 ### Logger Class
@@ -19937,7 +19937,7 @@ The following instructions are for upgrading to **Device OS v@FW_VER@** which re
 
 **Updating Device OS Automatically**
 
-To update your Photon or P1 Device OS version automatically, compile and flash your application in the [Build IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Photon, P1 and Electron can be found below.
+To update your Photon or P1 Device OS version automatically, compile and flash your application in the [Web IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Photon, P1 and Electron can be found below.
 
 ---
 

--- a/src/content/reference/discontinued/firmware-core.md
+++ b/src/content/reference/discontinued/firmware-core.md
@@ -16358,8 +16358,8 @@ Parameters:
 
 The log handlers below are written by the community and are not considered "Official" Particle-supported log handlers. If you have any issues with them please raise an issue in the forums or, ideally, in the online repo for the handler.
 
-- [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Build](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
-- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Build](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
+- [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Web IDE](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
+- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Web IDE](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
 - More to come (feel free to add your own by editing the docs on GitHub)
 
 ### Logger Class
@@ -18246,7 +18246,7 @@ The following instructions are for upgrading to **Device OS v@FW_VER@** which re
 
 **Updating Device OS Automatically**
 
-To update your Photon, P1 or Core Device OS version automatically, compile and flash your application in the [Build IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Core, Photon, P1 and Electron can be found below.
+To update your Photon, P1 or Core Device OS version automatically, compile and flash your application in the [Web IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Core, Photon, P1 and Electron can be found below.
 
 ---
 

--- a/src/content/reference/discontinued/firmware-xenon.md
+++ b/src/content/reference/discontinued/firmware-xenon.md
@@ -16877,8 +16877,8 @@ Parameters:
 
 The log handlers below are written by the community and are not considered "Official" Particle-supported log handlers. If you have any issues with them please raise an issue in the forums or, ideally, in the online repo for the handler.
 
-- [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Build](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
-- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Build](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
+- [Papertrail](https://papertrailapp.com/) Log Handler by [barakwei](https://community.particle.io/users/barakwei/activity). [[Particle Web IDE](https://build.particle.io/libs/585c5e64edfd74acf7000e7a/)] [[GitHub Repo](https://github.com/barakwei/ParticlePapertrail)] [[Known Issues](https://github.com/barakwei/ParticlePapertrail/issues/)]
+- Web Log Handler by [geeksville](https://github.com/geeksville). [[Particle Web IDE](https://build.particle.io/libs/ParticleWebLog)] [[GitHub Repo](https://github.com/geeksville/ParticleWebLog)] [[Known Issues](https://github.com/geeksville/ParticleWebLog/issues/)]
 - More to come (feel free to add your own by editing the docs on GitHub)
 
 ### Logger Class
@@ -18783,7 +18783,7 @@ The following instructions are for upgrading to **Device OS v@FW_VER@** which re
 
 **Updating Device OS Automatically**
 
-To update your Photon or P1 Device OS version automatically, compile and flash your application in the [Build IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Photon, P1 and Electron can be found below.
+To update your Photon or P1 Device OS version automatically, compile and flash your application in the [Web IDE](https://build.particle.io), selecting version **@FW_VER@** in the devices drawer. The app will be flashed, following by the system part1 and part2 firmware for Photon and P1. Other update instructions for Photon, P1 and Electron can be found below.
 
 ---
 

--- a/src/content/tutorials/developer-tools/build.md
+++ b/src/content/tutorials/developer-tools/build.md
@@ -1,5 +1,5 @@
 ---
-title: Web IDE (Build)
+title: Web IDE
 layout: tutorials.hbs
 columns: two
 redirects: true
@@ -7,32 +7,32 @@ order: 30
 description: Web-based IDE for programming your Particle IoT devices
 ---
 
-Flash Apps with Particle Build
+Flash Apps with the Particle Web IDE
 ===
 
 Logging In
 ---
 
-![Particle Build](/assets/images/ide-new-account.png)
+![Particle Web IDE](/assets/images/ide-new-account.png)
 
 When you're ready to reprogram your device, head over to our IDE:
 
-[Particle Build >](https://build.particle.io)
+[Particle Web IDE >](https://build.particle.io)
 
 Creating an account is a simple one-step process.  When presented with the login screen, click the "create account" text and fill out the form including your email address (careful!) and desired account password. That's it!
 
-![Particle Build](/assets/images/ide-login.png)
+![Particle Web IDE](/assets/images/ide-login.png)
 
-If you haven't logged into Particle Build before, click the "create account" text beneath the Log In button, and you'll be presented with a signup for existing users.  
+If you haven't logged into the Particle Web IDE before, click the "create account" text beneath the Log In button, and you'll be presented with a signup for existing users.  
 
 Web IDE
 ---
 
-![Particle Build](/assets/images/ide-main.png)
+![Particle Web IDE](/assets/images/ide-main.png)
 
-Particle Build is an Integrated Development Environment, or IDE; that means that you can do software development in an easy-to-use application, which just so happens to run in your web browser.
+The Particle Web IDE is an Integrated Development Environment, or IDE; that means that you can do software development in an easy-to-use application, which just so happens to run in your web browser.
 
-Particle Build starts with the navigation bar on the left. On the top, there are three buttons, which serve important functions:
+The Particle Web IDE starts with the navigation bar on the left. On the top, there are three buttons, which serve important functions:
 
 - **Flash**: Flashes the current code to the device. This initiates an *over-the-air firmware update* and loads the new software onto your device. **Note: Flashing OTA for the cellular devices uses data and should consider using flash over USB instead.**
 - **Verify**: This compiles your code without actually flashing it to the device; if there are any errors in your code, they will be shown in the debug console on the bottom of the screen.
@@ -56,9 +56,9 @@ Missing your keyboard shortcuts? [This cheatsheet will help.](https://github.com
 Particle Apps and Libraries
 ---
 
-![Particle Build](/assets/images/ide-apps.png)
+![Particle Web IDE](/assets/images/ide-apps.png)
 
-The heart of Particle Build is the "Particle Apps" section, which displays the name of the current app in your editor, as well as a list of your other applications and community-supported example apps.
+The heart of the Particle Web IDE is the "Particle Apps" section, which displays the name of the current app in your editor, as well as a list of your other applications and community-supported example apps.
 
 The application you've got open in the editor is displayed under the "Current App" header.  You'll notice that this empty application has only one file, but firmware with associated libraries/multiple files are fully supported.
 
@@ -69,7 +69,7 @@ From this pane, you've got a lot of buttons and actions available to you that ca
 - **Delete**: Click the "Remove App" button to remove it forever from your Particle library.
 
 - **Rename**: You can rename your Particle App by simply double-clicking on the title of your app under the "Current App" header.  You can modify the "Optional description" field in the same way.
-- **My Apps**: Tired of working on your current project?  Select the name of another app under the "My apps" header to open it in a tab of the Particle Build editor.
+- **My Apps**: Tired of working on your current project?  Select the name of another app under the "My apps" header to open it in a tab of the Particle Web IDE editor.
 
 - **Files**: This header lists all known files associated with the open application.  Click on a supporting file in your application to open it as an active tab in the editor.
 
@@ -81,7 +81,7 @@ Flashing Your First App
 
 The best way to get started with the IDE is to start writing code:
 
-- **Get Code**: Try clicking on the "Blink an LED" example under the "Example apps" header.  The Particle Build editor should display the code for the example application in an active tab.  Alternatively, you can copy and paste this snippet of code into a new application in the Build IDE.
+- **Get Code**: Try clicking on the "Blink an LED" example under the "Example apps" header.  The Particle Web IDE editor should display the code for the example application in an active tab.  Alternatively, you can copy and paste this snippet of code into a new application in the Web IDE.
 
 **NOTE**: Each over *over-the-air firmware update* on cellular devices counts towards your data allowance. You can also flash the devices locally [using our CLI](/reference/developer-tools/cli/#compiling-remotely-and-flashing-locally) over USB.
 
@@ -101,7 +101,7 @@ void loop() {
 }
 ```
 
-![Particle Build](/assets/images/enew-ide.png)
+![Particle Web IDE](/assets/images/enew-ide.png)
 
 
 - **Select Your Device**: If you have more than one device you have to make sure that you've selected which of your devices to flash code to.  Click on the "Devices" icon at the bottom left side of the navigation pane, then when you hover over device name the star will appear on the left. Click on it to set the device you'd like to update (it won't be visible if you have only one device). Once you've selected a device, the star associated with it will turn yellow. (If you only have one device, there is no need to select it, you can continue on to the next step).
@@ -118,7 +118,7 @@ void loop() {
 
 - **Flash**: Click the "Flash" button, and your code will be sent wirelessly to your device.  If the flash was successful, the LED on your device will begin flashing magenta.
 
-![Particle Build](/assets/images/ide-examples.png)
+![Particle Web IDE](/assets/images/ide-examples.png)
 
 - **Fork**: Wish the timing of that LED flash was a little bit faster?  Try clicking on the "Fork This Example" button after selecting the "Blink An LED" example application.  You've now got a personal copy of that application that you can modify, save, and flash to all of your devices.
 
@@ -129,7 +129,7 @@ Adding files to your app
 
 As your code base grows, you will naturally create libraries to better manage your firmware development. To add a file to your app, simply hit the "+" button located at the top right hand corner.
 
-![Particle Build](/assets/images/ide-add-files.png)
+![Particle Web IDE](/assets/images/ide-add-files.png)
 
 This will create two new tabs, one with `.h` and one with `.cpp` extension. You can read more about why we need both in [this C++ tutorial](http://www.learncpp.com/cpp-tutorial/19-header-files/).
 
@@ -153,9 +153,9 @@ When viewing a shared app you can either flash it to any of your devices or copy
 Account Information
 ---
 
-There are a couple of other neat bells and whistles in Particle Build.  The Particle Build IDE the best tool for viewing important information about your device, managing devices associated with your Particle account, and "unclaiming" them so they can be transferred to your friend.
+There are a couple of other neat bells and whistles in the Particle Web IDE.  The Particle Web IDE the best tool for viewing important information about your device, managing devices associated with your Particle account, and "unclaiming" them so they can be transferred to your friend.
 
-![Particle Build](/assets/images/ide-account.png)
+![Particle Web IDE](/assets/images/ide-account.png)
 
 - **Device ID**: You can view your device's ID by clicking on the "Device" icon at the bottom of the navigation pane, then clicking the dropdown arrow next to the device of interest.
 
@@ -163,7 +163,7 @@ There are a couple of other neat bells and whistles in Particle Build.  The Part
 
 Unclaiming a cellular device removes it from your account, but does not stop billing. As the claiming status and SIM are separate, you must also pause or release ownership of your SIM from the [console](https://console.particle.io) to stop billing.
 
-![Particle Build](/assets/images/ide-settings.png)
+![Particle Web IDE](/assets/images/ide-settings.png)
 
 
 Using Libraries
@@ -177,12 +177,12 @@ Particle libraries are hosted on GitHub, and can be easily accessed through thro
 
 To include a firmware library in your Particle project, open the library drawer, search for the corresponding library for your sensor or actuator, and click the `Include in Project` button. Including a library in your project will add the library dependency to the `project.properties` file that will be compiled with your project when it is verified or flashed to your target device.
 
-Read on for detailed instructions to include a firmware library in your Particle application with Build.
+Read on for detailed instructions to include a firmware library in your Particle application with the Web IDE.
 
 We have [a detailed reference guide about libraries](/tutorials/device-os/libraries/) but for now here's a step by step guide on how to include a library in the Web IDE.
 
 ##### Step 1 - Go to the Libraries tab
-Click on the libraries bookmark icon on the left hand side of the Build interface.
+Click on the libraries bookmark icon on the left hand side of the Web IDE interface.
 
 ![Bookmark icon](/assets/images/libraries-guide-bookmarkicon.png)
 
@@ -276,7 +276,7 @@ Troubleshooting
 
 ![Clear cache](/assets/images/ide-clear-cache.png)
 
-Particle Build uses a local cache to improve its performance. In some cases this may cause errors or outdated information about libraries. If you encounter similar symptoms try clearing the cache by going to **Settings** and clicking **Clear cache** button.
+The Particle Web IDE uses a local cache to improve its performance. In some cases this may cause errors or outdated information about libraries. If you encounter similar symptoms try clearing the cache by going to **Settings** and clicking **Clear cache** button.
 
 
 **Also**, check out and join our [community forums](http://community.particle.io/) for advanced help, tutorials, and troubleshooting.

--- a/src/content/tutorials/developer-tools/build.md
+++ b/src/content/tutorials/developer-tools/build.md
@@ -51,7 +51,18 @@ At the bottom, there are four more buttons to navigate through the IDE:
 Keyboard Shortcuts
 ---
 
-Missing your keyboard shortcuts? [This cheatsheet will help.](https://github.com/ajaxorg/ace/wiki/Default-Keyboard-Shortcuts)
+Here are the most useful keyboard shortcuts for the Web IDE.
+
+| Windows/Linux | Mac | Action |
+| --:|--:|--:|
+| Ctrl-F | Command-F | Find
+| Ctrl-K | Command-G | Find next
+| Ctrl-L | Command-L | Go to line
+| Ctrl-Z | Command-Z | Undo
+| Ctrl-Shift-Z | Command-Shift-Z | Redo
+| Ctrl-/ | Command-/ | Comment/uncomment selected lines
+
+Want to know all the keyboard shortcuts? [This cheatsheet will help.](https://github.com/ajaxorg/ace/wiki/Default-Keyboard-Shortcuts)
 
 Particle Apps and Libraries
 ---

--- a/src/content/tutorials/developer-tools/cli.md
+++ b/src/content/tutorials/developer-tools/cli.md
@@ -140,7 +140,7 @@ $ particle help keys
 If you're wanting to save data on your Electron you should definitely consider flashing your Electron over
 USB instead of OTA (over-the-air).
 
-Assuming you've compiled and downloaded the firmware binary from [Build IDE](https://build.particle.io) by clicking the cloud button next to the file name, you should
+Assuming you've compiled and downloaded the firmware binary from the [Web IDE](https://build.particle.io) by clicking the cloud button next to the file name, you should
 be able to use the Particle CLI, mentioned above, to flash your application firmware to your Electron *without using data.*
 
 Steps:

--- a/src/content/tutorials/developer-tools/dev.md
+++ b/src/content/tutorials/developer-tools/dev.md
@@ -49,7 +49,7 @@ To show the palette press `Command`+`Shift`+`P` keys together on a Mac or `Contr
 
 **Tip**: you can change toolbar's position in settings.
 
-There's also a toolbar on left side of IDE which contains shortcuts to the most frequently used commands like compiling and flashing (looks a lot like the one from [Web IDE (Build)](https://build.particle.io/), doesn't it?).
+There's also a toolbar on left side of IDE which contains shortcuts to the most frequently used commands like compiling and flashing (looks a lot like the one from the [Web IDE](https://build.particle.io/), doesn't it?).
 
 ### Logging In
 
@@ -153,7 +153,7 @@ Particle libraries are hosted on GitHub, and can be easily accessed through thro
 
 To include a firmware library in your Particle project, open the library drawer in the Desktop IDE, search for the corresponding library for your sensor or actuator, click the `Use` button, then select `Add to current project`. Adding a library in your project will add the library dependency to the `project.properties` file that will be compiled with your project when it is verified or flashed to your target device.
 
-Read on for detailed instructions to include a firmware library in your Particle application with Build.
+Read on for detailed instructions to include a firmware library in your Particle application with the Web IDE.
 
 We have [a detailed reference guide about libraries](/tutorials/device-os/libraries/) but for now here's a step by step guide on how to include a library in our Desktop IDE.
 

--- a/src/content/tutorials/developer-tools/workbench.md
+++ b/src/content/tutorials/developer-tools/workbench.md
@@ -668,7 +668,7 @@ Shows who you are logged in as. A small popup window will display in the lower r
 
 {{!-- See ch25559 --}}
 
-### From Particle Web IDE (Build)
+### From the Particle Web IDE
 
 One big change from the Web IDE is the lack of the icon bar on the left. Most replacements are available from the Command Palette (`cmd+shift+p` on Mac OS or `ctrl+shift+p` on Linux and Windows).
 

--- a/src/content/tutorials/device-cloud/webhooks.md
+++ b/src/content/tutorials/device-cloud/webhooks.md
@@ -84,7 +84,7 @@ The last step is getting your Particle device to publish the `temp` event with s
 
 ### Webhook firmware
 
-To get started, go to [Particle Build](https://build.particle.io). Create a new app called "TempWebhook."
+To get started, go to the [Particle Web IDE](https://build.particle.io). Create a new app called "TempWebhook."
 
 Copy/paste the following into your application's code:
 

--- a/src/content/tutorials/device-os/led.md
+++ b/src/content/tutorials/device-os/led.md
@@ -555,7 +555,7 @@ When your device is connected to {{network-type}} but not to the cloud, it will 
 
 #### I can't flash my device anymore
 
-Breathing green means that {{network-type}} is on, but you're not connected to the Particle cloud. Because of this, you cannot flash your device from the cloud. That includes Particle Build (Web IDE), Particle Workbench, and Particle CLI cloud-based flashing commands.
+Breathing green means that {{network-type}} is on, but you're not connected to the Particle cloud. Because of this, you cannot flash your device from the cloud. That includes the Particle Web IDE, Particle Workbench, and Particle CLI cloud-based flashing commands.
  
 Fortunately, you can usually get around this by entering safe mode, breathing magenta.
 

--- a/src/content/tutorials/device-os/libraries.md
+++ b/src/content/tutorials/device-os/libraries.md
@@ -232,7 +232,7 @@ Thank you!
 
 On January 23, 2017, Particle introduced a new version of our firmware library manager, requiring that libraries be migrated from the old library structure (v1) to our new library structure (v2).
 
-With our original firmware library manager, libraries could only be contributed and consumed through our Web IDE (Build). We’ve now upgraded the library manager behind the Web IDE, and made those libraries accessible in Particle Workbench and the Particle CLI.
+With our original firmware library manager, libraries could only be contributed and consumed through our Web IDE. We’ve now upgraded the library manager behind the Web IDE, and made those libraries accessible in Particle Workbench and the Particle CLI.
 
 Libraries under the new library format have the following features:
 

--- a/src/content/tutorials/integrations/google-maps.md
+++ b/src/content/tutorials/integrations/google-maps.md
@@ -151,7 +151,7 @@ collect and send network info to successfully fetch its location from
 Google Maps.
 
 
-#### Using Particle Build (Web IDE)
+#### Using the Particle Web IDE
 
 The quickest way to add the Google
 Maps firmware library is to start with the sample firmware application in the Web
@@ -311,9 +311,9 @@ This will flash the firmware to your electron locally (over USB) to
 prevent consuming data from over-the-air firmware updates.
 
 
-### Using Particle Build (Web IDE)
+### Using the Particle Web IDE
 
-If you want to use the examples in Particle Build (Web IDE), you need to copy and paste the example source into a new project and then add each of the libraries that it needs.
+If you want to use the examples in the Particle Web IDE, you need to copy and paste the example source into a new project and then add each of the libraries that it needs.
 
 For example, the oled-locator project has this project.properties.
 

--- a/src/content/workshops/photon-maker-kit-workshop/ch2.md
+++ b/src/content/workshops/photon-maker-kit-workshop/ch2.md
@@ -61,11 +61,11 @@ To build this circuit, you'll need the following items:
 
   ![](/assets/images/workshops/photon-maker-kit/02/login.png)
 
-2.  Once you log-in, you may be directed to the Particle home page. If so, [click here to navigate](https://build.particle.io) back to Particle Build.
+2.  Once you log-in, you may be directed to the Particle home page. If so, [click here to navigate](https://build.particle.io) back to the Particle Web IDE.
 
   ![](/assets/images/workshops/photon-maker-kit/02/particle-home.png)
 
-3.  When navigating to the Web IDE (Build), the first thing you'll see is an empty editor window for a new project and a prompt to give that project a name.
+3.  When navigating to the Web IDE, the first thing you'll see is an empty editor window for a new project and a prompt to give that project a name.
 
   ![](/assets/images/workshops/photon-maker-kit/02/newproject.png)
 
@@ -93,7 +93,7 @@ The bulk of your program, from state management, handling user input, reading fr
 
 ## Install the Onewire library
 
-1. Before reading from the temp sensors, we need to install the onewire library. In the Build IDE, you can work with libraries by clicking on the icon that looks like a bookmark.
+1. Before reading from the temp sensors, we need to install the onewire library. In the Web IDE, you can work with libraries by clicking on the icon that looks like a bookmark.
 
   ![](/assets/images/workshops/photon-maker-kit/02/06-libraries-tab.png)
 


### PR DESCRIPTION
Story details: https://app.clubhouse.io/particle/story/55960

Build hasn't been used as a brand for years so I updated the docs to say Web IDE.

Also added the list of most useful keyboard shortcuts for Web IDE.