### PR TITLE
Change "timer.*" to "timerName"

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -12728,7 +12728,7 @@ Software Timers provide a way to have timed actions in your program.  FreeRTOS p
 // EXAMPLE
 SerialLogHandler logHandler;
 
-Timer timer(1000, print_every_second);
+Timer timerName(1000, print_every_second);
 
 void print_every_second()
 {
@@ -12738,7 +12738,7 @@ void print_every_second()
 
 void setup()
 {
-    timer.start();
+    timerName.start();
 }
 ```
 
@@ -12755,7 +12755,7 @@ Software timers run with a smaller stack (1024 bytes vs. 6144 bytes). This can l
 
 // SYNTAX
 
-`Timer timer(period, callback, one_shot)`
+`Timer timerName(period, callback, one_shot)`
 
 - `period` is the period of the timer in milliseconds  (unsigned int)
 - `callback` is the callback function which gets called when the timer expires.
@@ -12770,7 +12770,7 @@ Software timers run with a smaller stack (1024 bytes vs. 6144 bytes). This can l
 
 A class member function can be used as a callback using this syntax to create the timer:
 
-`Timer timer(period, callback, instance, one_shot)`
+`Timer timerName(period, callback, instance, one_shot)`
 
 - `period` is the period of the timer in milliseconds  (unsigned int)
 - `callback` is the class member function which gets called when the timer expires.
@@ -12801,7 +12801,7 @@ Starts a stopped timer (a newly created timer is stopped). If `start()` is calle
 
 ```cpp
 // EXAMPLE USAGE
-timer.start(); // starts timer if stopped or resets it if started.
+timerName.start(); // starts timer if stopped or resets it if started.
 
 ```
 
@@ -12813,7 +12813,7 @@ Stops a running timer.
 
 ```cpp
 // EXAMPLE USAGE
-timer.stop(); // stops a running timer.
+timerName.stop(); // stops a running timer.
 
 ```
 
@@ -12827,13 +12827,13 @@ Changes the period of a previously created timer. It can be called to change the
 
 ```cpp
 // EXAMPLE USAGE
-timer.changePeriod(1000); // Reset period of timer to 1000ms.
+timerName.changePeriod(1000); // Reset period of timer to 1000ms.
 
 ```
 
 {{since when="1.5.0"}}
 
-You can also specify a value using [chrono literals](#chrono-literals), for example: `timer.changePeriod(2min)` for 2 minutes. 
+You can also specify a value using [chrono literals](#chrono-literals), for example: `timerName.changePeriod(2min)` for 2 minutes. 
 
 ### reset()
 
@@ -12843,7 +12843,7 @@ Resets a timer.  If a timer is running, it will reset to "zero".  If a timer is 
 
 ```cpp
 // EXAMPLE USAGE
-timer.reset(); // reset timer if running, or start timer if stopped.
+timerName.reset(); // reset timer if running, or start timer if stopped.
 
 ```
 
@@ -12861,13 +12861,13 @@ Start, stop and reset a timer or change a timer's period (as above) BUT from wit
 
 ```cpp
 // EXAMPLE USAGE
-timer.startFromISR(); // WITHIN an ISR, starts timer if stopped or resets it if started.
+timerName.startFromISR(); // WITHIN an ISR, starts timer if stopped or resets it if started.
 
-timer.stopFromISR(); // WITHIN an ISR,stops a running timer.
+timerName.stopFromISR(); // WITHIN an ISR,stops a running timer.
 
-timer.resetFromISR(); // WITHIN an ISR, reset timer if running, or start timer if stopped.
+timerName.resetFromISR(); // WITHIN an ISR, reset timer if running, or start timer if stopped.
 
-timer.changePeriodFromISR(newPeriod);  // WITHIN an ISR, change the timer period.
+timerName.changePeriodFromISR(newPeriod);  // WITHIN an ISR, change the timer period.
 ```
 
 ### dispose()
@@ -12878,7 +12878,7 @@ Stop and remove a timer from the (max. 10) timer list, freeing a timer "slot" in
 
 ```cpp
 // EXAMPLE USAGE
-timer.dispose(); // stop and delete timer from timer list.
+timerName.dispose(); // stop and delete timer from timer list.
 
 ```
 
@@ -12892,7 +12892,7 @@ Returns `true` if the timer is in active state (pending), or `false` otherwise.
 
 ```cpp
 // EXAMPLE USAGE
-if (timer.isActive()) {
+if (timerName.isActive()) {
     // ...
 }
 ```


### PR DESCRIPTION
For new coders, seeing an example name of the instantiated timer can save a significant amount of headache and reduce the learning curve.