### PR TITLE
Fix broken Icomoon font link

### DIFF
--- a/templates/partials/head.hbs
+++ b/templates/partials/head.hbs
@@ -14,7 +14,7 @@
 
 <!-- Spark theme mods -->
 <link href='/assets/css/style.css' rel='stylesheet'>
-<link rel="stylesheet" href="https://s3.amazonaws.com/icomoon.io/49057/Dashboard/style.css?9t9e91">
+<link rel="stylesheet" href="https://d1azc1qln24ryf.cloudfront.net/49057/Dashboard/style-cf.css?vut8cd">
 
 {{#if canonical}}
 <link rel="canonical" href="{{canonical}}/" />

--- a/templates/partials/headNoSection.hbs
+++ b/templates/partials/headNoSection.hbs
@@ -6,8 +6,7 @@
 
 <!-- Spark theme mods -->
 <link href='/assets/css/style.css' rel='stylesheet'>
-<link rel="stylesheet" href="https://s3.amazonaws.com/icomoon.io/49057/Dashboard/style.css?9t9e91">
-
+<link rel="stylesheet" href="https://d1azc1qln24ryf.cloudfront.net/49057/Dashboard/style-cf.css?vut8cd">
 <!-- Meta -->
 <meta content="Particle" property="og:title">
 <meta content="Documentation for Particle, a platform for connected devices." name="description">


### PR DESCRIPTION
Fixes a 404 not found error on the docs trying to load the Icomoon font. This is an icon font used in the Console. The S3 link is no longer available and it must be loaded from Cloudfront.

Steps to test:
- Check that https://docs.particle.io/tutorials/product-tools/device-groups/#creating-device-groups shows the group icon in the parentheses.
![image](https://user-images.githubusercontent.com/1919681/123890820-e7265b00-d925-11eb-9155-b6e6821db79d.png)
