### PR TITLE
Fix "loc.src" -> "src" in enhanced location docs

### DIFF
--- a/src/content/reference/device-cloud/api.md
+++ b/src/content/reference/device-cloud/api.md
@@ -624,7 +624,7 @@ The enhanced_loc event will have data the same as the original loc event, such a
 
 Note that loc.alt (altitude), loc.v_acc (vertical accuracy), loc.hd (heading), and loc.spd (speed) are not available for locations derived from location fusion, but if that information was in the original loc event from the GNSS, it will be preserved in the enhanced_loc event.
 
-#### loc.src
+#### src
 
 The sources used for enhanced geolocation, an array. Can be "cell" or "wifi" or both. Added in Tracker Edge v12.
 


### PR DESCRIPTION
From testing, it appears that the `src` field is added at the top level, not nested within the `loc` object