### PR TITLE
Remove extra call to hasPendingErase in docs

### DIFF
--- a/src/content/reference/device-os/firmware.md
+++ b/src/content/reference/device-os/firmware.md
@@ -15364,9 +15364,7 @@ run without rebooting for a long time.
 // EXAMPLE USAGE
 void setup() {
   // Erase full EEPROM page at boot when necessary
-  if(EEPROM.hasPendingErase()) {
-    EEPROM.performPendingErase();
-  }
+  EEPROM.performPendingErase();
 }
 ```
 


### PR DESCRIPTION
performPendingErase already checks hasPendingErase so there's no need to document checking for a pending erase before requesting the erase:
https://github.com/particle-iot/device-os/blob/0bc16d94772999c016aa4c70c1b330f53321f90f/services/inc/eeprom_emulation.h#L245