### PR TITLE
Improve contrast on api docs page

### DIFF
--- a/src/assets/less/api.less
+++ b/src/assets/less/api.less
@@ -1,7 +1,7 @@
 .content ul.api-attributes {
 	&::before {
 		text-transform: uppercase;
-		color: @another-gray;
+		color: @NC_SPACE_GRAY;
 		font-size: 12px;
 		line-height: 30px;
 	}
@@ -55,7 +55,7 @@
 
 	small {
 		display: block;
-		color: @another-gray;
+		color: @NC_SPACE_GRAY;
 		text-transform: lowercase;
 		font-size: 12px;
 	}
@@ -107,7 +107,7 @@
 	background-color: @super-dark-gray;
 
 	&::before {
-		color: @another-gray;
+		color: @NC_HAZE;
 		background-color: @NC_HEADER;
 		display: block;
 		margin: 0 -40px;

--- a/src/assets/less/variables.less
+++ b/src/assets/less/variables.less
@@ -451,7 +451,6 @@
 @super-dark-gray: @NC_MIDNIGHT; //
 @dark-gray: @NC_HEADER; // #333333
 @gray: @NC_COOL_GRAY; // #777777
-@another-gray: @NC_HAZE; // #999999
 @light-gray: @NC_MORNING_MIST; // #C7C7C7
 // @very-light-gray: #DDDDDD;
 @clouds: @NC_ALMOST_WHITE; // #ECF0F1


### PR DESCRIPTION
The request/response sections and types in the API docs were hard to read in pale gray so I made them darker.

Before:
![image](https://user-images.githubusercontent.com/1919681/169137322-9572de03-4171-4a31-82c0-454a8b1d5a7f.png)

After:
![image](https://user-images.githubusercontent.com/1919681/169137440-ca4d47f7-b222-4db8-bf0c-fed752af8581.png)
