### PR TITLE
tracker-edge Tutorial: Fix git clone, fix command palette

### DIFF
--- a/src/content/tutorials/asset-tracking/tracker-edge-firmware.md
+++ b/src/content/tutorials/asset-tracking/tracker-edge-firmware.md
@@ -35,7 +35,7 @@ The Tracker Edge firmware can be downloaded from Github:
 You will probably want to use the command line as there are additional commands you need to run after cloning the source:
 
 ```bash
-git clone git@github.com:particle-iot/tracker-edge.git 
+git clone https://github.com/particle-iot/tracker-edge 
 cd tracker-edge
 git submodule update --init --recursive
 ```
@@ -43,7 +43,7 @@ git submodule update --init --recursive
 - Open Particle Workbench.
 - From the command palette, **Particle: Import Project**.
 - Run **Particle: Configure Workspace for Device**, select version 1.5.4-rc.1, 2.0.0-rc.3, or later, Tracker, and your device.
-- Run **Particle: Compile and Flash**.
+- Run **Particle: Flash application (local)**.
 
 ## Overview
 


### PR DESCRIPTION
A user on the forum had some difficulties cloning the repo and compiling/flashing the project due to inaccuracies in the tutorial.

https://community.particle.io/t/particle-workbench-did-not-install/58321/6?u=nrobinson2000