### PR TITLE
Added missing ; to getNormalizedSoC example

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -4132,7 +4132,7 @@ It may be preferable to use [`System.batteryCharge()`](#batterycharge-) instead 
 
 ```cpp
 // PROTOTYPE
-float getNormalizedSoC()
+float getNormalizedSoC();
 ```
 
 Returns the State of Charge in percentage from 0-100% as a `float`, normalized based on the charge voltage. Returns -1.0 if the fuel gauge cannot be read.


### PR DESCRIPTION
Added the missing semicolon to the getNormalizedSoC prototype example. 

Original:
```cpp
float getNormalizedSoC()
```

Modified:
```cpp
float getNormalizedSoC();
```