### PR TITLE
Add emphasis on voltage level

### DIFF
--- a/src/content/tutorials/learn-more/about-i2c.md
+++ b/src/content/tutorials/learn-more/about-i2c.md
@@ -90,7 +90,7 @@ This is different than SPI, which is 5V tolerant, but will only supply 3.3V on M
 
 The P1 module should not use I2C at 5V as there is an internal 2.1K hardware pull-up resistor to 3V3 inside the P1 module. This is only on the P1, not the Photon or P0.
 
-3rd-generation devices (Argon, Boron, and B Series SoM) **are not 5V tolerant** and must not be used with pull-ups to 5V!
+3rd-generation devices (Argon, Boron, and B Series SoM) **are not 5V tolerant** and **must not** be used with pull-ups to 5V!
 
 ### Pins
 


### PR DESCRIPTION
Add emphases to not use 5V pull-ups on the I2C bus.