### PR TITLE
Added missing ; in getSoC example

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -4109,7 +4109,7 @@ Returns the battery voltage as a `float`. Returns -1.0 if the fuel gauge cannot 
 
 ```cpp
 // PROTOTYPE
-float getSoC() 
+float getSoC(); 
 
 // EXAMPLE
 FuelGauge fuel;


### PR DESCRIPTION
Added the missing semicolon to the getSoC prototype in the example:

original:
```cpp
float getSoC() 
```
modified:
```cpp
float getSoC();
```