### PR TITLE
Simplify keys commands

### DIFF
--- a/src/content/notes/status-led-blinking-cyan.md
+++ b/src/content/notes/status-led-blinking-cyan.md
@@ -23,5 +23,5 @@ Then put the device in DFU mode by holding down both the {{reset-button}} and {{
 
 ```
 particle keys server
-particle keys doctor YOUR_DEVICE_ID
+particle keys doctor
 ```

--- a/src/content/reference/developer-tools/cli.md
+++ b/src/content/reference/developer-tools/cli.md
@@ -1122,12 +1122,15 @@ If you are downgrading a Boron LTE (BRN402) or B Series SoM B402 from Device OS 
 
 ### particle keys doctor
 
-Helps you update your keys, or recover your device when the keys on the server are out of sync with the keys on your device.  The ```particle keys``` tools requires both dfu-util, and openssl to be installed.
+Helps you update your keys, or recover your device when the keys on the server are out of sync with the keys on your device.  The ```particle keys``` tools requires openssl to be installed.
 
-Connect your device in [DFU mode](/troubleshooting/led/#dfu-mode-device-firmware-upgrade-), and run this command to replace the unique cryptographic keys on your device.  Automatically attempts to send the new public key to the cloud as well.
+Connect your device, and run this command to replace the unique cryptographic keys on your device.  Automatically sends the new public key to the cloud as well.
 
 ```sh
-# helps repair key issues on a device
+# helps repair key issues on the connected device
+$ particle keys doctor
+
+# repair key issues on a specific connected device
 $ particle keys doctor 0123456789abcdef78901234
 ```
 
@@ -1136,82 +1139,89 @@ See also [`particle device doctor`](#particle-device-doctor)
 
 ### particle keys new
 
-Generates a new public / private key pair that can be used on a device.
+Generates a new public / private key pair that can be used on the connected device. The ```particle keys``` tools requires openssl to be installed.
 
 ```sh
 # generates a new public/private keypair
 $ particle keys new
-running openssl genrsa -out device.pem 1024
-running openssl rsa -in device.pem -pubout -out device.pub.pem
-running openssl rsa -in device.pem -outform DER -out device.der
-New Key Created!
+New key 0123456789abcdef78901234.der created for device 0123456789abcdef78901234
 
 # generates a new public/private keypair with the filename mykey
 $ particle keys new mykey
-running openssl genrsa -out mykey.pem 1024
-running openssl rsa -in mykey.pem -pubout -out mykey.pub.pem
-running openssl rsa -in mykey.pem -outform DER -out mykey.der
-New Key Created!
+New key mykey.der created for device 0123456789abcdef78901234
 ```
 
 
 ### particle keys load
 
-Copies a ```.DER``` formatted private key onto your device's external flash.  Make sure your device is connected and in [DFU mode](/troubleshooting/led/#dfu-mode-device-firmware-upgrade-).  The ```particle keys``` tools requires both dfu-util, and openssl to be installed.  Make sure any key you load is sent to the cloud with ```particle keys send device.pub.pem```
+Copies a ```.der``` formatted private key onto your device's external flash. It defaults to using the file ```<deviceID>.der``` or you can specify a key file on the command line. The ```particle keys``` tools requires openssl to be installed.  Make sure any key you load is sent to the cloud with ```particle keys send device.pub.pem```
 
 ```sh
+# loads a key named after your device
+$ particle keys load
+Saved existing key to backup_ec_0123456789abcdef78901234.der
+Key 0123456789abcdef78901234.der written to device
+
 # loads a key to your device via USB
-# make sure your device is connected and blinking yellow
-# requires dfu-util
-$ particle keys load device.der
-...
-Saved!
+$ particle keys load mykey.der
+Saved existing key to backup_ec_0123456789abcdef78901234.der
+Key mykey.der written to device
 ```
 
 
 ### particle keys save
 
-Copies a ```.DER``` formatted private key from your device's external flash to your computer.  Make sure your device is connected and in [DFU mode](/troubleshooting/led/#dfu-mode-device-firmware-upgrade-).  The ```particle keys``` tools requires both dfu-util, and openssl to be installed.
+Copies a ```.der``` formatted private key from your device's external flash to your computer.  It defaults to saving the key to a file named ```<deviceID>.der``` or you can specify a filename on the command line. The ```particle keys``` tools requires openssl to be installed.
 
 ```sh
-# creates a backup of the private key from your device to a file
-# requires dfu-util
-$ particle keys save device.der
-...
-Saved!
+# creates a backup of the private key from your device
+$ particle keys save
+Saved existing key to 0123456789abcdef78901234.der
+
+# creates a backup of the private key from your device to named file
+$ particle keys save backup.der
+Saved existing key to backup.der
 ```
 
 
 ### particle keys send
 
-Sends a device's public key to the cloud for use in opening an encrypted session with your device.  Please make sure your device has the corresponding private key loaded using the ```particle keys load``` command.
+Sends a device's public key to the cloud for use in opening an encrypted session with your device.  Please make sure your device has the corresponding private key loaded using the ```particle keys load``` command. The ```particle keys``` tools requires openssl to be installed.
 
 ```sh
-# sends a new public key to the API for use for your device
-$ particle keys send 0123456789abcdef78901234 device.pub.pem
+# sends a new public key to the API for the connected device
+$ particle keys send
+attempting to add a new public key for device 0123456789abcdef78901234
+submitting public key succeeded!
+
+# sends a new public key to the API for use for another device
+$ particle keys send 0123456789abcdef78901234 device.der
+attempting to add a new public key for device 0123456789abcdef78901234
 submitting public key succeeded!
 ```
 
 
 ### particle keys server
 
-Switches the server public key stored on the device's external flash. This command is important when changing which server your device is connecting to, and the server public key helps protect your connection. Your device will stay in DFU mode after this command, so that you can load new firmware to connect to your server. By default this will only change the server key associated with the default protocol for a device. If you wish to change a specific protocol, add `--protocol tcp` or `--protocol udp` to the end of your command.
+Switches the server public key stored on the device's external flash. This command is important when changing which server your device is connecting to, and the server public key helps protect your connection. Your device will stay in DFU mode after this command, so that you can load new firmware to connect to your server. By default this will only change the server key associated with the default protocol for a device.
 
 
 ```sh
+# change the server key
 $ particle keys server my_server.der
-$ particle keys server my_server.der --protocol udp
+
+# restore the default server key
+$ particle keys server
 ```
 
 
 #### Encoding a server address and port
 
-When using the local cloud you can ask the CLI to encode the IP or dns address into your key to control where your device will connect. You may also specify a port number to be included.
+When using the local cloud you can ask the CLI to encode the IP or DNS address into your key to control where your device will connect. You may also specify a port number to be included.
 
 ```sh
-$ particle keys server my_server.pub.pem 192.168.1.10
-$ particle keys server my_server.der 192.168.1.10 9000
-$ particle keys server my_server.der 192.168.1.10 9000 --protocol udp
+$ particle keys server my_server.der --host 192.168.1.10
+$ particle keys server my_server.der --host 192.168.1.10 --port 9000
 ```
 
 
@@ -1221,22 +1231,7 @@ Reads and displays the server address, port, and protocol from a device.
 
 ```sh
 $ particle keys address
-
-tcp://device.spark.io:5683
-```
-
-
-### particle keys protocol
-
-Views or changes the transport protocol used to communicate with the cloud. Available options are `tcp` and `udp` for Electrons (if you are running at least firmware version 0.4.8).
-
-```sh
-# determine the current protocol
-$ particle keys protocol
-
-# set the protocol to tcp or udp
-$ particle keys protocol tcp
-$ particle keys protocol udp
+udp://$id.udp.particle.io:5684
 ```
 
 

--- a/src/content/troubleshooting/connectivity/interpreting-cloud-debug.md
+++ b/src/content/troubleshooting/connectivity/interpreting-cloud-debug.md
@@ -652,7 +652,7 @@ If the server public key is corrupted you might see a message like: `WARN: unabl
 0000024251 [system] INFO: Cloud: disconnecting
 ```
 
-This is corrected by putting the device in DFU mode (blinking yellow) and using:
+This is corrected by using:
 
 ```
 particle keys server

--- a/src/content/troubleshooting/guides/device-management/repairing-product-device-keys.md
+++ b/src/content/troubleshooting/guides/device-management/repairing-product-device-keys.md
@@ -52,7 +52,7 @@ On Gen 3 devices, if the SPI flash or Little FS file system becomes corrupted or
 
 ```
 particle keys server  
-particle keys doctor [deviceid]
+particle keys doctor
 ```
 
 The most common way to repair the keys is using these two CLI commands. The caveat is that the CLI must be logged into the account that the device is claimed to. This is the normal situation for development devices, as they're typically your device, and you are logged into your own account.

--- a/src/content/troubleshooting/guides/device-troubleshooting/device-blinking-cyan.md
+++ b/src/content/troubleshooting/guides/device-troubleshooting/device-blinking-cyan.md
@@ -38,13 +38,11 @@ The device \*will\* generate a new private and public device key. (They have to 
 
 ## How to backup/save your key
 
-1. Place your into DFU mode by holding Mode and tapping Reset, then continue holding Mode for about 3 seconds until the LED starts flashing Yellow.
-2. Run the `particle keys save mykey.der` command. This will backup the key on your to the Home folder on your computer. You can substitute your own naming convention for the \*.der file if you wish.
+Run the `particle keys save mykey.der` command. This will backup the key on your to the Home folder on your computer. You can substitute your own naming convention for the \*.der file if you wish.
 
 ## How to restore/load your key
 
-1. Place your into DFU mode by holding Mode and tapping Reset, then continue holding Mode for about 3 seconds until the LED starts flashing Yellow.
-2. Run the `particle keys load mykey.der` command. This will restore the key you saved previously to your Home directory to your . The file may not necessarily be named mykey.der, substitute whatever you backed it up as previously with the `particle keys save` command.
+Run the `particle keys load mykey.der` command. This will restore the key you saved previously to your Home directory to your . The file may not necessarily be named mykey.der, substitute whatever you backed it up as previously with the `particle keys save` command.
 
 ## How to change your key
 
@@ -52,9 +50,6 @@ If you have physical access to the in question, here's how to change the Key on 
 
 1. Before we can start, you're going to want to install the Particle CLI tool to make life easier: [Particle CLI.](/getting-started/developer-tools/cli/)
 2. Once the CLI tool is installed, the first thing you should do is log in to your Particle account. To login on the Particle CLI, run the command `particle login` and follow the prompts for email and password.
-3. Next we need to get the Device ID of your device. Start by putting the device into Listening Mode by holding the Mode button for about 3 seconds until it starts blinking BLUE.
-4. Next run the following CLI command to get the ID of your device: `particle identify`. It should reply "Your device id is: xxxxxxxxxxxxxxxxxx". Copy the number down or to your clipboard for later.
-5. View the key commands and example output here for the next steps: [particle keys doctor.](/reference/developer-tools/cli/#particle-keys-doctor)
-6. Place your into DFU mode by holding Mode and tapping Reset, then continue holding Mode for about 3 seconds until the LED starts flashing Yellow.
-7. It's a good idea to run the `particle keys server` command in case your server keys or address are corrupted.
-8. Run the `particle keys doctor xxxxx` command, where xxxxx is the device ID you copied just earlier. This will generate a new public/private key pair and automatically download it to your device, and also send the public key up to the Cloud.
+3. View the key commands and example output here for the next steps: [particle keys doctor.](/reference/developer-tools/cli/#particle-keys-doctor)
+4. It's a good idea to run the `particle keys server` command in case your server keys or address are corrupted.
+5. Run the `particle keys doctor` command. This will generate a new public/private key pair and automatically download it to your device, and also send the public key up to the Cloud.

--- a/src/content/troubleshooting/led.md
+++ b/src/content/troubleshooting/led.md
@@ -663,7 +663,7 @@ Then put the device in DFU mode by holding down both the {{reset-button}} and {{
 
 ```
 particle keys server
-particle keys doctor YOUR_DEVICE_ID
+particle keys doctor
 ```
 
 If you get this error under Windows:
@@ -676,7 +676,7 @@ it may work if you do:
 
 ```html
 cd c:\OpenSSL-Win32\bin
-particle keys doctor YOUR_DEVICE_ID
+particle keys doctor
 ```
 
 There are additional tips for a [missing openssl error on this page](https://github.com/rickkas7/particle_notes/tree/master/installing-openssl), including tips for Mac OS (OS X) and Linux.


### PR DESCRIPTION
As of next CLI release, `particle keys` command will switch the device to DFU automatically and won't require to type the device name. So if you have one connected device, you can just type `particle keys doctor` or `particle keys save && particle keys send`

The `--protocol` option is removed since no device actually supports multiple protocols.