### PR TITLE
Add neopo to community tools

### DIFF
--- a/src/content/community/community-tools.md
+++ b/src/content/community/community-tools.md
@@ -1,0 +1,16 @@
+---
+title: Community Supported Tools
+layout: community.hbs
+columns: two
+order: 25
+---
+
+# Community Supported Tools
+
+These tools can provide additional utility or alternative workflows for Particle development.
+
+Note that these tools have not been tested by Particle. If you develop an open-source tool that you would like to add to this page, please submit a pull request.
+
+## Neopo
+
+* [Neopo](https://nrobinson2000.github.io/neopo/) - A utility created by [Nathan Robinson](https://github.com/nrobinson2000) that leverages existing Particle tools to provide a command-line experience compatible with Workbench and Particle CLI for Linux, macOS, Windows, and Raspberry Pi.

--- a/src/content/community/community.md
+++ b/src/content/community/community.md
@@ -56,19 +56,3 @@ library it needs. Code level is Java-8. It should be trivial to use Java-7 or lo
 ## Xamarin
 
 * [Particle Xamarin Cloud SDK](https://github.com/michael-watson/particle-xamarin) - Enables Xamarin mobile apps apps to interact with Particle-powered connected products.
-
-# Community Supported Tools
-
-Note that these tools have not been tested by
-Particle. If you develop an open-source tool that you would
-like to add to this page, please submit a pull request.
-
-## po-util
-
-* [po-util is tool created by Nathan Robinson to provide a local development workflow for Linux and macOS](https://nrobinson2000.github.io/po-util/).  It can be downloaded on macOS using [Homebrew](http://brew.sh/).
-
-```sh
-$ brew tap nrobinson2000/po
-$ brew install po
-$ po install
-```

--- a/src/content/community/community.md
+++ b/src/content/community/community.md
@@ -51,8 +51,8 @@ library it needs. Code level is Java-8. It should be trivial to use Java-7 or lo
 
 ## Typescript
 
-* [Soft AP Setup library for Typescript by Mark Terrill](https://www.npmjs.com/package/softap-setup-ts) - Port of the [Particle SoftAP Setup library](https://github.com/particle-iot/softap-setup-js) to perform wireless setup of Particle devices
+* [Soft AP Setup library for Typescript by Mark Terrill](https://www.npmjs.com/package/softap-setup-ts) - Port of the [Particle SoftAP Setup library](https://github.com/particle-iot/softap-setup-js) to perform wireless setup of Particle devices.
 
 ## Xamarin
 
-* [Particle Xamarin Cloud SDK](https://github.com/michael-watson/particle-xamarin) - Enables Xamarin mobile apps apps to interact with Particle-powered connected products.
+* [Particle Xamarin Cloud SDK](https://github.com/michael-watson/particle-xamarin) - Enables Xamarin mobile apps to interact with Particle-powered connected products


### PR DESCRIPTION
Hello,

For the past month, I have been working on [neopo](https://github.com/nrobinson2000/neopo), an elegant replacement for [po-util](https://github.com/nrobinson2000/po), my popular CLI tool for managing a local Particle development environment. I've made many improvements to neopo [since I announced it on the forum](https://community.particle.io/t/neopo-a-lightweight-solution-for-local-particle-development/56378?u=nrobinson2000), and I think it is appropriate to update [the community section in the documentation](https://docs.particle.io/community/community/) to reflect that.

![](https://github.com/nrobinson2000/neopo/raw/master/docs/neopo-carbon.png)



