### PR TITLE
feat: [sc-127947] Update API docs to include query and body parameters

### DIFF
--- a/config/sitemap.json
+++ b/config/sitemap.json
@@ -1155,8 +1155,8 @@
             "hash": "74b9315484be16ea70298a49d15ff440f68b636eb3074af419bb725240c7204e"
         },
         "reference/cloud-apis/javascript.md": {
-            "date": "2024-04-18",
-            "hash": "52fd67eed145af146f05f501be0d7c509f3f18b02507f56e7b3e59b86eaa984f"
+            "date": "2024-05-16",
+            "hash": "d91629ebb1cee06b2dbdb9c38bc9c9f83623f5e2e3b2901a9a8f6c79eaf31c95"
         },
         "reference/cloud-apis/node-js.md": {
             "date": "2023-03-17",

--- a/config/sitemap.json
+++ b/config/sitemap.json
@@ -1139,8 +1139,8 @@
             "hash": "3365c544cbe9b5f2e389145a088d91eb0881ede71a5f863ec6d49a05838fc72e"
         },
         "reference/cloud-apis/api.md": {
-            "date": "2024-05-13",
-            "hash": "e310e5ca2a5b6defce35b58af75502365770e9d95a110420a5adf06f0f058b62"
+            "date": "2024-05-16",
+            "hash": "365cebd2389866279f7913855f3559b686110687eaf97e8ca0393aa9be3f3414"
         },
         "reference/cloud-apis/authentication.md": {
             "date": "2023-07-12",

--- a/generated/api-service-libraries.json
+++ b/generated/api-service-libraries.json
@@ -5,74 +5,77 @@
     "title": "List libraries",
     "name": "listLibraries",
     "description": "<p>List firmware libraries. This includes private libraries visibile only to the user.</p>",
-    "group": "Libraries_1",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "filter",
-            "description": "<p>Search for libraries with this partial name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"1\""
-            ],
-            "optional": true,
-            "field": "page",
-            "description": "<p>Page number</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"10\""
-            ],
-            "optional": true,
-            "field": "limit",
-            "description": "<p>Items per page (max 100)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"popularity\""
-            ],
-            "optional": true,
-            "field": "sort",
-            "description": "<p>Sort order for results. Prefix with <code>-</code> for descending order.</p> <ul> <li><code>name</code></li> <li><code>installs</code></li> <li><code>popularity</code></li> <li><code>published</code></li> <li><code>updated</code></li> <li><code>created</code></li> <li><code>official</code></li> <li><code>verified</code></li> </ul>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"all\""
-            ],
-            "optional": true,
-            "field": "scope",
-            "description": "<p>Which subset of libraries to list.</p> <ul> <li><code>all</code> to retrieve public libraries and any private libraries belonging to the user</li> <li><code>official</code> to retrieve official public libraries</li> <li><code>public</code> to retrieve public libraries</li> <li><code>mine</code> to retrieve only public libraries belonging to the current user</li> <li><code>private</code> to retrieve only private libraries (belonging to the current user).</li> </ul>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "excludeScopes",
-            "description": "<p>Which subsets of libraries to avoid listing, separated by comma. Same values as <code>scope</code>.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "architectures",
-            "description": "<p>Architectures to list, separated by comma. Missing means all architectures.</p>"
-          }
-        ]
+    "group": "Libraries.1",
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "filter",
+        "isArray": false,
+        "description": "<p>Search for libraries with this partial name</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"1\""
+        ],
+        "optional": true,
+        "field": "page",
+        "isArray": false,
+        "description": "<p>Page number</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"10\""
+        ],
+        "optional": true,
+        "field": "limit",
+        "isArray": false,
+        "description": "<p>Items per page (max 100)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"popularity\""
+        ],
+        "optional": true,
+        "field": "sort",
+        "isArray": false,
+        "description": "<p>Sort order for results. Prefix with <code>-</code> for descending order.</p> <ul> <li><code>name</code></li> <li><code>installs</code></li> <li><code>popularity</code></li> <li><code>published</code></li> <li><code>updated</code></li> <li><code>created</code></li> <li><code>official</code></li> <li><code>verified</code></li> </ul>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"all\""
+        ],
+        "optional": true,
+        "field": "scope",
+        "isArray": false,
+        "description": "<p>Which subset of libraries to list.</p> <ul> <li><code>all</code> to retrieve public libraries and any private libraries belonging to the user</li> <li><code>official</code> to retrieve official public libraries</li> <li><code>public</code> to retrieve public libraries</li> <li><code>mine</code> to retrieve only public libraries belonging to the current user</li> <li><code>private</code> to retrieve only private libraries (belonging to the current user).</li> </ul>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "excludeScopes",
+        "isArray": false,
+        "description": "<p>Which subsets of libraries to avoid listing, separated by comma. Same values as <code>scope</code>.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "architectures",
+        "isArray": false,
+        "description": "<p>Architectures to list, separated by comma. Missing means all architectures.</p>"
       }
-    },
+    ],
     "success": {
       "fields": {
         "Success 200": [
@@ -81,6 +84,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "data",
+            "isArray": true,
             "description": "<p>Array of library objects. Described in <a href=\"#get-library-details\">Get library details</a></p>"
           }
         ]
@@ -93,44 +97,24 @@
         }
       ]
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/libraries?scope=official&sort=name&access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/libraries?scope=official&sort=name&access_token=1234\"",
+        "title": "$ curl \"https://api.particle.io/v1/libraries?scope=official&sort=name\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/libraries?scope=official&sort=name\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service-libraries/src/LibrariesController.js",
-    "groupTitle": "Libraries_1"
+    "filename": "src/LibrariesController.js",
+    "groupTitle": "Libraries.1"
   },
   {
     "type": "get",
-    "url": "/v1/libraries/:libraryName:",
+    "url": "/v1/libraries/:libraryName",
     "title": "Get library details",
     "name": "getLibrary",
     "description": "<p>Get details for a firmware library.</p>",
-    "group": "Libraries_2",
+    "group": "Libraries.2",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -139,31 +123,36 @@
             "type": "String",
             "optional": false,
             "field": "libraryName",
+            "isArray": false,
             "description": "<p>Name of library to retrieve (case insensitive)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"latest\""
-            ],
-            "optional": true,
-            "field": "version",
-            "description": "<p>Version to retrieve. Defaults to the latest version.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"all\""
-            ],
-            "optional": true,
-            "field": "scope",
-            "description": "<p>Which subset of versions to get.</p> <ul> <li><code>all</code></li> <li><code>public</code></li> <li><code>private</code></li> </ul>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"latest\""
+        ],
+        "optional": true,
+        "field": "version",
+        "isArray": false,
+        "description": "<p>Version to retrieve. Defaults to the latest version.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"all\""
+        ],
+        "optional": true,
+        "field": "scope",
+        "isArray": false,
+        "description": "<p>Which subset of versions to get.</p> <ul> <li><code>all</code></li> <li><code>public</code></li> <li><code>private</code></li> </ul>"
+      }
+    ],
     "success": {
       "fields": {
         "Success 200": [
@@ -172,27 +161,49 @@
             "type": "object",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>The library version in <a href=\"http://jsonapi.org/\">JSON API format</a></p>"
           },
           {
             "group": "Success 200",
             "type": "string",
             "optional": false,
+            "parentNode": {
+              "path": "data",
+              "field": "data",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "data.id",
+            "isArray": false,
             "description": "<p>The name of the library</p>"
           },
           {
             "group": "Success 200",
             "type": "string",
             "optional": false,
+            "parentNode": {
+              "path": "data",
+              "field": "data",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "data.links.download",
+            "isArray": false,
             "description": "<p>The URL to download the files for this library</p>"
           },
           {
             "group": "Success 200",
             "type": "string",
             "optional": false,
+            "parentNode": {
+              "path": "data",
+              "field": "data",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "data.attributes",
+            "isArray": false,
             "description": "<p>Additional meta data for the library. Not all fields are available for every library.</p>"
           }
         ]
@@ -205,44 +216,24 @@
         }
       ]
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/libraries/internetbutton?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/libraries/internetbutton?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/libraries/internetbutton \\",
+        "content": "$ curl https://api.particle.io/v1/libraries/internetbutton \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service-libraries/src/LibrariesController.js",
-    "groupTitle": "Libraries_2"
+    "filename": "src/LibrariesController.js",
+    "groupTitle": "Libraries.2"
   },
   {
     "type": "get",
-    "url": "/v1/libraries/:libraryName:/versions",
+    "url": "/v1/libraries/:libraryName/versions",
     "title": "Get library versions",
     "name": "getLibraryVersions",
     "description": "<p>Get details for all versions of a firmware library.</p>",
-    "group": "Libraries_3",
+    "group": "Libraries.3",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -251,21 +242,25 @@
             "type": "String",
             "optional": false,
             "field": "libraryName",
+            "isArray": false,
             "description": "<p>Name of library to retrieve (case insensitive)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"all\""
-            ],
-            "optional": true,
-            "field": "scope",
-            "description": "<p>Which subset of versions to get.</p> <ul> <li><code>all</code></li> <li><code>public</code></li> <li><code>private</code></li> </ul>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"all\""
+        ],
+        "optional": true,
+        "field": "scope",
+        "isArray": false,
+        "description": "<p>Which subset of versions to get.</p> <ul> <li><code>all</code></li> <li><code>public</code></li> <li><code>private</code></li> </ul>"
+      }
+    ],
     "success": {
       "fields": {
         "Success 200": [
@@ -274,6 +269,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "data",
+            "isArray": true,
             "description": "<p>Array of library version objects. Described in <a href=\"#get-library-details\">Get library details</a></p>"
           }
         ]
@@ -286,37 +282,24 @@
         }
       ]
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
+    "examples": [
+      {
+        "title": "$ curl https://api.particle.io/v1/libraries/internetbutton\\versions \\",
+        "content": "$ curl https://api.particle.io/v1/libraries/internetbutton\\versions \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      }
+    ],
     "version": "0.0.0",
-    "filename": "api-service-libraries/src/LibrariesController.js",
-    "groupTitle": "Libraries_3"
+    "filename": "src/LibrariesController.js",
+    "groupTitle": "Libraries.3"
   },
   {
     "type": "post",
-    "url": "/v1/libraries/:libraryName:",
+    "url": "/v1/libraries/:libraryName",
     "title": "Upload library version",
     "name": "uploadLibrary",
     "description": "<p>Upload a private version of a firmware library. If the library doesn't exist it is created.</p> <p>The library will be validated and an error response returned if invalid.</p>",
-    "group": "Libraries_4",
+    "group": "Libraries.4",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -325,18 +308,22 @@
             "type": "String",
             "optional": false,
             "field": "libraryName",
+            "isArray": false,
             "description": "<p>Name of library to retrieve (case insensitive)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "File",
-            "optional": false,
-            "field": "archive",
-            "description": "<p>A tar-gzip archive of all the files for the library.</p> <p>The meta data like name and version is taken from <code>library.properties.</code> See <a href=\"https://github.com/spark/uber-library-example\">the example library</a> for other files to include.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "File",
+        "optional": false,
+        "field": "archive",
+        "isArray": false,
+        "description": "<p>A tar-gzip archive of all the files for the library.</p> <p>The meta data like name and version is taken from <code>library.properties.</code> See <a href=\"https://github.com/spark/uber-library-example\">the example library</a> for other files to include.</p>"
+      }
+    ],
     "success": {
       "fields": {
         "Success 200": [
@@ -345,6 +332,7 @@
             "type": "Object",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>The library version created. Described in <a href=\"#get-library-details\">Get library details</a></p>"
           }
         ]
@@ -357,30 +345,10 @@
         }
       ]
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
-        "title": "$ curl -F \"archive=@library.tar.gz\" \"https://api.particle.io/v1/libraries?access_token=1234\"",
-        "content": "$ curl -F \"archive=@library.tar.gz\" \"https://api.particle.io/v1/libraries?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/libraries \\",
+        "content": "$ curl https://api.particle.io/v1/libraries \\\n       -F \"archive=@library.tar.gz\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -394,16 +362,16 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service-libraries/src/LibrariesController.js",
-    "groupTitle": "Libraries_4"
+    "filename": "src/LibrariesController.js",
+    "groupTitle": "Libraries.4"
   },
   {
     "type": "patch",
-    "url": "/v1/libraries/:libraryName:",
+    "url": "/v1/libraries/:libraryName",
     "title": "Make a library version public",
     "name": "publishLibrary",
     "description": "<p>Make the latest private version of a firmware library public. You must do this before others can access your uploaded library.</p>",
-    "group": "Libraries_5",
+    "group": "Libraries.5",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -412,18 +380,22 @@
             "type": "String",
             "optional": false,
             "field": "libraryName",
+            "isArray": false,
             "description": "<p>Name of library to retrieve (case insensitive)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "visibility",
-            "description": "<p>Must be set to <code>public</code> to publish a library.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "visibility",
+        "isArray": false,
+        "description": "<p>Must be set to <code>public</code> to publish a library.</p>"
+      }
+    ],
     "success": {
       "fields": {
         "Success 200": [
@@ -432,6 +404,7 @@
             "type": "Object",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>The library version published. Described in <a href=\"#get-library-details\">Get library details</a></p>"
           }
         ]
@@ -444,35 +417,15 @@
         }
       ]
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
-        "title": "$ curl -X PATCH -d \"visibility=public\" \"https://api.particle.io/v1/libraries/testlib43?access_token=1234\"",
-        "content": "$ curl -X PATCH -d \"visibility=public\" \"https://api.particle.io/v1/libraries/testlib43?access_token=1234\"",
+        "title": "$ curl -X PATCH https://api.particle.io/v1/libraries/testlib43 \\",
+        "content": "$ curl -X PATCH https://api.particle.io/v1/libraries/testlib43 \\\n       -d \"visibility=public\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service-libraries/src/LibrariesController.js",
-    "groupTitle": "Libraries_5"
+    "filename": "src/LibrariesController.js",
+    "groupTitle": "Libraries.5"
   }
 ]

--- a/generated/api-service.json
+++ b/generated/api-service.json
@@ -4,7 +4,7 @@
     "url": "/oauth/token",
     "title": "Generate an access token",
     "description": "<p>Creates an access token that gives you access to the Cloud API.</p> <p>You must give a valid OAuth client ID and secret in HTTP Basic Auth or in the <code>client_id</code> and <code>client_secret</code> parameters. For controlling your own developer account, you can use <code>particle:particle</code>. Otherwise use a valid OAuth Client ID and Secret. This endpoint doesn't accept JSON requests, only form encoded requests. See <a href=\"#oauth-clients\">OAuth Clients</a>.</p> <p>Refresh tokens only work for product tokens, and even then they are not particularly useful. In order to generate a new access token from the refresh token you still need the client ID and secret. Because of this, it's simpler to just generate a new token, and then you don't need to remember and keep secure the refresh token. Also refresh tokens have a lifetime of 14 days, much shorter than the default access token lifetime of 90 days.</p>",
-    "group": "Authentication_1",
+    "group": "Authentication.1",
     "header": {
       "fields": {
         "Header": [
@@ -12,67 +12,80 @@
             "group": "Header",
             "type": "String",
             "optional": false,
+            "field": "Content-Type",
+            "isArray": false,
+            "defaultValue": "application/x-www-form-urlencoded",
+            "description": "<p>Must be set to <code>application/x-www-form-urlencoded</code></p>"
+          },
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
             "field": "Authorization",
+            "isArray": false,
             "description": "<p>HTTP Basic Auth where username is the OAuth client ID and password is the OAuth client secret. Any client ID will work, but we suggest <code>particle:particle</code>.</p>"
           }
         ]
       }
     },
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_id",
-            "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_secret",
-            "description": "<p>OAuth client secret. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "grant_type",
-            "description": "<p>OAuth grant type. Usually <code>password</code>.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "username",
-            "description": "<p>Your Particle account username</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>Your Particle account password</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "expires_in",
-            "description": "<p>How many seconds the token will be valid for. <code>0</code> means forever. Short lived tokens are better for security.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Date",
-            "optional": true,
-            "field": "expires_at",
-            "description": "<p>When should the token expire? This should be an ISO8601 formatted date string.</p>"
-          }
-        ]
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "client_id",
+        "isArray": false,
+        "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "client_secret",
+        "isArray": false,
+        "description": "<p>OAuth client secret. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "grant_type",
+        "isArray": false,
+        "description": "<p>OAuth grant type. Usually <code>password</code>.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "username",
+        "isArray": false,
+        "description": "<p>Your Particle account username</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>Your Particle account password</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": true,
+        "field": "expires_in",
+        "isArray": false,
+        "description": "<p>How many seconds the token will be valid for. <code>0</code> means forever. Short lived tokens are better for security.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Date",
+        "optional": true,
+        "field": "expires_at",
+        "isArray": false,
+        "description": "<p>When should the token expire? This should be an ISO8601 formatted date string.</p>"
       }
-    },
+    ],
     "examples": [
       {
         "title": "$ curl https://api.particle.io/oauth/token \\",
@@ -88,23 +101,23 @@
             "type": "String",
             "optional": false,
             "field": "access_token",
+            "isArray": false,
             "description": "<p>The magical token you will use for all the other requests</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
-            "allowedValues": [
-              "bearer"
-            ],
             "optional": false,
             "field": "token_type",
-            "description": ""
+            "isArray": false,
+            "description": "<p>Always set to &quot;Bearer&quot;</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
             "field": "expires_in",
+            "isArray": false,
             "description": "<p>The number of seconds this token is valid for. Defaults to 7776000 seconds (90 days) if unspecified in the request. <code>0</code> means forever.</p>"
           },
           {
@@ -112,6 +125,7 @@
             "type": "String",
             "optional": false,
             "field": "refresh_token",
+            "isArray": false,
             "description": "<p>Used to generate a new access token when it has expired.</p>"
           }
         ]
@@ -132,6 +146,7 @@
             "type": "String",
             "optional": false,
             "field": "error",
+            "isArray": false,
             "description": "<p>The machine readable code identifying the error</p>"
           },
           {
@@ -139,6 +154,7 @@
             "type": "String",
             "optional": false,
             "field": "error_description",
+            "isArray": false,
             "description": "<p>The human readable reason for the error</p>"
           },
           {
@@ -146,6 +162,7 @@
             "type": "String",
             "optional": false,
             "field": "mfa_token",
+            "isArray": false,
             "description": "<p>The two-factor authentication state code that must be sent back with the one-time password</p>"
           }
         ]
@@ -164,8 +181,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Authentication_1",
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Authentication.1",
     "name": "PostOauthToken"
   },
   {
@@ -173,8 +190,8 @@
     "url": "/v1/access_tokens",
     "title": "List access tokens",
     "name": "ListAccessTokens",
-    "description": "<p>Retrieve a list of all the issued access tokens for your account</p>",
-    "group": "Authentication_4",
+    "description": "<p>Retrieve a list of all the issued access tokens for your account</p> <p>Note: Pass your Particle username and password using HTTP Basic Auth.</p>",
+    "group": "Authentication.4",
     "header": {
       "fields": {
         "Header": [
@@ -183,24 +200,22 @@
             "type": "String",
             "optional": false,
             "field": "Authorization",
+            "isArray": false,
             "description": "<p>Your Particle username and password</p>"
           }
         ]
       }
     },
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "otp",
-            "description": "<p>Token given from your MFA device. Usually 6 digits long</p>"
-          }
-        ]
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "otp",
+        "isArray": false,
+        "description": "<p>Token given from your MFA device. Usually 6 digits long</p>"
       }
-    },
+    ],
     "success": {
       "fields": {
         "Success 200": [
@@ -209,27 +224,49 @@
             "type": "Object[]",
             "optional": false,
             "field": "-",
+            "isArray": true,
             "description": "<p>List of access tokens</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-",
+              "field": "-",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "-.token",
+            "isArray": false,
             "description": "<p>Access token</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-",
+              "field": "-",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "-.expires_at",
+            "isArray": false,
             "description": "<p>Date the token expires and is no longer valid</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-",
+              "field": "-",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "-.client",
+            "isArray": false,
             "description": "<p>Client program used to create the token</p>"
           }
         ]
@@ -250,8 +287,8 @@
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Authentication_4"
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Authentication.4"
   },
   {
     "type": "delete",
@@ -265,14 +302,15 @@
             "type": "String",
             "optional": false,
             "field": "token",
+            "isArray": false,
             "description": "<p>Access Token to delete</p>"
           }
         ]
       }
     },
-    "description": "<p>Delete your unused or lost tokens.</p>",
+    "description": "<p>Delete your unused or lost tokens. Note: Pass your Particle username and password using HTTP Basic Auth.</p> <p>DEPRECATED. Use the <code>DELETE /v1/access_tokens/current</code> endpoint instead.</p>",
     "name": "DeleteAccessToken",
-    "group": "Authentication_5",
+    "group": "Authentication.5",
     "header": {
       "fields": {
         "Header": [
@@ -281,6 +319,7 @@
             "type": "String",
             "optional": false,
             "field": "Authorization",
+            "isArray": false,
             "description": "<p>Your Particle username and password</p>"
           }
         ]
@@ -294,7 +333,8 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
-            "description": "<p>Whether or not the token was deleted</p>"
+            "isArray": false,
+            "description": "<p>Whether the token was deleted</p>"
           }
         ]
       },
@@ -314,8 +354,8 @@
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Authentication_5"
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Authentication.5"
   },
   {
     "type": "delete",
@@ -323,7 +363,7 @@
     "title": "Delete all active access tokens",
     "description": "<p>Delete all your active access tokens.</p>",
     "name": "DeleteActiveAccessTokens",
-    "group": "Authentication_6",
+    "group": "Authentication.6",
     "success": {
       "fields": {
         "Success 200": [
@@ -332,7 +372,8 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
-            "description": "<p>Whether or not the tokens were deleted</p>"
+            "isArray": false,
+            "description": "<p>Whether the tokens were deleted</p>"
           }
         ]
       },
@@ -346,14 +387,14 @@
     },
     "examples": [
       {
-        "title": "$ curl -X DELETE \"https://api.particle.io/v1/access_tokens?access_token=123abc\"",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/access_tokens?access_token=123abc\"",
+        "title": "$ curl -X DELETE https://api.particle.io/v1/access_tokens -H \"Authorization: Bearer :access_token\"",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/access_tokens -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Authentication_6"
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Authentication.6"
   },
   {
     "type": "delete",
@@ -361,7 +402,7 @@
     "title": "Delete current access token",
     "description": "<p>Delete your currently used token.</p>",
     "name": "DeleteCurrentAccessToken",
-    "group": "Authentication_6",
+    "group": "Authentication.6",
     "success": {
       "fields": {
         "Success 200": [
@@ -370,7 +411,8 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
-            "description": "<p>Whether or not the token was deleted</p>"
+            "isArray": false,
+            "description": "<p>Whether the token was deleted</p>"
           }
         ]
       },
@@ -384,14 +426,14 @@
     },
     "examples": [
       {
-        "title": "$ curl -X DELETE \"https://api.particle.io/v1/access_tokens/current?access_token=123abc\"",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/access_tokens/current?access_token=123abc\"",
+        "title": "$ curl -X DELETE https://api.particle.io/v1/access_tokens/current \\",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/access_tokens/current \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Authentication_6"
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Authentication.6"
   },
   {
     "type": "get",
@@ -399,7 +441,7 @@
     "title": "Get the current access token information",
     "description": "<p>Get your currently used token.</p>",
     "name": "GetCurrentAccessToken",
-    "group": "Authentication_6",
+    "group": "Authentication.6",
     "success": {
       "fields": {
         "Success 200": [
@@ -408,6 +450,7 @@
             "type": "String",
             "optional": false,
             "field": "expires_in",
+            "isArray": false,
             "description": "<p>The number of seconds this token is valid for. <code>0</code> means forever.</p>"
           },
           {
@@ -415,6 +458,7 @@
             "type": "String",
             "optional": false,
             "field": "client",
+            "isArray": false,
             "description": "<p>Client program used to create the token.</p>"
           },
           {
@@ -422,6 +466,7 @@
             "type": "Array",
             "optional": false,
             "field": "scopes",
+            "isArray": false,
             "description": "<p>List of scopes for this token.</p>"
           },
           {
@@ -429,6 +474,7 @@
             "type": "Array",
             "optional": false,
             "field": "orgs",
+            "isArray": false,
             "description": "<p>List of orgs this token has access to.</p>"
           }
         ]
@@ -443,26 +489,40 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/access_tokens/current?access_token=123abc\"",
-        "content": "$ curl \"https://api.particle.io/v1/access_tokens/current?access_token=123abc\"",
+        "title": "$ curl https://api.particle.io/v1/access_tokens/current -H \"Authorization: Bearer :access_token\"",
+        "content": "$ curl https://api.particle.io/v1/access_tokens/current -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Authentication_6"
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Authentication.6"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/config",
     "title": "Get product configuration",
     "name": "GetProductConfig",
-    "group": "Configuration_1",
+    "group": "Configuration.1",
     "description": "<p>Get the configuration values that are the default for the product</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/1234/config?access_token=abc123\"",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/config?access_token=abc123\"",
+        "title": "$ curl https://api.particle.io/v1/products/1234/config -H \"Authorization: Bearer :access_token\"",
+        "content": "$ curl https://api.particle.io/v1/products/1234/config -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -485,20 +545,42 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_1"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.1"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/config/:deviceId",
     "title": "Get device configuration",
     "name": "GetDeviceConfig",
-    "group": "Configuration_2",
+    "group": "Configuration.2",
     "description": "<p>Get the configuration values that are specific to this device</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>The device ID to query.</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/1234/config/abc123?access_token=abc123\"",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/config/abc123?access_token=abc123\"",
+        "title": "$ curl https://api.particle.io/v1/products/1234/config/abc123 -H \"Authorization: Bearer :access_token\"",
+        "content": "$ curl https://api.particle.io/v1/products/1234/config/abc123 -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -510,20 +592,35 @@
             "type": "Object",
             "optional": false,
             "field": "configuration",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "configuration",
+              "field": "configuration",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "configuration.current",
+            "isArray": false,
             "description": "<p>The device's current confirmed configuration</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "configuration",
+              "field": "configuration",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "configuration.pending",
+            "isArray": false,
             "description": "<p>The configuration this device will be updated to</p>"
           }
         ]
@@ -546,21 +643,35 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_2"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.2"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/config",
     "title": "Get product schema",
     "name": "GetProductConfigSchema",
-    "group": "Configuration_3",
+    "group": "Configuration.3",
     "permission": [
       {
         "name": "configuration:get"
       }
     ],
     "description": "<p>Get the possible values that can be configured for this product, in JSON Schema format</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          }
+        ]
+      }
+    },
     "header": {
       "fields": {
         "Header": [
@@ -569,15 +680,17 @@
             "type": "String",
             "optional": false,
             "field": "Accept",
-            "description": "<p>must be set to &quot;application/schema+json&quot; for this endpoint</p>"
+            "isArray": false,
+            "defaultValue": "application/schema+json",
+            "description": "<p>Must be set to &quot;application/schema+json&quot; for this endpoint</p>"
           }
         ]
       }
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/1234/config?access_token=abc123\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/config?access_token=abc123\" \\\n       -H \"Accept: application/schema+json\"",
+        "title": "$ curl https://api.particle.io/v1/products/1234/config \\",
+        "content": "$ curl https://api.particle.io/v1/products/1234/config \\\n       -H \"Accept: application/schema+json\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -591,21 +704,43 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_3"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.3"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/config/:deviceId",
     "title": "Get device schema",
     "name": "GetDeviceConfigSchema",
-    "group": "Configuration_4",
+    "group": "Configuration.4",
     "permission": [
       {
         "name": "configuration:get"
       }
     ],
     "description": "<p>Get the possible values that can be configured for one device in this product, in JSON Schema format</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>The device ID to query.</p>"
+          }
+        ]
+      }
+    },
     "header": {
       "fields": {
         "Header": [
@@ -614,6 +749,8 @@
             "type": "String",
             "optional": false,
             "field": "Accept",
+            "isArray": false,
+            "defaultValue": "application/schema+json",
             "description": "<p>Must be set to &quot;application/schema+json&quot; for this endpoint</p>"
           }
         ]
@@ -621,8 +758,8 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/1234/config/abc123?access_token=abc123\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/config/abc123?access_token=abc123\" \\\n       -H \"Accept: application/schema+json\"",
+        "title": "$ curl https://api.particle.io/v1/products/1234/config/abc123 \\",
+        "content": "$ curl https://api.particle.io/v1/products/1234/config/abc123 \\\n       -H \"Accept: application/schema+json\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -636,25 +773,54 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_4"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.4"
   },
   {
     "type": "delete",
     "url": "/v1/products/:productIdOrSlug/config",
     "title": "Delete product configuration schema",
     "name": "DeleteProductConfigSchema",
-    "group": "Configuration_5",
+    "group": "Configuration.5",
     "permission": [
       {
         "name": "configuration:update"
       }
     ],
     "description": "<p>Delete configuration schema, use Tracker Edge defaults.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          }
+        ]
+      }
+    },
+    "header": {
+      "fields": {
+        "Header": [
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Content-Type",
+            "isArray": false,
+            "defaultValue": "application/schema+json",
+            "description": "<p>Must be set to &quot;application/schema+json&quot; for this endpoint.</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
         "title": "$ curl -X DELETE \"https://api.particle.io/v1/products/1234/config\" \\",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/1234/config\" \\\n       -H \"Authorization: Bearer ACCESS-TOKEN-HERE\" \\\n       -H \"Content-Type: application/schema+json\" \\\n       -d '{}'",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/1234/config\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/schema+json\" \\\n       -d '{}'",
         "type": "bash"
       }
     ],
@@ -668,15 +834,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_5"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.5"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/config",
     "title": "Set product configuration",
     "name": "SetProductConfig",
-    "group": "Configuration_5",
+    "group": "Configuration.5",
     "permission": [
       {
         "name": "configuration:update"
@@ -688,17 +854,29 @@
         "Parameter": [
           {
             "group": "Parameter",
-            "optional": true,
-            "field": "deviceIds",
-            "description": "<p>an array of deviceIDs to limit this update to.  If the request has no other content the devices will be reset to use the product defaults.</p>"
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "deviceIds",
+        "isArray": true,
+        "description": "<p>an array of deviceIDs to limit this update to.  If the request has no other content the devices will be reset to use the product defaults.</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config?access_token=abc123\" \\",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config?access_token=abc123\" \\\n       -H \"Content-Type: application/json\" \\\n       -d \"{\\\"location\\\":{\\\"radius\\\":5.0}}\"",
+        "title": "$ curl -X PUT https://api.particle.io/v1/products/1234/config \\",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/1234/config \\\n       -H \"Content-Type: application/json\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -d \"{\\\"location\\\":{\\\"radius\\\":5.0}}\"",
         "type": "bash"
       }
     ],
@@ -712,21 +890,50 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_5"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.5"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/config",
     "title": "Set product configuration schema",
     "name": "SetProductConfigSchema",
-    "group": "Configuration_5",
+    "group": "Configuration.5",
     "permission": [
       {
         "name": "configuration:update"
       }
     ],
     "description": "<p>Set configuration schema that will become the default for the product.</p> <p>This must be the entire schema, including the standard Particle parts; there is no merging of changes.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          }
+        ]
+      }
+    },
+    "header": {
+      "fields": {
+        "Header": [
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Content-Type",
+            "isArray": false,
+            "defaultValue": "application/schema+json",
+            "description": "<p>Must be set to &quot;application/schema+json&quot; for this endpoint.</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
         "title": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config\" \\",
@@ -753,25 +960,62 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_5"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.5"
   },
   {
     "type": "delete",
     "url": "/v1/products/:productIdOrSlug/config/:deviceId",
     "title": "Delete device configuration schema",
     "name": "DeleteDeviceConfigSchema",
-    "group": "Configuration_6",
+    "group": "Configuration.6",
     "permission": [
       {
         "name": "configuration:update"
       }
     ],
     "description": "<p>Delete device's configuration schema, use product's.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>The device ID to delete the schema.</p>"
+          }
+        ]
+      }
+    },
+    "header": {
+      "fields": {
+        "Header": [
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Content-Type",
+            "isArray": false,
+            "defaultValue": "application/schema+json",
+            "description": "<p>Must be set to &quot;application/schema+json&quot; for this endpoint.</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
         "title": "$ curl -X DELETE \"https://api.particle.io/v1/products/1234/config/43210\" \\",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/1234/config/43210\" \\\n       -H \"Authorization: Bearer ACCESS-TOKEN-HERE\" \\\n       -H \"Content-Type: application/schema+json\" \\\n       -d '{}'",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/1234/config/43210\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/schema+json\" \\\n       -d '{}'",
         "type": "bash"
       }
     ],
@@ -785,25 +1029,47 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_6"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.6"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/config/:deviceId",
     "title": "Set device configuration",
     "name": "SetDeviceConfig",
-    "group": "Configuration_6",
+    "group": "Configuration.6",
     "permission": [
       {
         "name": "configuration:update"
       }
     ],
     "description": "<p>Set some configuration values for the device that will override the product default.</p> <p>Send an empty request to reset the device to product defaults.</p> <p>Returns 200, 202 or 400 for various states</p> <ul> <li>200 when the device is online and accepted the configuration changes.</li> <li>202 when the device is offline. We'll complete the request when it comes online again</li> <li>400 When the device is online, but has rejected some of the configuration keys.  A list of accepted and rejected keys with device error codes is provided</li> </ul> <p>You should always get the entire configuration, change values, and set the whole configuration back. In HTTP REST APIs, POST and PUT do not merge changes with the existing data.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
-        "title": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config/abc123?access_token=abc123\" \\",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config/abc123?access_token=abc123\" \\\n       -H \"Content-Type: application/json\" \\\n       -d \"{\\\"location\\\":{\\\"radius\\\":5.0}}\"",
+        "title": "$ curl -X PUT https://api.particle.io/v1/products/1234/config/abc123 \\",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/1234/config/abc123 \\\n       -H \"Content-Type: application/json\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -d \"{\\\"location\\\":{\\\"radius\\\":5.0}}\"",
         "type": "bash"
       }
     ],
@@ -831,25 +1097,62 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_6"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.6"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/config/:deviceId",
     "title": "Set device configuration schema",
     "name": "SetDeviceSchema",
-    "group": "Configuration_6",
+    "group": "Configuration.6",
     "permission": [
       {
         "name": "configuration:update"
       }
     ],
     "description": "<p>Set configuration schema for the device.</p> <p>This must be the entire schema, including the standard Particle parts; there is no merging of changes.</p>",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
+          }
+        ]
+      }
+    },
+    "header": {
+      "fields": {
+        "Header": [
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
+            "field": "Content-Type",
+            "isArray": false,
+            "defaultValue": "application/schema+json",
+            "description": "<p>Must be set to &quot;application/schema+json&quot; for this endpoint.</p>"
+          }
+        ]
+      }
+    },
     "examples": [
       {
         "title": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config/43210\" \\",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config/43210\" \\\n       -H \"Authorization: Bearer ACCESS-TOKEN-HERE\" \\\n       -H \"Content-Type: application/schema+json\" \\\n       -d '{\n               \"$schema\": \"https://particle.io/draft-07/schema#\",\n               \"type\": \"object\",\n               \"title\": \"Fake Custom Schema\",\n               \"description\": \"A customized JSON schema for testing\",\n               \"required\": [\n                   \"foo\"\n               ],\n               \"properties\": {\n                   \"foo\": {\n                       \"$id\": \"#/properties/foo\",\n                       \"type\": \"integer\",\n                       \"title\": \"Foo\",\n                       \"description\": \"A test setting named `foo`\",\n                       \"default\": 1,\n                       \"examples\": [1, 2, 3],\n                       \"minimum\": 0\n                   },\n                   \"bar\": {\n                       \"$id\": \"#/properties/bar\",\n                       \"type\": \"string\",\n                       \"title\": \"Bar\",\n                       \"description\": \"A test setting named `bar`\",\n                       \"default\": \"\",\n                       \"examples\": [\"one\", \"two\", \"three\"]\n                   }\n               }\n          }'",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/1234/config/43210\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/schema+json\" \\\n       -d '{\n               \"$schema\": \"https://particle.io/draft-07/schema#\",\n               \"type\": \"object\",\n               \"title\": \"Fake Custom Schema\",\n               \"description\": \"A customized JSON schema for testing\",\n               \"required\": [\n                   \"foo\"\n               ],\n               \"properties\": {\n                   \"foo\": {\n                       \"$id\": \"#/properties/foo\",\n                       \"type\": \"integer\",\n                       \"title\": \"Foo\",\n                       \"description\": \"A test setting named `foo`\",\n                       \"default\": 1,\n                       \"examples\": [1, 2, 3],\n                       \"minimum\": 0\n                   },\n                   \"bar\": {\n                       \"$id\": \"#/properties/bar\",\n                       \"type\": \"string\",\n                       \"title\": \"Bar\",\n                       \"description\": \"A test setting named `bar`\",\n                       \"default\": \"\",\n                       \"examples\": [\"one\", \"two\", \"three\"]\n                   }\n               }\n          }'",
         "type": "bash"
       }
     ],
@@ -872,8 +1175,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/configuration.js",
-    "groupTitle": "Configuration_6"
+    "filename": "src/views/configuration.js",
+    "groupTitle": "Configuration.6"
   },
   {
     "type": "delete",
@@ -881,7 +1184,7 @@
     "title": "Delete a customer",
     "name": "deleteCustomer",
     "description": "<p>Delete a customer in a product. Will also revoke all of this customer's access tokens, pending device claim codes and activation codes.</p>",
-    "group": "Customers_10",
+    "group": "Customers.10",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -890,6 +1193,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           },
           {
@@ -897,6 +1201,7 @@
             "type": "String",
             "optional": false,
             "field": "customerEmail",
+            "isArray": false,
             "description": "<p>Email of the customer account that you'd like to remove</p>"
           }
         ]
@@ -910,7 +1215,7 @@
     "examples": [
       {
         "title": "$ curl -X DELETE \"https://api.particle.io/v1/products/:productIdOrSlug/customers/test@company.com\" \\",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/:productIdOrSlug/customers/test@company.com\" \\\n       -d access_token=123abc",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/:productIdOrSlug/customers/test@company.com\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -924,8 +1229,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Customers_10"
+    "filename": "src/views/product.js",
+    "groupTitle": "Customers.10"
   },
   {
     "type": "post",
@@ -941,26 +1246,31 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "email",
-            "description": "<p>Email Address or a unique identifier</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>Password</p>"
           }
         ]
       }
     },
-    "group": "Customers_1",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "email",
+        "isArray": false,
+        "description": "<p>Email Address or a unique identifier</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>Password</p>"
+      }
+    ],
+    "group": "Customers.1",
     "success": {
       "examples": [
         {
@@ -971,8 +1281,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Customers_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "Customers.1"
   },
   {
     "type": "post",
@@ -988,6 +1298,7 @@
             "type": "String",
             "optional": false,
             "field": "Authorization",
+            "isArray": false,
             "description": "<p>HTTP Basic Auth where username is the OAuth client ID and password is the OAuth client secret.</p>"
           }
         ]
@@ -1001,47 +1312,56 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_id",
-            "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_secret",
-            "description": "<p>OAuth client secret. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "email",
-            "description": "<p>Email Address</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "password",
-            "description": "<p>Password</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "no_password",
-            "description": "<p>For two-legged authentication, only required if you are creating password-less customers.</p>"
           }
         ]
       }
     },
-    "group": "Customers_2",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "client_id",
+        "isArray": false,
+        "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "client_secret",
+        "isArray": false,
+        "description": "<p>OAuth client secret. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "email",
+        "isArray": false,
+        "description": "<p>Email Address</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>Password</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "no_password",
+        "isArray": false,
+        "description": "<p>For two-legged authentication, only required if you are creating password-less customers.</p>",
+        "checked": false
+      }
+    ],
+    "group": "Customers.2",
     "success": {
       "examples": [
         {
@@ -1052,8 +1372,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Customers_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "Customers.2"
   },
   {
     "type": "post",
@@ -1069,6 +1389,7 @@
             "type": "String",
             "optional": false,
             "field": "Authorization",
+            "isArray": false,
             "description": "<p>HTTP Basic Auth where username is the OAuth client ID and password is blank.</p>"
           }
         ]
@@ -1082,40 +1403,47 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_id",
-            "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "email",
-            "description": "<p>Email Address</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>Password</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "response_type",
-            "description": "<p>OAuth response type. Should only be included for implicit grant type and should be set to <code>token</code>.</p>"
           }
         ]
       }
     },
-    "group": "Customers_3",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "client_id",
+        "isArray": false,
+        "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "email",
+        "isArray": false,
+        "description": "<p>Email Address</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>Password</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "response_type",
+        "isArray": false,
+        "description": "<p>OAuth response type. Should only be included for implicit grant type and should be set to <code>token</code>.</p>"
+      }
+    ],
+    "group": "Customers.3",
     "success": {
       "examples": [
         {
@@ -1126,8 +1454,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Customers_3"
+    "filename": "src/views/product.js",
+    "groupTitle": "Customers.3"
   },
   {
     "type": "get",
@@ -1143,6 +1471,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           }
         ]
@@ -1153,27 +1482,7 @@
         "name": "customers:list"
       }
     ],
-    "group": "Customers_4",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
+    "group": "Customers.4",
     "success": {
       "fields": {
         "Success 200": [
@@ -1182,6 +1491,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "customers",
+            "isArray": true,
             "description": "<p>List of Customers</p>"
           },
           {
@@ -1189,62 +1499,119 @@
             "type": "Object[]",
             "optional": false,
             "field": "devices",
+            "isArray": true,
             "description": "<p>List of Devices that belong to those customers</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "customers",
+              "field": "customers",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "customers.id",
+            "isArray": false,
             "description": "<p>Customer ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "customers",
+              "field": "customers",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "customers.username",
+            "isArray": false,
             "description": "<p>Username</p>"
           },
           {
             "group": "Success 200",
             "type": "String[]",
             "optional": false,
+            "parentNode": {
+              "path": "customers",
+              "field": "customers",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "customers.devices",
+            "isArray": true,
             "description": "<p>List of Device IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "devices",
+              "field": "devices",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "devices.id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "devices",
+              "field": "devices",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "devices.product_id",
+            "isArray": false,
             "description": "<p>Product ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "devices",
+              "field": "devices",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "devices.last_ip_address",
+            "isArray": false,
             "description": "<p>Last known IP Address</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "devices",
+              "field": "devices",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "devices.firmware_version",
+            "isArray": false,
             "description": "<p>Firmware Version</p>"
           },
           {
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
+            "parentNode": {
+              "path": "devices",
+              "field": "devices",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "devices.online",
+            "isArray": false,
             "description": "<p>Whether the device is currently online or not</p>"
           }
         ]
@@ -1258,15 +1625,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Customers_4"
+    "filename": "src/views/product.js",
+    "groupTitle": "Customers.4"
   },
   {
     "type": "post",
     "url": "/oauth/token",
     "title": "Generate a customer scoped access token",
     "description": "<p>Creates a token scoped to a customer for your organization.</p> <p>You must give a valid product OAuth client ID and secret in HTTP Basic Auth or in the <code>client_id</code> and <code>client_secret</code> parameters.</p>",
-    "group": "Customers_5",
+    "group": "Customers.5",
     "header": {
       "fields": {
         "Header": [
@@ -1274,60 +1641,72 @@
             "group": "Header",
             "type": "String",
             "optional": false,
+            "field": "Content-Type",
+            "isArray": false,
+            "defaultValue": "application/x-www-form-urlencoded",
+            "description": "<p>Must be set to <code>application/x-www-form-urlencoded</code></p>"
+          },
+          {
+            "group": "Header",
+            "type": "String",
+            "optional": false,
             "field": "Authorization",
+            "isArray": false,
             "description": "<p>HTTP Basic Auth where username is the OAuth client ID and password is the OAuth client secret.</p>"
           }
         ]
       }
     },
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_id",
-            "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "client_secret",
-            "description": "<p>OAuth client secret. Required if no Authorization header is present.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "grant_type",
-            "description": "<p>OAuth grant type. Must be <code>client_credentials</code>.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "expires_in",
-            "description": "<p>How many seconds the token will be valid for. <code>0</code> means forever. Short lived tokens are better for security.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Date",
-            "optional": true,
-            "field": "expires_at",
-            "description": "<p>When should the token expire? This should be an ISO8601 formatted date string.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "scope",
-            "description": "<p>The customer to scope this token to. Format of <code>customer=jane@example.com</code>.</p>"
-          }
-        ]
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "client_id",
+        "isArray": false,
+        "description": "<p>OAuth client ID. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "client_secret",
+        "isArray": false,
+        "description": "<p>OAuth client secret. Required if no Authorization header is present.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "grant_type",
+        "isArray": false,
+        "description": "<p>OAuth grant type. Must be <code>client_credentials</code>.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": true,
+        "field": "expires_in",
+        "isArray": false,
+        "description": "<p>How many seconds the token will be valid for. <code>0</code> means forever. Short lived tokens are better for security.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Date",
+        "optional": true,
+        "field": "expires_at",
+        "isArray": false,
+        "description": "<p>When should the token expire? This should be an ISO8601 formatted date string.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "scope",
+        "isArray": false,
+        "description": "<p>The customer to scope this token to. Format of <code>customer=jane@example.com</code>.</p>"
       }
-    },
+    ],
     "examples": [
       {
         "title": "$ curl https://api.particle.io/oauth/token \\",
@@ -1343,23 +1722,23 @@
             "type": "String",
             "optional": false,
             "field": "access_token",
+            "isArray": false,
             "description": "<p>The magical token you will use for all the other requests</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
-            "allowedValues": [
-              "bearer"
-            ],
             "optional": false,
             "field": "token_type",
-            "description": ""
+            "isArray": false,
+            "description": "<p>Always set to &quot;Bearer&quot;</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
             "field": "expires_in",
+            "isArray": false,
             "description": "<p>The number of seconds this token is valid for. <code>0</code> means forever.</p>"
           },
           {
@@ -1367,6 +1746,7 @@
             "type": "String",
             "optional": false,
             "field": "refresh_token",
+            "isArray": false,
             "description": "<p>Used to generate a new access token when it has expired.</p>"
           }
         ]
@@ -1380,8 +1760,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/accessToken.js",
-    "groupTitle": "Customers_5",
+    "filename": "src/views/accessToken.js",
+    "groupTitle": "Customers.5",
     "name": "PostOauthToken"
   },
   {
@@ -1389,7 +1769,7 @@
     "url": "/v1/products/:productIdOrSlug/customers/:customerEmail",
     "title": "Update customer password",
     "name": "updateCustomerPassword",
-    "group": "Customers_6",
+    "group": "Customers.6",
     "description": "<p>Update the account password for a customer. Only relevant for non-shadow customers that have a password saved in Particle's system. Must be called with an access token that has access to the product, not a customer access token.</p>",
     "parameter": {
       "fields": {
@@ -1399,6 +1779,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           },
           {
@@ -1406,18 +1787,22 @@
             "type": "String",
             "optional": false,
             "field": "customerEmail",
+            "isArray": false,
             "description": "<p>Email of the customer account that you'd like to update</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>The new password for the customer</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>The new password for the customer</p>"
+      }
+    ],
     "permission": [
       {
         "name": "customers:update"
@@ -1426,7 +1811,7 @@
     "examples": [
       {
         "title": "Example Request",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/:productIdOrSlug/customers/test@company.com\" \\\n       -d access_token=123abc \\\n       -d password=newpassword",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/:productIdOrSlug/customers/test@company.com\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -d password=newpassword",
         "type": "bash"
       }
     ],
@@ -1440,80 +1825,48 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Customers_6"
+    "filename": "src/views/product.js",
+    "groupTitle": "Customers.6"
   },
   {
     "type": "post",
-    "url": "/v1/device_claims",
-    "title": "Create a claim code",
-    "name": "GenerateClaimCode",
-    "description": "<p>Generate a device claim code that allows the device to be successfully claimed to a Particle account during the setup process. You can use the product endpoint for creating a claim code to allow customers to successfully claim a product device. Use an access token that was generated by the Particle account you'd like to claim ownership of the device.</p> <p>When creating claim codes for Wi-Fi devices like Photons, allow the cloud to generate the claim code for you. This is done by not passing anything to the request body (with the exception of products in private beta, which require an activation code to generate a claim code). Then, this claim code must be sent to the Photon via SoftAP. For more information on how to send claim codes to Particle devices via SoftAP, please check out <a href=\"https://github.com/spark/softap-setup-js\">Particle SoftAP setup for JavaScript</a>.</p> <p>Conversely, for cellular devices like Electrons, you must create a claim code equal to the <code>iccid</code> or <code>imei</code> of the device. This is because Electrons are not directly connected to by the client during setup. This is done by passing an <code>iccid</code> or <code>imei</code> in the body of the request when creating a claim code.</p> <p>When an device connects to the cloud, it will immediately publish its claim code (or in the case of Electrons, it will publish its ICCID and IMEI). The cloud will check this code against all valid claim codes, and if there is a match, successfully claim the device to the account used to create the claim code.</p>",
-    "group": "Devices_10",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "imei",
-            "description": "<p>IMEI number of the Electron you are generating a claim for. This will be used as the claim code if <code>iccid</code> is not specified.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "iccid",
-            "description": "<p>ICCID number (SIM card ID number) of the SIM you are generating a claim for. This will be used as the claim code.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "activation_code",
-            "description": "<p>Activation Code. Only required if product is in private beta. <em>Product endpoint only</em>.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "productIdOrSlug",
-            "description": "<p>Product ID or Slug. <em>Product endpoint only</em>.</p>"
-          }
-        ]
-      }
-    },
+    "url": "/v1/devices",
+    "title": "Claim a device",
+    "name": "ClaimDevice",
+    "description": "<p>Claim a new or unclaimed device to your account.</p>",
+    "group": "Devices.12",
     "examples": [
       {
-        "title": "$ curl https://api.particle.io/v1/device_claims \\",
-        "content": "$ curl https://api.particle.io/v1/device_claims \\\n       -d access_token=1234",
+        "title": "$ curl https://api.particle.io/v1/devices \\",
+        "content": "$ curl https://api.particle.io/v1/devices \\\n       -d id=0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
-        "title": "Create claim code for a product device",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/device_claims \\\n       -d access_token=1234",
+        "title": "Request a transfer",
+        "content": "$ curl https://api.particle.io/v1/devices \\\n       -d id=0123456789abcdef01234567 \\\n       -d request_transfer=true \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
+      }
+    ],
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "id",
+        "isArray": false,
+        "description": "<p>Device ID</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "allowedValues": [
+          "true"
+        ],
+        "optional": false,
+        "field": "request_transfer",
+        "isArray": false,
+        "description": "<p>Indicates you are requesting a device transfer from another user</p>",
+        "checked": false
       }
     ],
     "success": {
@@ -1523,94 +1876,20 @@
             "group": "Success 200",
             "type": "String",
             "optional": false,
-            "field": "claim_code",
-            "description": "<p>a claim code for use during the device setup process</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "String[]",
-            "optional": false,
-            "field": "device_ids",
-            "description": "<p>Array of device IDs that already belong to the user</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Example Response",
-          "content": " POST /v1/device_claims\n HTTP/1.1 200 OK\n {\n\t\tclaim_code: 'rCFr2KAJNgzJ2rR3Jm1ZoUd7G4Sr3ak7MRHdWrM274eYzInP1+psZ0fP2qNehlj',\n\t\tdevice_ids: ['33ff210644893f533e242597']\n }",
-          "type": "json"
-        }
-      ]
-    },
-    "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_10"
-  },
-  {
-    "type": "post",
-    "url": "/v1/devices",
-    "title": "Claim a device",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "id",
-            "description": "<p>Device ID</p>"
-          }
-        ],
-        "Request device transfer from another user": [
-          {
-            "group": "transfer",
-            "type": "Boolean",
-            "allowedValues": [
-              "true"
-            ],
-            "optional": false,
-            "field": "request_transfer",
-            "description": "<p>Indicates you are requesting a device transfer from another user</p>"
-          }
-        ]
-      }
-    },
-    "name": "ClaimDevice",
-    "description": "<p>Claim a new or unclaimed device to your account.</p>",
-    "group": "Devices_12",
-    "examples": [
-      {
-        "title": "$ curl https://api.particle.io/v1/devices \\",
-        "content": "$ curl https://api.particle.io/v1/devices \\\n       -d id=0123456789abcdef01234567 \\\n       -d access_token=1234",
-        "type": "bash"
-      },
-      {
-        "title": "transfer",
-        "content": "$ curl https://api.particle.io/v1/devices \\\n       -d id=0123456789abcdef01234567 \\\n       -d request_transfer=true \\\n       -d access_token=1234",
-        "type": "bash"
-      }
-    ],
-    "success": {
-      "fields": {
-        "Request device transfer from another user": [
-          {
-            "group": "transfer",
-            "type": "String",
-            "optional": false,
             "field": "transfer_id",
+            "isArray": false,
             "description": "<p>Unique ID that represents the transfer</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_12"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.12"
   },
   {
     "type": "delete",
-    "url": "/v1/products/:productIdOrSlug/devices/:deviceID",
+    "url": "/v1/products/:productIdOrSlug/devices/:deviceId",
     "title": "Remove device from product",
     "name": "removeDeviceFromProduct",
     "permission": [
@@ -1618,7 +1897,7 @@
         "name": "devices:remove"
       }
     ],
-    "group": "Devices_13",
+    "group": "Devices.13",
     "description": "<p>Remove a device from a product and re-assign to a generic Particle product. This endpoint will unclaim the device if it is owned by a <code>customer</code>.</p>",
     "parameter": {
       "fields": {
@@ -1628,37 +1907,19 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "deviceID",
+            "field": "deviceId",
+            "isArray": false,
             "description": "<p>ID of the device to be removed</p>"
           }
         ]
       }
-    },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
     },
     "success": {
       "examples": [
@@ -1670,16 +1931,16 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Devices_13"
+    "filename": "src/views/product.js",
+    "groupTitle": "Devices.13"
   },
   {
     "type": "delete",
-    "url": "/v1/devices/:deviceID",
+    "url": "/v1/devices/:deviceId",
     "title": "Unclaim device",
     "name": "unclaimDevice",
-    "group": "Devices_14",
-    "description": "<p>Remove ownership of a device. This will unclaim regardless if the device is owned by a <code>user</code> or a <code>customer</code>, in the case of a product.</p> <p>When using this endpoint to unclaim a product device, the route looks slightly different:</p> <p><code>DELETE /v1/products/:productIdOrSlug/devices/:deviceID/owner</code></p> <p>Note the <code>/owner</code> at the end of the route.</p>",
+    "group": "Devices.14",
+    "description": "<p>Remove ownership of a device. This will unclaim regardless if the device is owned by a <code>user</code> or a <code>customer</code>, in the case of a product.</p> <p>When using this endpoint to unclaim a product device, the route looks slightly different:</p> <p><code>DELETE /v1/products/:productIdOrSlug/devices/:deviceId/owner</code></p> <p>Note the <code>/owner</code> at the end of the route.</p>",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -1687,7 +1948,8 @@
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "deviceID",
+            "field": "deviceId",
+            "isArray": false,
             "description": "<p>ID of the device to be unclaimed</p>"
           },
           {
@@ -1695,6 +1957,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           }
         ]
@@ -1708,12 +1971,12 @@
     "examples": [
       {
         "title": "$ curl -X DELETE https://api.particle.io/v1/devices/12345 \\",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/devices/12345 \\\n       -d access_token=123abc",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/devices/12345 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Unclaim product device",
-        "content": "# Note that the product endpoint requires adding \"/owner\" to the end of the route\n\n$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/devices/12345/owner \\\n       -d access_token=123abc",
+        "content": "# Note that the product endpoint requires adding \"/owner\" to the end of the route\n\n$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/devices/12345/owner \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -1727,33 +1990,44 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_14"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.14"
   },
   {
     "type": "put",
-    "url": "/v1/devices/:deviceID",
+    "url": "/v1/devices/:deviceId",
     "title": "Signal a device",
     "name": "signalDevice",
-    "group": "Devices_15",
+    "group": "Devices.15",
     "description": "<p>Make the device conspicuous by causing its LED to flash in rainbow patterns</p>",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
-            "type": "Number",
+            "type": "String",
             "optional": false,
-            "field": "signal",
-            "description": "<p>1 to start shouting rainbows, 0 to stop</p>"
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": false,
+        "field": "signal",
+        "isArray": false,
+        "description": "<p>1 to start shouting rainbows, 0 to stop</p>"
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/devices/12345 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/devices/12345 \\\n       -d signal=1 \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/12345 \\\n       -d signal=1 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -1767,29 +2041,41 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_15"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.15"
   },
   {
     "type": "put",
-    "url": "/v1/devices/:deviceID",
+    "url": "/v1/devices/:deviceId",
     "title": "Force enable OTA updates",
     "name": "forceUpdates",
-    "group": "Devices_16",
+    "group": "Devices.16",
     "description": "<p><a href=\"https://docs.particle.io/tutorials/device-cloud/ota-updates/#force-enable-ota-updates\">Force enable</a> OTA updates on this device.</p>",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
-            "type": "Boolean",
+            "type": "String",
             "optional": false,
-            "field": "firmware_updates_forced",
-            "description": "<p><code>true</code> to force enable updates, <code>false</code> to unforce updates.</p>"
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "firmware_updates_forced",
+        "isArray": false,
+        "description": "<p><code>true</code> to force enable updates, <code>false</code> to unforce updates.</p>",
+        "checked": false
+      }
+    ],
     "permission": [
       {
         "name": "devices:update"
@@ -1798,7 +2084,7 @@
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/devices/12345 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/devices/12345 \\\n       -d firmware_updates_forced=true \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/12345 \\\n       -d firmware_updates_forced=true \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -1812,14 +2098,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_16"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.16"
   },
   {
     "type": "get",
     "url": "/v1/serial_numbers/:serial_number",
     "title": "Look up device identification from a serial number",
-    "group": "Devices_17",
+    "group": "Devices.17",
     "description": "<p>Return the device ID and SIM card ICCD (if applicable) for a device by serial number. This API can look up devices that you have not yet added to your product and is rate limited to 50 requests per hour. Once you've imported your devices to your product you should instead use the list devices in a product API and filter on serial number. No special rate limits apply to that API.</p>",
     "parameter": {
       "fields": {
@@ -1829,6 +2115,7 @@
             "type": "String",
             "optional": false,
             "field": "serial_number",
+            "isArray": false,
             "description": "<p>The serial number printed on the barcode of the device packaging.</p>"
           }
         ]
@@ -1836,8 +2123,8 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/serial_numbers/E26AAA111111111?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/serial_numbers/E26AAA111111111?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/serial_numbers/E26AAA111111111 \\",
+        "content": "$ curl https://api.particle.io/v1/serial_numbers/E26AAA111111111 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -1849,6 +2136,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceID",
+            "isArray": false,
             "description": "<p>The ID of the device associated with this device</p>"
           },
           {
@@ -1856,6 +2144,7 @@
             "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>The ICCID number (SIM card ID number) of the SIM card associated with this device</p>"
           }
         ]
@@ -1869,8 +2158,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_17",
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.17",
     "name": "GetV1Serial_numbersSerial_number"
   },
   {
@@ -1879,7 +2168,7 @@
     "title": "List devices",
     "name": "ListDevices",
     "description": "<p>List devices the currently authenticated user has access to. By default, devices will be sorted by <code>last_handshake_at</code> in descending order.</p>",
-    "group": "Devices_1",
+    "group": "Devices.1",
     "success": {
       "fields": {
         "Success 200": [
@@ -1888,6 +2177,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "-",
+            "isArray": true,
             "description": "<p>Array of devices. See <a href=\"#get-device-information\">Get device information</a> for the response attributes of each device.</p>"
           }
         ]
@@ -1900,16 +2190,23 @@
         }
       ]
     },
+    "examples": [
+      {
+        "title": "$ curl https://api.particle.io/v1/devices \\",
+        "content": "$ curl https://api.particle.io/v1/devices \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      }
+    ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_1"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.1"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/devices",
     "title": "List devices in a product",
     "name": "listDevicesForProduct",
-    "group": "Devices_2",
+    "group": "Devices.2",
     "description": "<p>List all devices that are part of a product. Results are paginated, by default returns 25 device records per page.</p>",
     "parameter": {
       "fields": {
@@ -1919,79 +2216,91 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceId",
-            "description": "<p>Filter results to devices with this ID (partial matching)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "groups",
-            "description": "<p>Comma separated list of full group names to filter results to devices belonging to these groups only</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceName",
-            "description": "<p>Filter results to devices with this name (partial matching)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "serialNumber",
-            "description": "<p>Filter results to devices with this serial number (partial matching)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "sortAttr",
-            "description": "<p>The attribute by which to sort results. Options for sorting are <code>deviceId</code>, <code>firmwareVersion</code>, or <code>lastConnection</code>. By default, if no <code>sortAttr</code> parameter is set, devices will be sorted by last connection, in descending order</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "sortDir",
-            "description": "<p>The direction of sorting. Pass <code>asc</code> for ascending sorting or <code>desc</code> for descending sorting</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "allowedValues": [
-              "true"
-            ],
-            "optional": true,
-            "field": "quarantined",
-            "description": "<p>include / exclude quarantined devices</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "page",
-            "defaultValue": "1",
-            "description": "<p>Current page of results</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "perPage",
-            "defaultValue": "25",
-            "description": "<p>Records per page</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "deviceId",
+        "isArray": false,
+        "description": "<p>Filter results to devices with this ID (partial matching)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "groups",
+        "isArray": false,
+        "description": "<p>Comma separated list of full group names to filter results to devices belonging to these groups only</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "deviceName",
+        "isArray": false,
+        "description": "<p>Filter results to devices with this name (partial matching)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "serialNumber",
+        "isArray": false,
+        "description": "<p>Filter results to devices with this serial number (partial matching)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "sortAttr",
+        "isArray": false,
+        "description": "<p>The attribute by which to sort results. Options for sorting are <code>deviceId</code>, <code>firmwareVersion</code>, or <code>lastConnection</code>. By default, if no <code>sortAttr</code> parameter is set, devices will be sorted by last connection, in descending order</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "sortDir",
+        "isArray": false,
+        "description": "<p>The direction of sorting. Pass <code>asc</code> for ascending sorting or <code>desc</code> for descending sorting</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Boolean",
+        "allowedValues": [
+          "true"
+        ],
+        "optional": true,
+        "field": "quarantined",
+        "isArray": false,
+        "description": "<p>include / exclude quarantined devices</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "page",
+        "isArray": false,
+        "defaultValue": "1",
+        "description": "<p>Current page of results</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "perPage",
+        "isArray": false,
+        "defaultValue": "25",
+        "description": "<p>Records per page</p>"
+      }
+    ],
     "permission": [
       {
         "name": "devices:list"
@@ -1999,13 +2308,13 @@
     ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices \\",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List devices in a group",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?groups=beta&access_token=1234\"",
+        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?groups=beta\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -2017,6 +2326,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "devices",
+            "isArray": true,
             "description": "<p>An array of devices objects. See <a href=\"#get-device-information\">Get device information</a> for the response attributes of each device.</p>"
           },
           {
@@ -2024,41 +2334,57 @@
             "type": "Object[]",
             "optional": false,
             "field": "customers",
+            "isArray": true,
             "description": "<p>An array of customer objects</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "customers",
+              "field": "customers",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "customers.id",
+            "isArray": false,
             "description": "<p>Customer ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "customers",
+              "field": "customers",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "customers.username",
+            "isArray": false,
             "description": "<p>Customer username</p>"
-          },
-          {
-            "group": "Success 200",
-            "type": "String",
-            "optional": false,
-            "field": "customers.activation_code",
-            "description": "<p>An activation code used for device claiming if the product is in &quot;Private Beta&quot; mode</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
             "field": "meta",
+            "isArray": false,
             "description": "<p>Pagination metadata</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.total_pages",
+            "isArray": false,
             "description": "<p>Total number of pages of device records</p>"
           }
         ]
@@ -2072,15 +2398,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Devices_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "Devices.2"
   },
   {
     "type": "post",
     "url": "/v1/products/:productIdOrSlug/devices",
     "title": "Import devices into product",
     "name": "importDevicesIntoProduct",
-    "group": "Devices_3",
+    "group": "Devices.3",
     "description": "<p>Import devices into a product. Devices must be of the same <em>platform type</em> as the product in order to be successfully imported. Imported devices may receive an immediate OTA firmware update to the product's released firmware.</p> <p>Importing a device with a Particle SIM card will also import the SIM card into the product and activate the SIM card.</p>",
     "parameter": {
       "fields": {
@@ -2090,46 +2416,55 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "id",
-            "description": "<p>A device ID to import into a product. Pass <code>id</code> if you are trying to import a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Array",
-            "optional": true,
-            "field": "ids",
-            "description": "<p>An array of device ID to import into a product. Pass <code>ids</code> if you are trying to import multiple device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "import_sims",
-            "description": "<p>Import SIM card associated with each device into the product</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "claim_user",
-            "description": "<p>The username (email) of a Particle user to claim the imported devices. This user must be a member of the product team.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "File",
-            "optional": true,
-            "field": "file",
-            "description": "<p>A .txt file containing a single-column list of device identifiers: device IDs, serial numbers, IMEIs or ICCIDs. This is an alternative to <code>ids</code> for importing many devices into a product at once. Encoded in <code>multipart/form-data</code> format</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "id",
+        "isArray": false,
+        "description": "<p>A device ID to import into a product. Pass <code>id</code> if you are trying to import a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "ids",
+        "isArray": true,
+        "description": "<p>An array of device ID to import into a product. Pass <code>ids</code> if you are trying to import multiple device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "import_sims",
+        "isArray": false,
+        "description": "<p>Import SIM card associated with each device into the product</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "claim_user",
+        "isArray": false,
+        "description": "<p>The username (email) of a Particle user to claim the imported devices. This user must be a member of the product team.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "File",
+        "optional": true,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>A .txt file containing a single-column list of device identifiers: device IDs, serial numbers, IMEIs or ICCIDs. This is an alternative to <code>ids</code> for importing many devices into a product at once. Encoded in <code>multipart/form-data</code> format</p>"
+      }
+    ],
     "permission": [
       {
         "name": "devices:import"
@@ -2138,12 +2473,12 @@
     "examples": [
       {
         "title": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?claim_user=user@domain.com\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?claim_user=user@domain.com\" \\\n       -H \"Authorization: Bearer 12345\" \\\n       -F file=@devices.txt",
+        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices?claim_user=user@domain.com\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -F file=@devices.txt",
         "type": "bash"
       },
       {
         "title": "Providing devices in the body",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices\n       -H \"Authorization: Bearer 12345\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{ \"ids\":[\"abc123\"], \"claim_user\": \"user@domain.com\" }'",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{ \"ids\":[\"abc123\"], \"claim_user\": \"user@domain.com\" }'",
         "type": "bash"
       }
     ],
@@ -2155,6 +2490,7 @@
             "type": "Number",
             "optional": false,
             "field": "updated",
+            "isArray": false,
             "description": "<p>The number of devices successfully added to the product</p>"
           },
           {
@@ -2162,6 +2498,7 @@
             "type": "Array",
             "optional": false,
             "field": "updatedDeviceIds",
+            "isArray": false,
             "description": "<p>Device identifiers that have been added to the product. The identifiers correspond to what was passed in the <code>file</code> or <code>id</code> field of the request, so they could be device IDs, serial numbers, IMEIs or ICCIDs.</p>"
           },
           {
@@ -2169,6 +2506,7 @@
             "type": "Array",
             "optional": false,
             "field": "existingDeviceIds",
+            "isArray": false,
             "description": "<p>Device identifiers that were already in the product</p>"
           },
           {
@@ -2176,6 +2514,7 @@
             "type": "Array",
             "optional": false,
             "field": "nonmemberDeviceIds",
+            "isArray": false,
             "description": "<p>Device identifiers that belong to another owner and could not be imported</p>"
           },
           {
@@ -2183,6 +2522,7 @@
             "type": "Array",
             "optional": false,
             "field": "invalidDeviceIds",
+            "isArray": false,
             "description": "<p>Device identifiers that were invalid and could not be imported</p>"
           }
         ]
@@ -2196,8 +2536,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Devices_3"
+    "filename": "src/views/product.js",
+    "groupTitle": "Devices.3"
   },
   {
     "type": "get",
@@ -2211,6 +2551,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           }
         ]
@@ -2218,7 +2559,7 @@
     },
     "name": "GetDevice",
     "description": "<p>Get basic information about the given device, including the custom variables and functions it has exposed. This can be called for sandbox devices claimed to your account and for product devices you have access to, regardless of claiming.</p>",
-    "group": "Devices_4",
+    "group": "Devices.4",
     "success": {
       "fields": {
         "Success 200": [
@@ -2227,6 +2568,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2234,6 +2576,7 @@
             "type": "String",
             "optional": false,
             "field": "name",
+            "isArray": false,
             "description": "<p>Device name</p>"
           },
           {
@@ -2241,6 +2584,7 @@
             "type": "String",
             "optional": false,
             "field": "owner",
+            "isArray": false,
             "description": "<p>Particle username for the user who claimed this device</p>"
           },
           {
@@ -2248,6 +2592,7 @@
             "type": "String",
             "optional": false,
             "field": "last_ip_address",
+            "isArray": false,
             "description": "<p>IP address of the device the last time it connected to the cloud</p>"
           },
           {
@@ -2255,6 +2600,7 @@
             "type": "Date",
             "optional": false,
             "field": "last_heard",
+            "isArray": false,
             "description": "<p>Date and Time that the cloud last heard from the device in ISO 8601 format</p>"
           },
           {
@@ -2262,6 +2608,7 @@
             "type": "Date",
             "optional": false,
             "field": "last_handshake_at",
+            "isArray": false,
             "description": "<p>Date and time that the device most recently connected to the cloud in ISO 8601 format</p>"
           },
           {
@@ -2269,6 +2616,7 @@
             "type": "Number",
             "optional": false,
             "field": "product_id",
+            "isArray": false,
             "description": "<p>For development devices, this equals platform_id. For product devices, your product number.</p>"
           },
           {
@@ -2276,6 +2624,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "online",
+            "isArray": false,
             "description": "<p>Indicates whether the device is currently connected to the cloud</p>"
           },
           {
@@ -2283,6 +2632,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "connected",
+            "isArray": false,
             "description": "<p>Deprecated. Use <code>online</code></p>"
           },
           {
@@ -2290,6 +2640,7 @@
             "type": "Number",
             "optional": false,
             "field": "platform_id",
+            "isArray": false,
             "description": "<p>Indicates the type of device. Example values are <code>6</code> for Photon, <code>10</code> for Electron, <code>12</code> for Argon, <code>13</code> for Boron.</p>"
           },
           {
@@ -2297,6 +2648,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "cellular",
+            "isArray": false,
             "description": "<p>True for cellular devices (Electron, Boron), false otherwise</p>"
           },
           {
@@ -2304,6 +2656,7 @@
             "type": "String",
             "optional": false,
             "field": "notes",
+            "isArray": false,
             "description": "<p>Free-form notes about the device</p>"
           },
           {
@@ -2311,6 +2664,7 @@
             "type": "String[]",
             "optional": false,
             "field": "functions",
+            "isArray": true,
             "description": "<p>List of function names exposed by the device</p>"
           },
           {
@@ -2318,6 +2672,7 @@
             "type": "Object",
             "optional": false,
             "field": "variables",
+            "isArray": false,
             "description": "<p>List of variable name and types exposed by the device</p>"
           },
           {
@@ -2325,6 +2680,7 @@
             "type": "String",
             "optional": false,
             "field": "serial_number",
+            "isArray": false,
             "description": "<p>The serial number of the device, if it exists</p>"
           },
           {
@@ -2332,6 +2688,7 @@
             "type": "String",
             "optional": false,
             "field": "status",
+            "isArray": false,
             "description": "<p>When <code>normal</code> indicates the is running user application, when <code>safe_mode</code> indicates that the device has missing Device OS dependencies and is not running the user application.</p>"
           },
           {
@@ -2339,6 +2696,7 @@
             "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>Last SIM card ID used for cellular devices</p>"
           },
           {
@@ -2346,6 +2704,7 @@
             "type": "String",
             "optional": false,
             "field": "last_iccid",
+            "isArray": false,
             "description": "<p>Deprecated. Use <code>iccid</code>.</p>"
           },
           {
@@ -2353,6 +2712,7 @@
             "type": "String",
             "optional": false,
             "field": "imei",
+            "isArray": false,
             "description": "<p>IMEI number for cellular devices</p>"
           },
           {
@@ -2360,6 +2720,7 @@
             "type": "String",
             "optional": false,
             "field": "mac_wifi",
+            "isArray": false,
             "description": "<p>The device MAC address if it has one. <em>Non cellular devices only</em></p>"
           },
           {
@@ -2367,6 +2728,7 @@
             "type": "String",
             "optional": false,
             "field": "system_firmware_version",
+            "isArray": false,
             "description": "<p>Version of Device OS running on the device last reported to the cloud</p>"
           },
           {
@@ -2374,6 +2736,7 @@
             "type": "String",
             "optional": false,
             "field": "current_build_target",
+            "isArray": false,
             "description": "<p>Deprecated. Use <code>system_firmware_version</code>.</p>"
           },
           {
@@ -2381,6 +2744,7 @@
             "type": "String",
             "optional": false,
             "field": "pinned_build_target",
+            "isArray": false,
             "description": "<p>Version of Device OS to use when compiling firmware for this device in the Web IDE. If not set, uses <code>default_build_target</code>.</p>"
           },
           {
@@ -2388,6 +2752,7 @@
             "type": "String",
             "optional": false,
             "field": "default_build_target",
+            "isArray": false,
             "description": "<p>Version of Device OS to use when compiling firmware for the platform of this device in the Web IDE.</p>"
           },
           {
@@ -2395,6 +2760,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "firmware_updates_enabled",
+            "isArray": false,
             "description": "<p>Indicates whether the device will accept firmware updates without being forced</p>"
           },
           {
@@ -2402,6 +2768,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "firmware_updates_forced",
+            "isArray": false,
             "description": "<p>Indicates whether firmware updates on the device have been forced from the cloud.</p>"
           },
           {
@@ -2409,6 +2776,7 @@
             "type": "String",
             "optional": false,
             "field": "mobile_secret",
+            "isArray": false,
             "description": "<p>The shared secret used by a mobile app to communicate securely with a device over BLE during setup</p>"
           },
           {
@@ -2416,6 +2784,7 @@
             "type": "Number",
             "optional": false,
             "field": "firmware_product_id",
+            "isArray": false,
             "description": "<p>The product ID that the device reported in its firmware the last time it connected to the cloud. <em>Product devices only</em></p>"
           },
           {
@@ -2423,6 +2792,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "groups",
+            "isArray": true,
             "description": "<p>An array of group names that the device belongs to. <em>Product devices only</em></p>"
           },
           {
@@ -2430,6 +2800,7 @@
             "type": "Number",
             "optional": false,
             "field": "firmware_version",
+            "isArray": false,
             "description": "<p>The version number the device reported in its firmware. <em>Product devices only</em></p>"
           },
           {
@@ -2437,6 +2808,7 @@
             "type": "Number",
             "optional": false,
             "field": "desired_firmware_version",
+            "isArray": false,
             "description": "<p>The version of firmware that the device has been individually locked to run. <em>Product devices only</em></p>"
           },
           {
@@ -2444,6 +2816,7 @@
             "type": "Number",
             "optional": false,
             "field": "targeted_firmware_release_version",
+            "isArray": false,
             "description": "<p>The product firmware version the device is targeted to receive based on the locked version and released firmware. If <code>firmware_version</code> matches <code>targeted_firmware_release_version</code>, the device is currently running this firmware. <em>Product endpoint only</em></p>"
           },
           {
@@ -2451,6 +2824,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "development",
+            "isArray": false,
             "description": "<p>Set to <code>true</code> if a device has been marked as a <em>development device</em>, meaning it will not receive any product firmware updates from the cloud. <em>Product endpoint only</em></p>"
           },
           {
@@ -2458,6 +2832,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "quarantined",
+            "isArray": false,
             "description": "<p>If set to <code>true</code>, the device is unrecognized and has lost product privileges until it is manually approved. <em>Product endpoint only</em></p>"
           },
           {
@@ -2465,6 +2840,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "denied",
+            "isArray": false,
             "description": "<p>If set to <code>true</code>, this is a quarantined device that has been permanently denied access to product privileges. <em>Product endpoint only</em></p>"
           },
           {
@@ -2472,6 +2848,7 @@
             "type": "String",
             "optional": false,
             "field": "device_protection.status",
+            "isArray": false,
             "description": "<p>The device protection status of this device</p>"
           }
         ]
@@ -2486,23 +2863,23 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567 \\",
+        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get product device information",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_4"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.4"
   },
   {
     "type": "get",
-    "url": "/v1/products/:productId/devices/:deviceId",
+    "url": "/v1/products/:productIdOrSlug/devices/:deviceId",
     "title": "Get product device information",
     "parameter": {
       "fields": {
@@ -2512,6 +2889,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2519,6 +2897,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           }
         ]
@@ -2531,10 +2910,10 @@
     ],
     "name": "GetProductDevice",
     "description": "<p>Get basic information about a given device that is part of a product</p> <p>See <a href=\"#get-device-information\">Get device information</a> for the response attributes</p>",
-    "group": "Devices_5",
+    "group": "Devices.5",
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_5"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.5"
   },
   {
     "type": "get",
@@ -2548,6 +2927,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2555,28 +2935,33 @@
             "type": "String",
             "optional": false,
             "field": "varName",
+            "isArray": false,
             "description": "<p>Variable name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"raw\""
-            ],
-            "optional": true,
-            "field": "format",
-            "description": "<p>Specify <code>raw</code> if you just the value returned</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "allowedValues": [
+          "\"raw\""
+        ],
+        "optional": true,
+        "field": "format",
+        "isArray": false,
+        "description": "<p>Specify <code>raw</code> if you just the value returned</p>"
+      }
+    ],
     "permission": [
       {
         "name": "devices.variable:get"
@@ -2584,7 +2969,7 @@
     ],
     "name": "GetDeviceVariable",
     "description": "<p>Request the current value of a variable exposed by the device. Variables can be read on a device you own, or for any device that is part of a product you are a team member of.</p>",
-    "group": "Devices_6",
+    "group": "Devices.6",
     "success": {
       "fields": {
         "Success 200": [
@@ -2593,6 +2978,7 @@
             "type": "String",
             "optional": false,
             "field": "result",
+            "isArray": false,
             "description": "<p>The variable value</p>"
           },
           {
@@ -2600,6 +2986,7 @@
             "type": "String",
             "optional": false,
             "field": "name",
+            "isArray": false,
             "description": "<p>The variable name</p>"
           },
           {
@@ -2607,6 +2994,7 @@
             "type": "Object",
             "optional": false,
             "field": "coreInfo",
+            "isArray": false,
             "description": "<p>The device information</p>"
           }
         ]
@@ -2626,25 +3014,25 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567/temperature?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567/temperature?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/temperature \\",
+        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/temperature \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get variable value on product device",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567/temperature?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567/temperature \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_6"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.6"
   },
   {
     "type": "post",
     "url": "/v1/devices/:deviceId/:functionName",
     "title": "Call a function",
-    "group": "Devices_7",
+    "group": "Devices.7",
     "description": "<p>Call a function exposed by the device, with arguments passed in the request body. Functions can be called on a device you own, or for any device that is part of a product you are a team member of.</p>",
     "parameter": {
       "fields": {
@@ -2654,6 +3042,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": ""
           },
           {
@@ -2661,35 +3050,41 @@
             "type": "String",
             "optional": false,
             "field": "functionName",
+            "isArray": false,
             "description": ""
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "arg",
-            "description": "<p>Function argument with a maximum length of 63 characters</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "allowedValues": [
-              "\"raw\""
-            ],
-            "optional": true,
-            "field": "format",
-            "description": "<p>Specify if you want the just the function return value returned</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "arg",
+        "isArray": false,
+        "description": "<p>Function argument with a maximum length of 63 characters</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "allowedValues": [
+          "\"raw\""
+        ],
+        "optional": true,
+        "field": "format",
+        "isArray": false,
+        "description": "<p>Specify if you just want the function return value returned</p>"
+      }
+    ],
     "permission": [
       {
         "name": "devices.function:call"
@@ -2698,12 +3093,12 @@
     "examples": [
       {
         "title": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/gong \\",
-        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/gong \\\n       -d arg=\"ZEN PLEASE\" \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/gong \\\n       -d arg=\"ZEN PLEASE\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Call a function on a product device",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567/gong \\\n       -d arg=\"ZEN PLEASE\" \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567/gong \\\n       -d arg=\"ZEN PLEASE\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -2715,6 +3110,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2722,6 +3118,7 @@
             "type": "String",
             "optional": false,
             "field": "name",
+            "isArray": false,
             "description": "<p>Device name</p>"
           },
           {
@@ -2729,6 +3126,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "connected",
+            "isArray": false,
             "description": "<p>Indicates if the device is currently connected to the cloud</p>"
           },
           {
@@ -2736,6 +3134,7 @@
             "type": "Number",
             "optional": false,
             "field": "return_value",
+            "isArray": false,
             "description": "<p>Return value from the called function</p>"
           }
         ]
@@ -2754,15 +3153,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_7",
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.7",
     "name": "PostV1DevicesDeviceidFunctionname"
   },
   {
     "type": "put",
     "url": "/v1/devices/:deviceId/ping",
     "title": "Ping a device",
-    "group": "Devices_7",
+    "group": "Devices.7",
     "description": "<p>This will ping a device, enabling you to see if your device is online or offline</p>",
     "parameter": {
       "fields": {
@@ -2772,6 +3171,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": ""
           },
           {
@@ -2779,6 +3179,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug. <em>Product endpoint only</em>.</p>"
           }
         ]
@@ -2792,12 +3193,12 @@
     "examples": [
       {
         "title": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/ping \\",
-        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/ping \\\n       -X PUT \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/ping \\\n       -X PUT \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Ping a product device",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567/ping \\\n       -X PUT \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567/ping \\\n       -X PUT \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -2809,6 +3210,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "online",
+            "isArray": false,
             "description": "<p>Indicates if the device is currently online</p>"
           }
         ]
@@ -2822,8 +3224,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_7",
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.7",
     "name": "PutV1DevicesDeviceidPing"
   },
   {
@@ -2838,6 +3240,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2845,20 +3248,25 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
-          },
-          {
-            "group": "Parameter",
-            "optional": true,
-            "field": "name",
-            "description": "<p>The desired name for the device</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>The desired name for the device</p>"
+      }
+    ],
     "name": "updateDeviceName",
     "description": "<p>Rename a device, either owned by a user or a product</p>",
-    "group": "Devices_8",
+    "group": "Devices.8",
     "permission": [
       {
         "name": "devices:update"
@@ -2867,12 +3275,12 @@
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -d name=phancy_photon \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -d name=phancy_photon \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Rename a product device",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567 \\\n       -d name=phancy_photon \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567 \\\n       -d name=phancy_photon \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -2884,6 +3292,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2891,6 +3300,7 @@
             "type": "String",
             "optional": false,
             "field": "name",
+            "isArray": false,
             "description": "<p>Device name</p>"
           },
           {
@@ -2898,6 +3308,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -2911,15 +3322,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_8"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.8"
   },
   {
     "type": "put",
     "url": "/v1/devices/:deviceId",
     "title": "Add device notes",
     "name": "updateDeviceNotes",
-    "group": "Devices_9",
+    "group": "Devices.9",
     "permission": [
       {
         "name": "devices:update"
@@ -2933,6 +3344,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2940,27 +3352,31 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "notes",
-            "description": "<p>Notes that you would like to add to the device</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "notes",
+        "isArray": false,
+        "description": "<p>Notes that you would like to add to the device</p>"
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -d notes=\"A fancy device note\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -d notes=\"A fancy device note\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Add notes to a product device",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567 \\\n       -d notes=\"A fancy device note\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/0123456789abcdef01234567 \\\n       -d notes=\"A fancy device note\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -2972,6 +3388,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -2979,6 +3396,7 @@
             "type": "String",
             "optional": false,
             "field": "notes",
+            "isArray": false,
             "description": "<p>Notes that have been added to the device</p>"
           },
           {
@@ -2986,6 +3404,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -2999,8 +3418,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Devices_9"
+    "filename": "src/views/api.js",
+    "groupTitle": "Devices.9"
   },
   {
     "type": "post",
@@ -3014,6 +3433,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -3021,6 +3441,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
@@ -3028,16 +3449,16 @@
     },
     "name": "updateDeviceDiagnostics",
     "description": "<p>Refresh diagnostic vitals for a single device. This will instruct the device to publish a new event to the Device Cloud containing a device vitals payload. This is an asynchronous request: the HTTP request returns immediately after the request to the device is sent. In order for the device to respond with a vitals payload, it must be online and connected to the Device Cloud.</p> <p>The device will respond by publishing an event named <code>spark/device/diagnostics/update</code>. See the description of <a href=\"#device-vitals-event\">the device vitals event</a>.</p>",
-    "group": "Diagnostics_1",
+    "group": "Diagnostics.1",
     "examples": [
       {
-        "title": "$ curl -X POST \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/update?access_token=1234\"",
-        "content": "$ curl -X POST \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/update?access_token=1234\"",
+        "title": "$ curl -X POST https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/update \\",
+        "content": "$ curl -X POST https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/update \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Refresh diagnostics for a device inside a product",
-        "content": "$ curl -X POST \"https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567/update?access_token=1234\"",
+        "content": "$ curl -X POST https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567/update \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -3051,8 +3472,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Diagnostics_1"
+    "filename": "src/views/api.js",
+    "groupTitle": "Diagnostics.1"
   },
   {
     "type": "publish",
@@ -3065,7 +3486,7 @@
       }
     ],
     "description": "<p>The device publishes a Particle event named <code>spark/device/diagnostics/update</code> in response to <a href=\"#refresh-device-vitals\">a Device Cloud request to refresh device vitals</a>. The body of the event will contain the diagnostic vitals for the device. The payload of the diagnostics payload will differ per device type.</p> <p>To contextualize and interpret raw device vitals published by the device, please see the <a href=\"#get-device-vitals-metadata\">get device vitals metadata</a> API documentation.</p>",
-    "group": "Diagnostics_2",
+    "group": "Diagnostics.2",
     "success": {
       "fields": {
         "Success 200": [
@@ -3074,433 +3495,1773 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The device vitals payload information</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-",
+              "field": "-",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device",
+            "isArray": false,
             "description": "<p>Device vitals data containing diagnostics reported directly from the device</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network",
+            "isArray": false,
             "description": "<p>Represents diagnostics on all layers of the network stack that impact the device's ability to communicate with the Device Cloud</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular",
+            "isArray": false,
             "description": "<p>Cellular network information</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.radio_access_technology",
+            "isArray": false,
             "description": "<p>The human readible form of the access technology. Possible values are 2G, 3G, LTE</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.operator",
+            "isArray": false,
             "description": "<p>The name of the company operating the tower on which the device is currently connected</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.cell_global_identity",
+            "isArray": false,
             "description": "<p>A globally unique identifier that can be used to geographically locate the tower to which a device is connected</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular.cell_global_identity",
+              "parentNode": {
+                "path": "-.device.network.cellular",
+                "parentNode": {
+                  "path": "-.device.network",
+                  "parentNode": {
+                    "path": "-.device",
+                    "parentNode": {
+                      "path": "-",
+                      "field": "-",
+                      "type": "Object",
+                      "isArray": false
+                    },
+                    "field": "-.device",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device.network",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network.cellular",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular.cell_global_identity",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.cell_global_identity.mobile_country_code",
+            "isArray": false,
             "description": "<p>MCC. Can be used together with the Mobile Network Code (MNC) to determine the mobile network operator (i.e. mcc:310 and mnc:410 is AT&amp;T)</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular.cell_global_identity",
+              "parentNode": {
+                "path": "-.device.network.cellular",
+                "parentNode": {
+                  "path": "-.device.network",
+                  "parentNode": {
+                    "path": "-.device",
+                    "parentNode": {
+                      "path": "-",
+                      "field": "-",
+                      "type": "Object",
+                      "isArray": false
+                    },
+                    "field": "-.device",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device.network",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network.cellular",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular.cell_global_identity",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.cell_global_identity.mobile_network_code",
+            "isArray": false,
             "description": "<p>MNC. Can be used together with the Mobile Country Code (MCC) to determine the mobile network operator (i.e. mcc:310 and mnc:410 is AT&amp;T). This is a string because leading zeros are significant for MNC</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular.cell_global_identity",
+              "parentNode": {
+                "path": "-.device.network.cellular",
+                "parentNode": {
+                  "path": "-.device.network",
+                  "parentNode": {
+                    "path": "-.device",
+                    "parentNode": {
+                      "path": "-",
+                      "field": "-",
+                      "type": "Object",
+                      "isArray": false
+                    },
+                    "field": "-.device",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device.network",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network.cellular",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular.cell_global_identity",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.cell_global_identity.location_area_code",
+            "isArray": false,
             "description": "<p>a unique number identifying the current location area. A location area is a set of base stations that are grouped together to optimize signalling</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.cellular.cell_global_identity",
+              "parentNode": {
+                "path": "-.device.network.cellular",
+                "parentNode": {
+                  "path": "-.device.network",
+                  "parentNode": {
+                    "path": "-.device",
+                    "parentNode": {
+                      "path": "-",
+                      "field": "-",
+                      "type": "Object",
+                      "isArray": false
+                    },
+                    "field": "-.device",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device.network",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network.cellular",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.cellular.cell_global_identity",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.cellular.cell_global_identity.cell_id",
+            "isArray": false,
             "description": "<p>a generally unique number used to identify each Base Transceiver Station (BTS) or sector of a BTS within a location area code</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal",
+            "isArray": false,
             "description": "<p>The signal strength and quality metrics</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.at",
+            "isArray": false,
             "description": "<p>The detailed radio access technology, which determines the range of good signal strength and quality. Possible values are Wi-Fi, GSM, EDGE, UMTS, CDMA, LTE, LTE Cat-M1, LTE Cat-NB1</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.strength",
+            "isArray": false,
             "description": "<p>Measure of the current radio network strength in % (0-100)</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.strength_units",
+            "isArray": false,
             "description": "<p>Always %</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.strengthv",
+            "isArray": false,
             "description": "<p>Signal strength raw value specific to the access technology</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.strengthv_units",
+            "isArray": false,
             "description": "<p>Always dbM</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.strengthv_type",
+            "isArray": false,
             "description": "<p>The algorithm used to calculate signal strength. Possible values are RSSI (Wi-Fi), RXLEV (2G), RSCP (3G), RSRP (LTE)</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.quality",
+            "isArray": false,
             "description": "<p>Measure of the current radio connection quality in % (0-100)</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.quality_units",
+            "isArray": false,
             "description": "<p>Always %</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.qualityv",
+            "isArray": false,
             "description": "<p>Signal quality raw value specific to the access technology</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.qualityv_units",
+            "isArray": false,
             "description": "<p>Always dB</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.signal",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.signal",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.signal.qualityv_type",
+            "isArray": false,
             "description": "<p>The algorithm used to calculate signal quality. Possible values are SNR (Wi-Fi), RXQUAL (2G), ECN0 (3G), RSRQ (LTE)</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.connection",
+            "isArray": false,
             "description": "<p>Statistics about the network</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.connection",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.connection.status",
+            "isArray": false,
             "description": "<p>Status of the network connection. When receiving a vitals event through the Cloud it should always be connected. Possible values are turned_off, turning_on, disconnected, connecting, connected, disconnecting, turning_off</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.connection",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.connection.error",
+            "isArray": false,
             "description": "<p>A platform-specific error code that is returned by the low-level Device OS function for the most recent network connectivity event</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.connection",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.connection.disconnects",
+            "isArray": false,
             "description": "<p>Count of network disconnects</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.connection",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.connection.attempts",
+            "isArray": false,
             "description": "<p>Number of attempts required to establish a successful network connection</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.network.connection",
+              "parentNode": {
+                "path": "-.device.network",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.network",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.network.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.network.connection.disconnect_reason",
+            "isArray": false,
             "description": "<p>Last reason the network got disconnected. Possible values are none, error, user, network_off, listening, sleep, reset</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud",
+            "isArray": false,
             "description": "<p>Device Cloud communication information</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.connection",
+            "isArray": false,
             "description": "<p>Information on the state of the device's cloud connection</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.connection",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.connection.status",
+            "isArray": false,
             "description": "<p>Status of the cloud connection. When receiving a vitals event through the Cloud it should always be connected. Possible values are disconnected, connecting, connected, disconnecting</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.connection",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.connection.error",
+            "isArray": false,
             "description": "<p>A platform-specific error code that is returned by the low-level Device OS function for the most recent cloud connectivity event</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.connection",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.connection.attempts",
+            "isArray": false,
             "description": "<p>Number of attempts required to establish a successful cloud connection</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.disconnects",
+            "isArray": false,
             "description": "<p>The number of unexpected disconnections from the cloud since the last reset</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.connection",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.connection",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.connection.disconnect_reason",
+            "isArray": false,
             "description": "<p>Last reason the cloud connection got disconnected. Possible values are none, error, user, network_disconnect, listening</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.coap",
+            "isArray": false,
             "description": "<p>Information regarding the underlying communication protocol</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.coap",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.coap",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.coap.transmit",
+            "isArray": false,
             "description": "<p>The number of CoAP messages sent by the device to the cloud</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.coap",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.coap",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.coap.retransmit",
+            "isArray": false,
             "description": "<p>The number of times a CoAP message was resent by the device to the cloud due to the original message not being acknowledged</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.coap",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.coap",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.coap.unack",
+            "isArray": false,
             "description": "<p>The number of CoAP messages that were resent the maximum number of times by the device, still not acknowledged by the cloud then dropped</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.coap",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.coap",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.coap.round_trip",
+            "isArray": false,
             "description": "<p>The round-trip time of the last device to cloud message in milliseconds</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.publish",
+            "isArray": false,
             "description": "<p>Information regarding publish attempts from the device</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.cloud.publish",
+              "parentNode": {
+                "path": "-.device.cloud",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.cloud.publish",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.cloud.publish.rate_limited",
+            "isArray": false,
             "description": "<p>The current count of rate limited publishes since the device was reset</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.power",
+            "isArray": false,
             "description": "<p>Concerns sources of device power. <em>This will only be populated for devices with on-board power management.</em></p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.power",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.power",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.power.battery",
+            "isArray": false,
             "description": "<p>Information about batteries</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.power.battery",
+              "parentNode": {
+                "path": "-.device.power",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.power",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.power.battery",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.power.battery.charge",
+            "isArray": false,
             "description": "<p>Battery charge as a percent</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.power.battery",
+              "parentNode": {
+                "path": "-.device.power",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.power",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.power.battery",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.power.battery.state",
+            "isArray": false,
             "description": "<p>The current charging state of the battery. Possible values are unknown, not_charging, charging, charged, discharging, fault, disconnected</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.power",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.power",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.power.source",
+            "isArray": false,
             "description": "<p>An enumeration describing the current power source. Possible values are unknown, VIN, USB host, USB adapter, USB otg</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.system",
+            "isArray": false,
             "description": "<p>Indicators of general device health and system status</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.system",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.system",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.system.uptime",
+            "isArray": false,
             "description": "<p>The number of seconds the system has been running</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.system",
+              "parentNode": {
+                "path": "-.device",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.system",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.system.memory",
+            "isArray": false,
             "description": "<p>Memory metrics for the device</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.system.memory",
+              "parentNode": {
+                "path": "-.device.system",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.system",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.system.memory",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.system.memory.used",
+            "isArray": false,
             "description": "<p>User application static RAM + heap used</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.device.system.memory",
+              "parentNode": {
+                "path": "-.device.system",
+                "parentNode": {
+                  "path": "-.device",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.device",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.device.system",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.device.system.memory",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.device.system.memory.total",
+            "isArray": false,
             "description": "<p>Total amount of RAM available on the device in bytes</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-",
+              "field": "-",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service",
+            "isArray": false,
             "description": "<p>Device vitals data containing diagnostics collected by the Particle Device Cloud on behalf of the device</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.service",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.device",
+            "isArray": false,
             "description": "<p>Cloud to device information</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "-.service.device",
+              "parentNode": {
+                "path": "-.service",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.service",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service.device",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.device.status",
+            "isArray": false,
             "description": "<p>The result of the last attempt to decode the vitals message from the device. Should always be ok. Possible values are ok, error</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.service",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.cloud",
+            "isArray": false,
             "description": "<p>Information on the device's cloud session</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.service.cloud",
+              "parentNode": {
+                "path": "-.service",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.service",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service.cloud",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.cloud.uptime",
+            "isArray": false,
             "description": "<p>Duration of the device session in seconds</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.service.cloud",
+              "parentNode": {
+                "path": "-.service",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.service",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service.cloud",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.cloud.publish",
+            "isArray": false,
             "description": "<p>Cloud-side metrics for device messages</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.service.cloud.publish",
+              "parentNode": {
+                "path": "-.service.cloud",
+                "parentNode": {
+                  "path": "-.service",
+                  "parentNode": {
+                    "path": "-",
+                    "field": "-",
+                    "type": "Object",
+                    "isArray": false
+                  },
+                  "field": "-.service",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.service.cloud",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service.cloud.publish",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.cloud.publish.sent",
+            "isArray": false,
             "description": "<p>The total number of Particle.publish events sent by the device</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "-.service",
+              "parentNode": {
+                "path": "-",
+                "field": "-",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.coap",
+            "isArray": false,
             "description": "<p>Information regarding the underlying communication protocol</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "-.service.coap",
+              "parentNode": {
+                "path": "-.service",
+                "parentNode": {
+                  "path": "-",
+                  "field": "-",
+                  "type": "Object",
+                  "isArray": false
+                },
+                "field": "-.service",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "-.service.coap",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "-.service.coap.round_trip",
+            "isArray": false,
             "description": "<p>The round-trip time of the last cloud to device message in milliseconds</p>"
           }
         ]
@@ -3514,8 +5275,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Diagnostics_2"
+    "filename": "src/views/api.js",
+    "groupTitle": "Diagnostics.2"
   },
   {
     "type": "get",
@@ -3529,6 +5290,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -3536,6 +5298,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
@@ -3548,16 +5311,16 @@
     ],
     "name": "getLastDeviceDiagnostics",
     "description": "<p>Returns the last device vitals payload sent by the device to the Device Cloud.</p>",
-    "group": "Diagnostics_3",
+    "group": "Diagnostics.3",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/last?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/last?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/last \\",
+        "content": "$ curl https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/last \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get last known vitals for a device that's inside a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567/last?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567/last \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -3569,27 +5332,49 @@
             "type": "Object",
             "optional": false,
             "field": "diagnostics",
+            "isArray": false,
             "description": "<p>The last known device vitals object</p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "diagnostics",
+              "field": "diagnostics",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "diagnostics.updated_at",
+            "isArray": false,
             "description": "<p>Timestamp of when the diagnostic vitals record was reported</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "diagnostics",
+              "field": "diagnostics",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "diagnostics.deviceID",
+            "isArray": false,
             "description": "<p>ID of the device</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "diagnostics",
+              "field": "diagnostics",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "diagnostics.payload",
+            "isArray": false,
             "description": "<p>Full device vitals payload. See the <a href=\"#device-vitals-event\">device vitals</a> documentation for the structure of this object.</p>"
           }
         ]
@@ -3603,8 +5388,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Diagnostics_3"
+    "filename": "src/views/api.js",
+    "groupTitle": "Diagnostics.3"
   },
   {
     "type": "get",
@@ -3618,6 +5403,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -3625,25 +5411,30 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "ISO8601",
-            "optional": true,
-            "field": "start_date",
-            "description": "<p>Oldest diagnostic to return, inclusive</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "ISO8601",
-            "optional": true,
-            "field": "end_date",
-            "description": "<p>Newest diagnostic to return, exclusive</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "Date",
+        "optional": true,
+        "field": "start_date",
+        "isArray": false,
+        "description": "<p>Oldest diagnostic to return, inclusive. Date in ISO8601 format.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Date",
+        "optional": true,
+        "field": "end_date",
+        "isArray": false,
+        "description": "<p>Newest diagnostic to return, exclusive. Date in ISO8601 format.</p>"
+      }
+    ],
     "permission": [
       {
         "name": "devices.diagnostics:get"
@@ -3657,6 +5448,7 @@
             "type": "String",
             "optional": true,
             "field": "Accept",
+            "isArray": false,
             "description": "<p>Optionally set to <code>text/csv</code> to return historic device vitals as a CSV</p>"
           }
         ]
@@ -3664,21 +5456,21 @@
     },
     "name": "getAllDeviceDiagnostics",
     "description": "<p>Returns all stored device vital records sent by the device to the Device Cloud. Device vitals records will expire after 1 month.</p>",
-    "group": "Diagnostics_4",
+    "group": "Diagnostics.4",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/diagnostics/0123456789abcdef01234567 \\",
+        "content": "$ curl https://api.particle.io/v1/diagnostics/0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get all historical vitals for a device that's inside a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get historical vitals for a device scoped to a time period.",
-        "content": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567?access_token=1234&start_date=2017-12-18T12:37:07.318Z&end_date=2017-12-20T12:37:07.318Z\"",
+        "content": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567?start_date=2017-12-18T12:37:07.318Z&end_date=2017-12-20T12:37:07.318Z\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -3690,6 +5482,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "diagnostics",
+            "isArray": true,
             "description": "<p>An array of stored device vitals records. See the <a href=\"#device-vitals-event\">device vitals</a> documentation for the structure of the payload for each object in the array.</p>"
           }
         ]
@@ -3710,6 +5503,7 @@
             "type": "Object",
             "optional": false,
             "field": "bad_request",
+            "isArray": false,
             "description": "<p>when invalid start/end dates are provided</p>"
           }
         ]
@@ -3728,83 +5522,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Diagnostics_4"
-  },
-  {
-    "type": "get",
-    "url": "/v1/diagnostics/:deviceId/metadata",
-    "title": "Get device vitals metadata",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "deviceId",
-            "description": "<p>Device ID</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "productIdOrSlug",
-            "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
-          }
-        ]
-      }
-    },
-    "permission": [
-      {
-        "name": "devices.diagnostics.metadata:get"
-      }
-    ],
-    "name": "getMetadataForDeviceDiagnostics",
-    "description": "<p>Contextualizes and allows for interpretation of <a href=\"#refresh-device-vitals\">device vitals</a>. The objects in the device vitals payload map to the metadata objects returned by this endpoint. Metadata will vary depending on the device type, and is subject to change as more is learned about device health.</p> <p>Each metadata object mapping to a device vital can include:</p> <ul> <li><code>title</code>: A friendly name.</li> <li><code>type</code>: The data type of the vital returned by the device. Can be set to <code>number</code> or <code>string</code>.</li> <li><code>units</code>: Information on the specific unit of measurement, including how to convert the raw vital into the preferred unit of measurement.</li> <li><code>ranges</code>: Establishes healthy vital ranges. If outside the healthy range, the vital will be marked in the &quot;warning&quot; state in the Console. Ranges help assert whether a reported vital is above/below a specified value, or use a ratio between two related vitals as an indicator of health.</li> <li><code>values</code>: Similar to <code>ranges</code>, but maps reported vitals with a <code>type</code> of <code>string</code> to determine a healthy or warning state.</li> <li><code>messages</code>: Helpful messages to provide analysis and interpretation of diagnostics test results. Also includes a description of the vital.</li> <li><code>priority</code>: Used for visual ordering of device vitals on the Console.</li> <li><code>describes</code>: Creates a relationship between two vitals used for visual arrangement on the Console.</li> </ul>",
-    "group": "Diagnostics_5",
-    "examples": [
-      {
-        "title": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/metadata?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/diagnostics/0123456789abcdef01234567/metadata?access_token=1234\"",
-        "type": "bash"
-      },
-      {
-        "title": "Get vitals metadata for a device that's inside a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/diagnostics/0123456789abcdef01234567/metadata?access_token=1234\"",
-        "type": "bash"
-      }
-    ],
-    "success": {
-      "fields": {
-        "Success 200": [
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "diagnostics_metadata",
-            "description": "<p>Metadata for device vitals. See <a href=\"#refresh-device-vitals\">refresh device vitals</a> API docs for the device vitals payload.</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "GET /v1/diagnostics/0123456789abcdef01234567/metadata",
-          "content": "GET /v1/diagnostics/0123456789abcdef01234567/metadata\nHTTP/1.1 200 OK\n{\n  \"diagnostics_metadata\": {\n\t\"device\": {\n\t  \"power\": {\n\t\t\"battery\": {\n\t\t  \"charge\": {\n\t\t\t\"title\": \"battery charge\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"priority\": 1,\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"percent\",\n\t\t\t  \"convert\": {\n\t\t\t\t\"type\": \"round\"\n\t\t\t  }\n\t\t\t},\n\t\t\t\"ranges\": {\n\t\t\t  \"warning\": 20,\n\t\t\t  \"type\": \"below\"\n\t\t\t},\n\t\t\t\"messages\": {\n\t\t\t  \"description\": \"The state of charge of the device’s connected battery, represented as a percentage.\",\n\t\t\t  \"healthy\": \"The battery’s state of charge is in a healthy range.\",\n\t\t\t  \"warning\": \"The charge for this battery is low. Recharge the battery soon to prevent the device from losing power and going offline.\"\n\t\t\t}\n\t\t  },\n\t\t  \"state\": {\n\t\t\t\"title\": \"\",\n\t\t\t\"type\": \"string\",\n\t\t\t\"describes\": \"device.power.battery.charge\",\n\t\t\t\"values\": {\n\t\t\t  \"all\": [\n\t\t\t\t\"unknown\",\n\t\t\t\t\"not_charging\",\n\t\t\t\t\"charging\",\n\t\t\t\t\"charged\",\n\t\t\t\t\"discharging\",\n\t\t\t\t\"fault\"\n\t\t\t  ],\n\t\t\t  \"healthy\": [\n\t\t\t\t\"charging\",\n\t\t\t\t\"charged\",\n\t\t\t\t\"discharging\"\n\t\t\t  ],\n\t\t\t  \"warning\": [\n\t\t\t\t\"fault\",\n\t\t\t\t\"unknown\",\n\t\t\t\t\"not_charging\"\n\t\t\t  ]\n\t\t\t}\n\t\t  }\n\t\t}\n\t  },\n\t  \"system\": {\n\t\t\"memory\": {\n\t\t  \"used\": {\n\t\t\t\"title\": \"RAM used\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"priority\": 6,\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"kB\",\n\t\t\t  \"convert\": {\n\t\t\t\t\"type\": \"divide\",\n\t\t\t\t\"by\": 1024\n\t\t\t  }\n\t\t\t},\n\t\t\t\"ranges\": {\n\t\t\t  \"type\": \"ratio_above\",\n\t\t\t  \"ratio\": 0.9,\n\t\t\t  \"param1\": \"device.system.memory.used\",\n\t\t\t  \"param2\": \"device.system.memory.total\"\n\t\t\t},\n\t\t\t\"messages\": {\n\t\t\t  \"description\": \"The amount of memory used by the device, combining the heap and the user application’s static RAM in bytes.\",\n\t\t\t  \"healthy\": \"The device has a healthy amount of available memory.\",\n\t\t\t  \"warning\": \"The device may soon run out of available memory. This can result in unexpected failures in your firmware application. If possible, reduce the amount of RAM that your application uses.\"\n\t\t\t}\n\t\t  },\n\t\t  \"total\": {\n\t\t\t\"title\": \"\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"kB\",\n\t\t\t  \"convert\": {\n\t\t\t\t\"type\": \"divide\",\n\t\t\t\t\"by\": 1024\n\t\t\t  }\n\t\t\t},\n\t\t\t\"describes\": \"device.system.memory.used\"\n\t\t  }\n\t\t}\n\t  },\n\t  \"network\": {\n\t\t\"signal\": {\n\t\t  \"strengthv\": {\n\t\t\t\"title\": \"signal strength value\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"dBm\"\n\t\t\t},\n\t\t\t\"describes\": \"device.network.signal.strength\"\n\t\t  },\n\t\t  \"strength\": {\n\t\t\t\"title\": \"signal strength\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"priority\": 2,\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"percent\"\n\t\t\t},\n\t\t\t\"ranges\": {\n\t\t\t  \"type\": \"below\",\n\t\t\t  \"warning\": 20\n\t\t\t},\n\t\t\t\"messages\": {\n\t\t\t  \"description\": \"The strength of the device’s connection to the Cellular network, measured in decibels of received signal power.\",\n\t\t\t  \"healthy\": \"The device’s signal strength is in a healthy range, with a signal power value of {describes} (the closer to 0, the stronger the signal).\",\n\t\t\t  \"warning\": \"The device’s signal strength is poor, with a signal power value of {describes} (the further from 0, the weaker the signal). This can cause the device to drop offline unexpectedly. If possible, move the device to a place with better Cellular signal.\"\n\t\t\t}\n\t\t  }\n\t\t}\n\t  },\n\t  \"cloud\": {\n\t\t\"disconnects\": {\n\t\t  \"title\": \"disconnect events\",\n\t\t  \"type\": \"number\",\n\t\t  \"priority\": 3,\n\t\t  \"units\": \"count\",\n\t\t  \"ranges\": {\n\t\t\t\"type\": \"ratio_above\",\n\t\t\t\"ratio\": 0.0013,\n\t\t\t\"param1\": \"device.cloud.disconnects\",\n\t\t\t\"param2\": \"service.cloud.uptime\"\n\t\t  },\n\t\t  \"messages\": {\n\t\t\t\"description\": \"The number of times the device disconnected unexpectedly from the Particle Cloud since its last reset.\",\n\t\t\t\"healthy\": \"The device’s frequency of cloud disconnects is in a healthy range.\",\n\t\t\t\"warning\": \"The device is disconnecting from the Particle Cloud too frequently. Large numbers of cloud disconnects are often caused by poor signal strength or network congestion. If possible, move the device to a place with better Cellular signal.\"\n\t\t  }\n\t\t},\n\t\t\"publish\": {\n\t\t  \"rate_limited\": {\n\t\t\t\"title\": \"rate-limited publishes\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"priority\": 5,\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"count\"\n\t\t\t},\n\t\t\t\"ranges\": {\n\t\t\t  \"type\": \"ratio_above\",\n\t\t\t  \"ratio\": 0.05,\n\t\t\t  \"param1\": \"device.cloud.publish.rate_limited\",\n\t\t\t  \"param2\": \"service.cloud.publish.sent\"\n\t\t\t},\n\t\t\t\"messages\": {\n\t\t\t  \"description\": \"Particle devices are allowed to publish an average of 1 event per second in application firmware. Publishing at a rate higher than this will result in rate limiting of events.\",\n\t\t\t  \"healthy\": \"The device’s published events are being sent to the Particle Cloud successfully.\",\n\t\t\t  \"warning\": \"The device is publishing messages too rapidly, and is being rate limited. This causes messages sent by firmware to be blocked from reaching the Particle cloud. Reduce the frequency of published messages in your application firmware to below 1 per second to avoid rate limiting.\"\n\t\t\t}\n\t\t  }\n\t\t}\n\t  }\n\t},\n\t\"service\": {\n\t  \"coap\": {\n\t\t\"round_trip\": {\n\t\t  \"title\": \"round-trip time\",\n\t\t  \"type\": \"number\",\n\t\t  \"priority\": 4,\n\t\t  \"units\": {\n\t\t\t\"title\": \"ms\"\n\t\t  },\n\t\t  \"messages\": {\n\t\t\t\"description\": \"The amount of time it takes for the device to successfully respond to a CoAP message sent by the Particle Cloud in milliseconds.\",\n\t\t\t\"healthy\": \"The device has a round-trip time in a healthy range.\",\n\t\t\t\"warning\": \"The device is taking a long time to respond to messages from the Particle Cloud. A higher than average round trip time is normally caused by poor signal strength or network congestion. If possible, move the device to a place with better Cellular signal.\"\n\t\t  }\n\t\t}\n\t  },\n\t  \"cloud\": {\n\t\t\"publish\": {\n\t\t  \"sent\": {\n\t\t\t\"title\": \"Total events published\",\n\t\t\t\"type\": \"number\",\n\t\t\t\"units\": {\n\t\t\t  \"title\": \"count\"\n\t\t\t},\n\t\t\t\"describes\": \"device.cloud.publish.rate_limited\"\n\t\t  }\n\t\t}\n\t  }\n\t},\n  }\n}",
-          "type": "json"
-        }
-      ]
-    },
-    "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Diagnostics_5"
+    "filename": "src/views/api.js",
+    "groupTitle": "Diagnostics.4"
   },
   {
     "type": "get",
     "url": "/v1/sims/:iccid/status",
     "title": "Get cellular network status",
     "name": "getCellularNetworkStatus",
-    "group": "Diagnostics_6",
+    "group": "Diagnostics.6",
     "description": "<p>Get cellular network status for a given device. Kicks off a long running task that checks if the device/SIM has an active data session with a cell tower. Values for keys in the <code>sim_status</code> object will be <code>null</code> until the task has finished. Poll the endpoint until <code>meta.state</code> is <code>complete</code>. At this point, the <code>sim_status</code> object will be populated.</p> <p>Note that responses are cached by the cellular network providers. This means that on occasion, the real-time status of the device/SIM may not align with the results of this test.</p>",
     "parameter": {
       "fields": {
@@ -3814,6 +5540,7 @@
             "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>The ICCID of the desired SIM</p>"
           },
           {
@@ -3821,6 +5548,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
@@ -3834,12 +5562,12 @@
     "examples": [
       {
         "title": "Get cellular network status",
-        "content": "$ curl \"https://api.particle.io/v1/sims/1234/status?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/sims/1234/status \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get cellular network status for device inside a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/sims/1234/status?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims/1234/status \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -3851,55 +5579,99 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
-            "description": "<p>whether or not the request was successful</p>"
+            "isArray": false,
+            "description": "<p>Whether the request was successful</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
             "field": "meta",
+            "isArray": false,
             "description": "<p>Meta information about the task</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.created_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the task was kicked off</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.expires_at",
+            "isArray": false,
             "description": "<p>UTC timestamp when the task results will expire</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.check_again_after",
+            "isArray": false,
             "description": "<p>UTC timestamp of the suggested time after which to check status again</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.method",
+            "isArray": false,
             "description": "<p>Set to <code>async</code> to communicate an asynchronous request</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.state",
+            "isArray": false,
             "description": "<p>the state of the task. Can be <code>pending</code> or <code>complete</code>.</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "meta",
+              "field": "meta",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "meta.task_id",
+            "isArray": false,
             "description": "<p>the id of the task</p>"
           },
           {
@@ -3907,27 +5679,49 @@
             "type": "Object",
             "optional": false,
             "field": "sim_status",
+            "isArray": false,
             "description": "<p>Status information about the SIM</p>"
           },
           {
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
+            "parentNode": {
+              "path": "sim_status",
+              "field": "sim_status",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim_status.connected",
+            "isArray": false,
             "description": "<p>Whether the device/SIM has an active data session with a cell tower (both GSM and data connection are <code>true</code>)?</p>"
           },
           {
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
+            "parentNode": {
+              "path": "sim_status",
+              "field": "sim_status",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim_status.gsm_connection",
+            "isArray": false,
             "description": "<p>Whether the device/SIM has a GSM connection?</p>"
           },
           {
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
+            "parentNode": {
+              "path": "sim_status",
+              "field": "sim_status",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim_status.data_connection",
+            "isArray": false,
             "description": "<p>Whether the device/SIM has a GPRS/LTE/Data connection?</p>"
           }
         ]
@@ -3941,8 +5735,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Diagnostics_6"
+    "filename": "src/views/api.js",
+    "groupTitle": "Diagnostics.6"
   },
   {
     "type": "get",
@@ -3956,18 +5750,19 @@
             "type": "String",
             "optional": false,
             "field": "eventPrefix",
+            "isArray": false,
             "description": "<p>Filters the stream to only events starting with the specified prefix. <strong>The event prefix filter is required for this endpoint.</strong></p>"
           }
         ]
       }
     },
     "name": "GetEvents",
-    "group": "Events_1",
-    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all public events and private events for your devices matching the filter.</p> <p>Note that as of April 2018, the event prefix filter is required. It was optional before.</p>",
+    "group": "Events.1",
+    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all events. for your devices matching the filter.</p> <p>Note that as of April 2018, the event prefix filter is required. It was optional before.</p>",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/events/temp?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/events/temp?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/events/temp \\",
+        "content": "$ curl https://api.particle.io/v1/events/temp \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -3979,6 +5774,7 @@
             "type": "String",
             "optional": false,
             "field": "event",
+            "isArray": false,
             "description": "<p>event name</p>"
           },
           {
@@ -3986,6 +5782,7 @@
             "type": "String",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>event data in JSON format</p>"
           }
         ]
@@ -4004,12 +5801,12 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Events_1"
+    "filename": "src/views/event.js",
+    "groupTitle": "Events.1"
   },
   {
     "type": "get",
-    "url": "/v1/devices/events/[:eventPrefix]",
+    "url": "/v1/devices/events/:eventPrefix",
     "title": "Get a stream of your events",
     "parameter": {
       "fields": {
@@ -4019,23 +5816,24 @@
             "type": "String",
             "optional": true,
             "field": "eventPrefix",
+            "isArray": false,
             "description": "<p>Filters the stream to only events starting with the specified prefix. Omit to get all events.</p>"
           }
         ]
       }
     },
     "name": "GetDeviceEvents",
-    "group": "Events_2",
-    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all public and private events for your devices.</p>",
+    "group": "Events.2",
+    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all events for your devices.</p>",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/devices/events?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/devices/events?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/devices/events \\",
+        "content": "$ curl https://api.particle.io/v1/devices/events \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Filtered Stream",
-        "content": "$ curl \"https://api.particle.io/v1/devices/events/temp?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/devices/events/temp \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4047,6 +5845,7 @@
             "type": "String",
             "optional": false,
             "field": "event",
+            "isArray": false,
             "description": "<p>event name</p>"
           },
           {
@@ -4054,6 +5853,7 @@
             "type": "String",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>event data in JSON format</p>"
           }
         ]
@@ -4067,8 +5867,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Events_2"
+    "filename": "src/views/event.js",
+    "groupTitle": "Events.2"
   },
   {
     "type": "get",
@@ -4082,6 +5882,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4089,23 +5890,24 @@
             "type": "String",
             "optional": true,
             "field": "eventPrefix",
+            "isArray": false,
             "description": "<p>Filters the stream to only events starting with the specified prefix</p>"
           }
         ]
       }
     },
     "name": "GetDeviceEvents",
-    "group": "Events_3",
-    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all public and private events for the specified device.</p>",
+    "group": "Events.3",
+    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all events for the specified device.</p>",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567/events?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567/events?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/events \\",
+        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/events \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Filtered Stream",
-        "content": "$ curl \"https://api.particle.io/v1/devices/0123456789abcdef01234567/events/temp?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/devices/0123456789abcdef01234567/events/temp \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4117,6 +5919,7 @@
             "type": "String",
             "optional": false,
             "field": "event",
+            "isArray": false,
             "description": "<p>event name</p>"
           },
           {
@@ -4124,6 +5927,7 @@
             "type": "String",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>event data in JSON format</p>"
           }
         ]
@@ -4137,12 +5941,12 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Events_3"
+    "filename": "src/views/event.js",
+    "groupTitle": "Events.3"
   },
   {
     "type": "get",
-    "url": "/v1/products/:productIdOrSlug/events/[:eventPrefix]",
+    "url": "/v1/products/:productIdOrSlug/events/:eventPrefix",
     "title": "Product event stream",
     "parameter": {
       "fields": {
@@ -4152,6 +5956,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -4159,6 +5964,7 @@
             "type": "String",
             "optional": true,
             "field": "eventPrefix",
+            "isArray": false,
             "description": "<p>Filters the stream to only events starting with the specified prefix</p>"
           }
         ]
@@ -4170,12 +5976,12 @@
       }
     ],
     "name": "GetProductEvents",
-    "group": "Events_4",
-    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all public and private events for a product.</p>",
+    "group": "Events.4",
+    "description": "<p>Open a stream of <a href=\"http://www.w3.org/TR/eventsource/\">Server Sent Events</a> for all events for a product.</p>",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/photon/events?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/products/photon/events?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/products/photon/events \\",
+        "content": "$ curl https://api.particle.io/v1/products/photon/events \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4187,6 +5993,7 @@
             "type": "String",
             "optional": false,
             "field": "event",
+            "isArray": false,
             "description": "<p>event name</p>"
           },
           {
@@ -4194,6 +6001,7 @@
             "type": "String",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>event data in JSON format</p>"
           }
         ]
@@ -4207,54 +6015,46 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Events_4"
+    "filename": "src/views/product.js",
+    "groupTitle": "Events.4"
   },
   {
     "type": "post",
     "url": "/v1/devices/events",
     "title": "Publish an event",
     "description": "<p>Publish an event</p>",
-    "group": "Events_6",
+    "group": "Events.6",
     "name": "CreateEvent",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "name",
-            "description": "<p>Event name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "data",
-            "description": "<p>Event data</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "private",
-            "description": "<p>If you wish this event to be publicly visible</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "ttl",
-            "description": "<p>How long the event should persist</p>"
-          }
-        ]
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>Event name</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "data",
+        "isArray": false,
+        "description": "<p>Event data</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": true,
+        "field": "ttl",
+        "isArray": false,
+        "description": "<p>How long the event should persist</p>"
       }
-    },
+    ],
     "examples": [
       {
         "title": "$ curl https://api.particle.io/v1/devices/events \\",
-        "content": "$ curl https://api.particle.io/v1/devices/events \\\n       -d \"name=myevent\" \\\n       -d \"data=Hello World\" \\\n       -d \"private=true\" \\\n       -d \"ttl=60\" \\\n       -d \"access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/devices/events \\\n       -d \"name=myevent\" \\\n       -d \"data=Hello World\" \\\n       -d \"ttl=60\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
@@ -4273,15 +6073,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Events_6"
+    "filename": "src/views/event.js",
+    "groupTitle": "Events.6"
   },
   {
     "type": "post",
-    "url": "/v1/products/:productId/events",
+    "url": "/v1/products/:productIdOrSlug/events",
     "title": "Publish a product event",
     "description": "<p>Publish an event that is sent to the product's event stream</p>",
-    "group": "Events_7",
+    "group": "Events.7",
     "name": "PublishProductEvent",
     "parameter": {
       "fields": {
@@ -4290,33 +6090,39 @@
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "name",
-            "description": "<p>Event name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "data",
-            "description": "<p>Event data</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "private",
-            "description": "<p>If you wish this event to be publicly visible</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "ttl",
-            "description": "<p>How long the event should persist</p>"
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>Event name</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "data",
+        "isArray": false,
+        "description": "<p>Event data</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": true,
+        "field": "ttl",
+        "isArray": false,
+        "description": "<p>How long the event should persist</p>"
+      }
+    ],
     "permission": [
       {
         "name": "events:send"
@@ -4325,7 +6131,7 @@
     "examples": [
       {
         "title": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/events\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/events\" \\\n       -d \"name=myevent\" \\\n       -d \"data=Hello World\" \\\n       -d \"private=true\" \\\n       -d \"ttl=60\" \\\n       -d access_token=1234",
+        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/events\" \\\n       -d \"name=myevent\" \\\n       -d \"data=Hello World\" \\\n       -d \"ttl=60\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4339,13 +6145,13 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Events_7"
+    "filename": "src/views/product.js",
+    "groupTitle": "Events.7"
   },
   {
     "type": "put",
     "url": "/v1/devices/:deviceId",
-    "title": "Update device firmware",
+    "title": "Flash a device with source code",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -4354,95 +6160,57 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
-          }
-        ],
-        "Flash a device with source code": [
-          {
-            "group": "flashCode",
-            "type": "String",
-            "optional": false,
-            "field": "file",
-            "description": "<p>The source code encoded in <code>multipart/form-data</code> format</p>"
-          },
-          {
-            "group": "flashCode",
-            "type": "String",
-            "optional": true,
-            "field": "build_target_version",
-            "description": "<p>The firmware version to compile against. Defaults to latest</p>"
-          }
-        ],
-        "Flash a device with a pre-compiled binary": [
-          {
-            "group": "flashBinary",
-            "type": "String",
-            "optional": false,
-            "field": "file",
-            "description": "<p>The pre-compiled binary encoded in <code>multipart/form-data</code> format.</p>"
-          }
-        ],
-        "Flash a device with a bundle": [
-          {
-            "group": "flashBundle",
-            "type": "String",
-            "optional": false,
-            "field": "file",
-            "description": "<p>The bundle encoded in <code>multipart/form-data</code> format. The MIME type must be <code>application/zip</code>.</p>"
           }
         ]
       }
     },
-    "name": "UpdateDeviceFirmware",
-    "description": "<p>Update the device firmware from source or binary</p>",
-    "group": "Firmware_1",
+    "name": "FlashSourceCode",
+    "description": "<p>Update the device firmware from source</p>",
+    "group": "Firmware.1",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>The source code encoded in <code>multipart/form-data</code> format</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "build_target_version",
+        "isArray": false,
+        "description": "<p>The firmware version to compile against. Defaults to latest</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "flashCode",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/devices/0123456789abcdef01234567?access_token=1234\" \\\n       -F \"file=@application.cpp;filename=application.cpp\" \\\n       -F \"file1=@lib/my_lib.cpp;filename=lib/my_lib.cpp\" \\\n       -F \"file2=@lib/my_lib.h;filename=lib/my_lib.h\"",
-        "type": "bash"
-      },
-      {
-        "title": "flashBinary",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/devices/0123456789abcdef01234567?access_token=1234\" \\\n       -F file=@my-firmware-app.bin",
-        "type": "bash"
-      },
-      {
-        "title": "flashBundle",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/devices/0123456789abcdef01234567?access_token=1234\" \\\n       -F \"file=@my-firmware-bundle.zip;type=application/zip\"",
+        "title": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -F \"file=@application.cpp;filename=application.cpp\" \\\n       -F \"file1=@lib/my_lib.cpp;filename=lib/my_lib.cpp\" \\\n       -F \"file2=@lib/my_lib.h;filename=lib/my_lib.h\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "flashCode",
+          "title": "PUT /v1/devices/0123456789abcdef01234567",
           "content": "PUT /v1/devices/0123456789abcdef01234567\nHTTP/1.1 200 OK\n{\n  \"ok\": true,\n  \"message\": \"Update started\"\n}",
-          "type": "json"
-        },
-        {
-          "title": "flashBinary",
-          "content": "PUT /v1/devices/0123456789abcdef01234567\nHTTP/1.1 200 OK\n{\n  \"id\": \"0123456789abcdef01234567\",\n  \"status\": \"Update started\"\n}",
-          "type": "json"
-        },
-        {
-          "title": "flashBundle",
-          "content": "PUT /v1/devices/0123456789abcdef01234567\nHTTP/1.1 200 OK\n{\n  \"id\": \"0123456789abcdef01234567\",\n  \"status\": \"Update started\"\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Firmware_1"
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.1"
   },
   {
-    "type": "post",
-    "url": "/v1/binaries",
-    "title": "Compile source code",
-    "name": "compileSource",
-    "description": "<p>Compile source code into a binary for a device</p>",
-    "group": "Firmware_2",
+    "type": "put",
+    "url": "/v1/devices/:deviceId",
+    "title": "Flash a device with a pre-compiled binary",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -4450,37 +6218,142 @@
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "file",
-            "description": "<p>The source code encoded in <code>multipart/form-data</code> format</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "platform_id",
-            "description": "<p>The platform ID to target the compilation</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "product_id",
-            "description": "<p>The product to target for compilation</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "build_target_version",
-            "description": "<p>The firmware version to compile against. Defaults to latest</p>"
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
           }
         ]
       }
     },
+    "name": "UpdateDeviceFirmware",
+    "description": "<p>Update the device firmware from a binary</p>",
+    "group": "Firmware.1",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>The pre-compiled binary encoded in <code>multipart/form-data</code> format.</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl -X POST \"https://api.particle.io/v1/binaries?access_token=1234\" \\",
-        "content": "$ curl -X POST \"https://api.particle.io/v1/binaries?access_token=1234\" \\\n       -F platform_id=6 \\\n       -F \"file=@application.cpp;filename=application.cpp\" \\\n       -F \"file1=@lib/my_lib.cpp;filename=lib/my_lib.cpp\" \\\n       -F \"file2=@lib/my_lib.h;filename=lib/my_lib.h\"",
+        "title": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -F file=@my-firmware-app.bin",
+        "type": "bash"
+      }
+    ],
+    "success": {
+      "examples": [
+        {
+          "title": "PUT /v1/devices/0123456789abcdef01234567",
+          "content": "PUT /v1/devices/0123456789abcdef01234567\nHTTP/1.1 200 OK\n{\n  \"id\": \"0123456789abcdef01234567\",\n  \"status\": \"Update started\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "version": "0.0.0",
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.1"
+  },
+  {
+    "type": "put",
+    "url": "/v1/devices/:deviceId",
+    "title": "Flash a device with a bundle",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
+          }
+        ]
+      }
+    },
+    "name": "UpdateDeviceFirmware",
+    "description": "<p>Update the device firmware from a bundle</p>",
+    "group": "Firmware.1",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>The bundle encoded in <code>multipart/form-data</code> format. The MIME type must be <code>application/zip</code>.</p>"
+      }
+    ],
+    "examples": [
+      {
+        "title": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\",
+        "content": "$ curl -X PUT https://api.particle.io/v1/devices/0123456789abcdef01234567 \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -F \"file=@my-firmware-bundle.zip;type=application/zip\"",
+        "type": "bash"
+      }
+    ],
+    "success": {
+      "examples": [
+        {
+          "title": "PUT /v1/devices/0123456789abcdef01234567",
+          "content": "PUT /v1/devices/0123456789abcdef01234567\nHTTP/1.1 200 OK\n{\n  \"id\": \"0123456789abcdef01234567\",\n  \"status\": \"Update started\"\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "version": "0.0.0",
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.1"
+  },
+  {
+    "type": "post",
+    "url": "/v1/binaries",
+    "title": "Compile source code",
+    "name": "compileSource",
+    "description": "<p>Compile source code into a binary for a device</p>",
+    "group": "Firmware.2",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>The source code encoded in <code>multipart/form-data</code> format</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": true,
+        "field": "platform_id",
+        "isArray": false,
+        "description": "<p>The platform ID to target the compilation</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "product_id",
+        "isArray": false,
+        "description": "<p>The product to target for compilation</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "build_target_version",
+        "isArray": false,
+        "description": "<p>The firmware version to compile against. Defaults to latest</p>"
+      }
+    ],
+    "examples": [
+      {
+        "title": "$ curl -X POST https://api.particle.io/v1/binaries \\",
+        "content": "$ curl -X POST https://api.particle.io/v1/binaries \\\n       -F platform_id=6 \\\n       -F \"file=@application.cpp;filename=application.cpp\" \\\n       -F \"file1=@lib/my_lib.cpp;filename=lib/my_lib.cpp\" \\\n       -F \"file2=@lib/my_lib.h;filename=lib/my_lib.h\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4494,33 +6367,30 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Firmware_2"
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.2"
   },
   {
     "type": "get",
     "url": "/v1/build_targets",
     "title": "List firmware build targets",
     "name": "listBuildTargets",
-    "description": "<p>Lists the firmware versions for all platforms that can be used as build targets during firmware compilation</p>",
-    "group": "Firmware_4",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "featured",
-            "description": "<p>When true, show most relevant (featured) build targets only.</p>"
-          }
-        ]
+    "description": "<p>Lists the firmware versions for all platforms that can be used as build targets during firmware compilation.</p> <p>Note: This endpoint does not require an access token.</p>",
+    "group": "Firmware.4",
+    "query": [
+      {
+        "group": "Query",
+        "type": "Boolean",
+        "optional": false,
+        "field": "featured",
+        "isArray": false,
+        "description": "<p>When true, show most relevant (featured) build targets only.</p>"
       }
-    },
+    ],
     "examples": [
       {
         "title": "buildTargets",
-        "content": "$ curl \"https://api.particle.io/v1/build_targets\"",
+        "content": "$ curl https://api.particle.io/v1/build_targets",
         "type": "bash"
       }
     ],
@@ -4532,6 +6402,7 @@
             "type": "Array",
             "optional": false,
             "field": "targets",
+            "isArray": false,
             "description": "<p>Array of build target objects</p>"
           },
           {
@@ -4539,6 +6410,7 @@
             "type": "Object",
             "optional": false,
             "field": "platforms",
+            "isArray": false,
             "description": "<p>Name of each platform ID with a build target</p>"
           }
         ]
@@ -4552,8 +6424,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/buildTarget.js",
-    "groupTitle": "Firmware_4"
+    "filename": "src/views/buildTarget.js",
+    "groupTitle": "Firmware.4"
   },
   {
     "type": "put",
@@ -4566,7 +6438,7 @@
       }
     ],
     "description": "<p>Locks a product device to a specific version of product firmware. This device will download and run this firmware if it is not already running it the next time it connects to the cloud. You can optionally trigger an immediate update to this firmware for devices that are currently online</p>",
-    "group": "Firmware_5",
+    "group": "Firmware.5",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -4575,6 +6447,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4582,29 +6455,35 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": false,
-            "field": "desired_firmware_version",
-            "description": "<p>The firmware version the device should be locked to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "flash",
-            "description": "<p>Set to <code>true</code> to immediately flash to a device. Will only successfully deliver the firmware update if the device is currently online and connected to the cloud.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": false,
+        "field": "desired_firmware_version",
+        "isArray": false,
+        "description": "<p>The firmware version the device should be locked to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "flash",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to immediately flash to a device. Will only successfully deliver the firmware update if the device is currently online and connected to the cloud.</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d desired_firmware_version=1 \\\n       -d flash=true \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d desired_firmware_version=1 \\\n       -d flash=true \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4616,6 +6495,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4623,6 +6503,7 @@
             "type": "String",
             "optional": false,
             "field": "desired_firmware_version",
+            "isArray": false,
             "description": "<p>The newly set firmware version to lock the device to</p>"
           },
           {
@@ -4630,6 +6511,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -4643,8 +6525,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Firmware_5"
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.5"
   },
   {
     "type": "put",
@@ -4657,7 +6539,7 @@
       }
     ],
     "description": "<p>Unlocks a product device from receiving and running a specific version of product firmware. The device will now be eligible to receive released firmware in the product.</p>",
-    "group": "Firmware_6",
+    "group": "Firmware.6",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -4666,6 +6548,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4673,22 +6556,26 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": false,
-            "field": "desired_firmware_version",
-            "description": "<p>Set to <code>null</code> to unlock the device</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": false,
+        "field": "desired_firmware_version",
+        "isArray": false,
+        "description": "<p>Set to <code>null</code> to unlock the device</p>"
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d desired_firmware_version=null \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d desired_firmware_version=null \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4700,6 +6587,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4707,6 +6595,7 @@
             "type": "String",
             "optional": false,
             "field": "desired_firmware_version",
+            "isArray": false,
             "description": "<p>Should now be <code>null</code> signaling that the device is no longer locked to a specific version of firmware</p>"
           },
           {
@@ -4714,6 +6603,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -4727,8 +6617,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Firmware_6"
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.6"
   },
   {
     "type": "put",
@@ -4741,7 +6631,7 @@
       }
     ],
     "description": "<p>Mark a device in a product fleet as a <em>development device</em>. Once marked as a development device, it will opt-out from receiving automatic product firmware updates. This includes both locked firmware as well as released firmware.</p>",
-    "group": "Firmware_7",
+    "group": "Firmware.7",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -4750,6 +6640,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4757,22 +6648,27 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": false,
-            "field": "development",
-            "description": "<p>Set to <code>true</code> to mark as development device</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "development",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to mark as development device</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d development=true \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d development=true \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4784,6 +6680,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4791,6 +6688,7 @@
             "type": "String",
             "optional": false,
             "field": "development",
+            "isArray": false,
             "description": "<p>Should now be <code>true</code> signaling that the device is now a development device</p>"
           },
           {
@@ -4798,6 +6696,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -4811,8 +6710,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Firmware_7"
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.7"
   },
   {
     "type": "put",
@@ -4825,7 +6724,7 @@
       }
     ],
     "description": "<p>Unmark a device in a product fleet as a <em>development device</em>. Once unmarked, the device will opt-in to receiving automatic product firmware updates. This includes both locked firmware as well as released firmware.</p>",
-    "group": "Firmware_8",
+    "group": "Firmware.8",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -4834,6 +6733,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4841,22 +6741,27 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": false,
-            "field": "development",
-            "description": "<p>Set to <code>false</code> to unmark as development device</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "development",
+        "isArray": false,
+        "description": "<p>Set to <code>false</code> to unmark as development device</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d development=false \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d development=false \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -4868,6 +6773,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -4875,6 +6781,7 @@
             "type": "String",
             "optional": false,
             "field": "development",
+            "isArray": false,
             "description": "<p>Should now be <code>false</code> signaling that the device is not a development device</p>"
           },
           {
@@ -4882,6 +6789,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -4895,15 +6803,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Firmware_8"
+    "filename": "src/views/api.js",
+    "groupTitle": "Firmware.8"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/groups/:groupName",
     "title": "Get device group",
     "name": "getDeviceGroup",
-    "group": "Groups_1",
+    "group": "Groups.1",
     "description": "<p>Retrieve full info on a specific product group, including its device count.</p>",
     "parameter": {
       "fields": {
@@ -4913,6 +6821,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -4920,6 +6829,7 @@
             "type": "String",
             "optional": false,
             "field": "groupName",
+            "isArray": false,
             "description": "<p>The group name to fetch</p>"
           }
         ]
@@ -4938,41 +6848,77 @@
             "type": "Object",
             "optional": false,
             "field": "group",
+            "isArray": false,
             "description": "<p>The group object</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "group",
+              "field": "group",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "group.name",
+            "isArray": false,
             "description": "<p>The name of the group</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "group",
+              "field": "group",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "group.description",
+            "isArray": false,
             "description": "<p>A description of the group</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "group",
+              "field": "group",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "group.color",
+            "isArray": false,
             "description": "<p>A hex value representing of the color displayed next to the group tag on the Console</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "group",
+              "field": "group",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "group.fw_version",
+            "isArray": false,
             "description": "<p>The version number of the product firmware that has been released to this group</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "group",
+              "field": "group",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "group.device_count",
+            "isArray": false,
             "description": "<p>The number of devices that belong to this group</p>"
           }
         ]
@@ -4988,20 +6934,20 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/groups/group_a?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/groups/group_a \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.1"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/groups",
     "title": "List device groups",
     "name": "getDeviceGroups",
-    "group": "Groups_2",
+    "group": "Groups.2",
     "description": "<p>List the group objects that exist in the product. Optionally, filter by group name (partial match).</p>",
     "parameter": {
       "fields": {
@@ -5011,18 +6957,22 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>String to filter group names by. Partial string matching.</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>String to filter group names by. Partial string matching.</p>"
+      }
+    ],
     "permission": [
       {
         "name": "groups:list"
@@ -5036,14 +6986,15 @@
             "type": "Object[]",
             "optional": false,
             "field": "groups",
+            "isArray": true,
             "description": "<p>An array of the device groups objects</p>"
           }
         ]
       },
       "examples": [
         {
-          "title": "GET /v1/products/:productIdOrSlug/groups?name=gr&access_token=1234",
-          "content": "GET /v1/products/:productIdOrSlug/groups?name=gr&access_token=1234\nHTTP/1.1 200 OK\n{\n  \"groups\": [\n    {\n      \"name\":\"group_a\",\n      \"description\":\"the A group\",\n      \"fw_version\":3,\n      \"color\":\"#34495e\"\n    },\n    {\n      \"name\":\"group_b\",\n      \"description\": \"the B group\",\n      \"color\":\"#34495e\"\n    }\n  ]\n}",
+          "title": "GET /v1/products/:productIdOrSlug/groups?name=gr",
+          "content": "GET /v1/products/:productIdOrSlug/groups?name=gr\nHTTP/1.1 200 OK\n{\n  \"groups\": [\n    {\n      \"name\":\"group_a\",\n      \"description\":\"the A group\",\n      \"fw_version\":3,\n      \"color\":\"#34495e\"\n    },\n    {\n      \"name\":\"group_b\",\n      \"description\": \"the B group\",\n      \"color\":\"#34495e\"\n    }\n  ]\n}",
           "type": "json"
         }
       ]
@@ -5051,20 +7002,20 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/groups?name=gr&access_token=1234\"",
+        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/groups?name=gr\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.2"
   },
   {
     "type": "post",
     "url": "/v1/products/:productIdOrSlug/groups",
     "title": "Create device group",
     "name": "createDeviceGroup",
-    "group": "Groups_3",
+    "group": "Groups.3",
     "description": "<p>Create a new device group withinin a product</p>",
     "parameter": {
       "fields": {
@@ -5074,32 +7025,38 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "name",
-            "description": "<p>The name of the group. Must only contain lowercase letters, numbers, dashes, and underscores.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "color",
-            "description": "<p>A hex value representing of the color displayed next to the group tag on the Console</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "description",
-            "description": "<p>String A description of the group</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>The name of the group. Must only contain lowercase letters, numbers, dashes, and underscores.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "color",
+        "isArray": false,
+        "description": "<p>A hex value representing of the color displayed next to the group tag on the Console</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "description",
+        "isArray": false,
+        "description": "<p>String A description of the group</p>"
+      }
+    ],
     "permission": [
       {
         "name": "groups:create"
@@ -5113,6 +7070,7 @@
             "type": "Object",
             "optional": false,
             "field": "group",
+            "isArray": false,
             "description": "<p>The group object</p>"
           }
         ]
@@ -5128,20 +7086,20 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/groups \\\n       -d name=group_a \\\n       -d description=\"the A group\" \\\n       -d color=\"#34495e\" \\\n       -d access_token=123abc",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/groups \\\n       -d name=group_a \\\n       -d description=\"the A group\" \\\n       -d color=\"#34495e\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_3"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.3"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/groups/:groupName",
     "title": "Edit device group",
     "name": "updateDeviceGroup",
-    "group": "Groups_4",
+    "group": "Groups.4",
     "description": "<p>Edit attributes of a specific device group. You must pass one of <code>name</code>, <code>color</code>, or <code>description</code>.</p>",
     "parameter": {
       "fields": {
@@ -5151,6 +7109,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -5158,32 +7117,38 @@
             "type": "String",
             "optional": false,
             "field": "groupName",
+            "isArray": false,
             "description": "<p>The group name to edit</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>Provide a new group name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "color",
-            "description": "<p>Provide a new group color</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "description",
-            "description": "<p>Provide a new description</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>Provide a new group name</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "color",
+        "isArray": false,
+        "description": "<p>Provide a new group color</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "description",
+        "isArray": false,
+        "description": "<p>Provide a new description</p>"
+      }
+    ],
     "permission": [
       {
         "name": "groups:update"
@@ -5197,6 +7162,7 @@
             "type": "Object",
             "optional": false,
             "field": "group",
+            "isArray": false,
             "description": "<p>The updated group object</p>"
           }
         ]
@@ -5212,19 +7178,19 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/groups/group_a \\\n       -d name=double_agent \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/groups/group_a \\\n       -d name=double_agent \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_4"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.4"
   },
   {
     "type": "delete",
     "url": "/v1/products/:productIdOrSlug/groups/:groupName",
     "title": "Delete device group",
-    "group": "Groups_5",
+    "group": "Groups.5",
     "name": "deleteDeviceGroup",
     "description": "<p>Delete device group. All devices that belong to this group will be removed from the deleted group.</p>",
     "parameter": {
@@ -5235,6 +7201,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -5242,6 +7209,7 @@
             "type": "String",
             "optional": false,
             "field": "groupName",
+            "isArray": false,
             "description": "<p>The group name to delete</p>"
           }
         ]
@@ -5255,7 +7223,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/groups/group_a \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/groups/group_a \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5269,8 +7237,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_5"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.5"
   },
   {
     "type": "put",
@@ -5283,7 +7251,7 @@
       }
     ],
     "description": "<p>Update group memberships for an individual device. This is an <em>absolute</em> endpoint, meaning that regardless of previous group memberships, the group names passed to this endpoint will be the ones assigned to the device.</p> <p>If you pass a group name that does not yet exist, it will be created and assigned to the device.</p>",
-    "group": "Groups_6",
+    "group": "Groups.6",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -5292,6 +7260,7 @@
             "type": "String",
             "optional": false,
             "field": "deviceId",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -5299,22 +7268,26 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object[]",
-            "optional": false,
-            "field": "groups",
-            "description": "<p>Array of group names</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object[]",
+        "optional": false,
+        "field": "groups",
+        "isArray": true,
+        "description": "<p>Array of group names</p>"
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d groups[]=\"testing\" \\\n       -d access_token=123abc\n$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d groups[]=\"europe&groups[]=asia\" \\\n       -d access_token=123abc",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d groups[]=\"testing\" \\\n       -H \"Authorization: Bearer :access_token\"\n$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices/12345 \\\n       -d groups[]=\"europe&groups[]=asia\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5326,6 +7299,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Device ID</p>"
           },
           {
@@ -5333,6 +7307,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "groups",
+            "isArray": true,
             "description": "<p>Array of updated device group names</p>"
           },
           {
@@ -5340,6 +7315,7 @@
             "type": "Date",
             "optional": false,
             "field": "updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the deivce was updated in ISO8601 format</p>"
           }
         ]
@@ -5353,14 +7329,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Groups_6"
+    "filename": "src/views/api.js",
+    "groupTitle": "Groups.6"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/devices",
     "title": "Batch assign groups to devices",
-    "group": "Groups_7",
+    "group": "Groups.7",
     "name": "batchAssignDeviceGroups",
     "description": "<p>Assign groups to devices in a product as a batch action. Groups can either be added or removed from all devices passed to the endpoint.</p>",
     "parameter": {
@@ -5371,46 +7347,66 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "action",
-            "description": "<p>Set to <code>groups</code></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object[]",
-            "optional": false,
-            "field": "devices",
-            "description": "<p>An array of device IDs to update group memberships</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": false,
-            "field": "metadata",
-            "description": "<p>metadata object to inform which groups should be added/removed</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object[]",
-            "optional": true,
-            "field": "metadata.add",
-            "description": "<p>Array of group names to add to devices</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object[]",
-            "optional": true,
-            "field": "metadata.remove",
-            "description": "<p>Array of group names to remove to devices</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "action",
+        "isArray": false,
+        "description": "<p>Set to <code>groups</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object[]",
+        "optional": false,
+        "field": "devices",
+        "isArray": true,
+        "description": "<p>An array of device IDs to update group memberships</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "metadata",
+        "isArray": false,
+        "description": "<p>metadata object to inform which groups should be added/removed</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object[]",
+        "optional": true,
+        "parentNode": {
+          "path": "metadata",
+          "field": "metadata",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "metadata.add",
+        "isArray": true,
+        "description": "<p>Array of group names to add to devices</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object[]",
+        "optional": true,
+        "parentNode": {
+          "path": "metadata",
+          "field": "metadata",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "metadata.remove",
+        "isArray": true,
+        "description": "<p>Array of group names to remove to devices</p>"
+      }
+    ],
     "permission": [
       {
         "name": "devices:update"
@@ -5419,7 +7415,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/products/:productIdOrSlug/devices?access_token=1234\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\"action\": \"groups\", \"devices\": [\"123\", \"456\"], \"metadata\": {\"add\": [\"foo\"]}}'",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/devices \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\"action\": \"groups\", \"devices\": [\"123\", \"456\"], \"metadata\": {\"add\": [\"foo\"]}}'",
         "type": "bash"
       }
     ],
@@ -5433,15 +7429,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_7"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.7"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/impact",
     "title": "Impact of taking action",
     "name": "getDeviceGroupsImpact",
-    "group": "Groups_7",
+    "group": "Groups.7",
     "description": "<p>Understand the number of devices that would receive an over-the-air update as a result of taking an action related to device groups.</p> <p>Currently, this endpoint supports understanding the impact of releasing/unreleasing firmware to one or more device groups. Pass <code>edit_groups_for_firmware</code> as the <code>action</code> parameter when calling the endpoint.</p>",
     "parameter": {
       "fields": {
@@ -5451,39 +7447,47 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "action",
-            "description": "<p>The action you are about to take. Currently only accepts <code>edit_groups_for_firmware</code></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "firmware_version",
-            "description": "<p>Firmware version you wish to release</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "groups",
-            "description": "<p>Comma separated list of device group names to release the <code>firmware_version</code> version to. Do not include to simulate the impact of unreleasing to all groups.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "product_default",
-            "description": "<p>Set to <code>true</code> if you intend to release this <code>firmware_version</code> as the product default firmware. Set to <code>false</code> if the firmware is currently marked as <code>product_default</code> to simulate unreleasing as the <code>product_default</code>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "action",
+        "isArray": false,
+        "description": "<p>The action you are about to take. Currently only accepts <code>edit_groups_for_firmware</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "firmware_version",
+        "isArray": false,
+        "description": "<p>Firmware version you wish to release</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "groups",
+        "isArray": false,
+        "description": "<p>Comma separated list of device group names to release the <code>firmware_version</code> version to. Do not include to simulate the impact of unreleasing to all groups.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "product_default",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> if you intend to release this <code>firmware_version</code> as the product default firmware. Set to <code>false</code> if the firmware is currently marked as <code>product_default</code> to simulate unreleasing as the <code>product_default</code>.</p>",
+        "checked": false
+      }
+    ],
     "permission": [
       {
         "name": "groups.impact:get"
@@ -5492,7 +7496,7 @@
     "examples": [
       {
         "title": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/impact?\\",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/impact?\\\n&action=edit_groups_for_firmware\\\n&groups=asia,europe\\\n&firmware_version=3\\\n&product_default=false\\\n&access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/impact?\\\n&action=edit_groups_for_firmware\\\n&groups=asia,europe\\\n&firmware_version=3\\\n&product_default=false\\\n-H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5504,20 +7508,35 @@
             "type": "Object",
             "optional": false,
             "field": "firmware_update",
+            "isArray": false,
             "description": "<p>object containing impact details</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "firmware_update",
+              "field": "firmware_update",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "firmware_update.total",
+            "isArray": false,
             "description": "<p>number of devices which will get OTA update resulting from the planned groups action</p>"
           },
           {
             "group": "Success 200",
             "type": "Object[]",
             "optional": false,
+            "parentNode": {
+              "path": "firmware_update",
+              "field": "firmware_update",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "firmware_update.by_version",
+            "isArray": true,
             "description": "<p>number of devices which will get OTA update broken out by the firmware version they'll be flashed with. Each sub-object will have the <code>version</code> of product firmware and the <code>total</code> number of devices that will receive this version of firmware.</p>"
           }
         ]
@@ -5531,71 +7550,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Groups_7"
-  },
-  {
-    "type": "get",
-    "url": "/v1/products/:productIdOrSlug/integrations/:integrationId",
-    "title": "",
-    "name": "Get_Integration",
-    "group": "Integraitons_1",
-    "description": "<p>Get a single integration</p>",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "productIdOrSlug",
-            "description": "<p>Product ID or slug</p>"
-          }
-        ]
-      }
-    },
-    "permission": [
-      {
-        "name": "integrations:get"
-      }
-    ],
-    "examples": [
-      {
-        "title": "Get a product integration",
-        "content": "$ curl \"https://api.particle.io/v1/products/abc/integrations/12345?access_token=12345\"",
-        "type": "bash"
-      }
-    ],
-    "success": {
-      "fields": {
-        "Success 200": [
-          {
-            "group": "Success 200",
-            "type": "Object",
-            "optional": false,
-            "field": "integration",
-            "description": "<p>The integration</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "GET /v1/products/abc/integrations/12345",
-          "content": "GET /v1/products/abc/integrations/12345\nHTTP/1.1 200 OK\n\n{\nintegration: {\n\"id\": \"12345\",\n\t\"url\": \"https://samplesite.com\",\n\t\"event\": \"hello\",\n\t\"created_at\": \"2016-04-28T17:06:33.123Z\",\n\t\"requestType\": \"POST\"\n}\n}",
-          "type": "json"
-        }
-      ]
-    },
-    "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Integraitons_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "Groups.7"
   },
   {
     "type": "get",
     "url": "/v1/integrations",
     "title": "List integrations",
     "name": "listIntegrations",
-    "group": "Integrations_10",
+    "group": "Integrations.10",
     "permission": [
       {
         "name": "integrations:list"
@@ -5610,6 +7573,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
@@ -5617,23 +7581,23 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\"",
-        "content": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\"",
+        "title": "$ curl https://api.particle.io/v1/integrations \\",
+        "content": "$ curl https://api.particle.io/v1/integrations \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List all product integrations",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/integrations?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List all webhooks",
-        "content": "$ curl \"https://api.particle.io/v1/webhooks?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/webhooks \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List all product webhooks",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/webhooks?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/webhooks \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5645,6 +7609,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "-",
+            "isArray": true,
             "description": "<p>An array of integration objects. The object will vary in its attributes depending on integration type. For information on specific integration type response bodies, please see creation docs for <a href=\"#create-a-webhook\">Webhooks</a>, <a href=\"#enable-azure-iot-hub-integration\">Azure IoT Hub</a>, and <a href=\"#enable-google-cloud-platform-integration\">Google Cloud Platform</a>.</p>"
           }
         ]
@@ -5658,14 +7623,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_10"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.10"
   },
   {
     "type": "post",
     "url": "/v1/integrations/:integrationId/test",
     "title": "Test an integration",
-    "group": "Integrations_11",
+    "group": "Integrations.11",
     "permission": [
       {
         "name": "integrations:test"
@@ -5680,6 +7645,7 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
@@ -5687,20 +7653,39 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "data",
+        "isArray": false,
+        "description": "<p>Custom data to send with the test event. Defaults to &quot;test-event&quot; if omitted.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "device_id",
+        "isArray": false,
+        "description": "<p>The device ID to test the integration with. Defaults to &quot;api&quot; if omitted.</p>"
+      }
+    ],
     "examples": [
       {
         "title": "$ curl https://api.particle.io/v1/integrations/12345/test \\",
-        "content": "$ curl https://api.particle.io/v1/integrations/12345/test \\\n       -d access_token=12345",
+        "content": "$ curl https://api.particle.io/v1/integrations/12345/test \\\n       -d data=my-data \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Test a product integration",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345/test \\\n       -d access_token=12345",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345/test \\\n       -d data=my-data \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5712,13 +7697,15 @@
             "type": "Boolean",
             "optional": false,
             "field": "pass",
-            "description": "<p>Whether or not the integration was able to receive a successful response from the target</p>"
+            "isArray": false,
+            "description": "<p>Whether the integration was able to receive a successful response from the target</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
             "field": "data",
+            "isArray": false,
             "description": "<p>The data returned by a successful integration test attempt</p>"
           },
           {
@@ -5726,6 +7713,7 @@
             "type": "String",
             "optional": false,
             "field": "error",
+            "isArray": false,
             "description": "<p>If unsuccessful, the error returned from the target</p>"
           }
         ]
@@ -5733,14 +7721,14 @@
       "examples": [
         {
           "title": "POST /v1/integrations/1234/test",
-          "content": "POST /v1/integrations/1234/test\nHTTP/1.1 200 OK\n{\n\t  pass: true,\n\t  data: null\n\n}",
+          "content": "POST /v1/integrations/1234/test\nHTTP/1.1 200 OK\n{\n\t  pass: true,\n\t  data: null\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_11",
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.11",
     "name": "PostV1IntegrationsIntegrationidTest"
   },
   {
@@ -5748,7 +7736,7 @@
     "url": "/v1/integrations/:integrationId",
     "title": "Delete an integration",
     "name": "Delete_Integration",
-    "group": "Integrations_12",
+    "group": "Integrations.12",
     "permission": [
       {
         "name": "integrations:remove"
@@ -5762,6 +7750,7 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
@@ -5769,6 +7758,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug (only for product webhooks)</p>"
           }
         ]
@@ -5778,12 +7768,12 @@
     "examples": [
       {
         "title": "$ curl -X DELETE https://api.particle.io/v1/integrations/12345 \\",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/integrations/12345 \\\n       -d access_token=12345",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/integrations/12345 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Delete a product integration",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d access_token=12345",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5797,15 +7787,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_12"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.12"
   },
   {
     "type": "post",
     "url": "/v1/integrations",
     "title": "Create a webhook",
     "description": "<p>A webhook is a flexible type of integration that allows you to interact with a wide variety of external tools and services. Create a webhook either for devices you own as a Particle developer, or for your product fleet. For more info, check out <a href=\"/guide/tools-and-features/webhooks/\">the webhooks guide</a>.</p>",
-    "group": "Integrations_1",
+    "group": "Integrations.1",
     "name": "CreateWebhook",
     "permission": [
       {
@@ -5818,148 +7808,180 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "integration_type",
-            "description": "<p>Must be set to <code>Webhook</code></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "url",
-            "description": "<p>The web address that will be targeted when the webhook is triggered</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for {domain}&quot; if omitted.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "requestType",
-            "description": "<p>Type of web request triggered by the webhook that can be set to GET, POST, PUT, or DELETE</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the webhook triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "body",
-            "description": "<p>Send a custom body along with the HTTP request</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "json",
-            "description": "<p>Send custom data as JSON with the request. This will change the Content-Type header of the request to application/json</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "form",
-            "description": "<p>Send custom data as a form with the request by including key/value pairs. This will change the Content-Type header of the request to application/x-www-form-urlencoded</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "query",
-            "description": "<p>Send query parameters in the URL of the request by including key/value pairs</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "auth",
-            "description": "<p>Add an HTTP basic auth header by including a JSON object with username/password set</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "headers",
-            "description": "<p>Add custom HTTP headers by including key/value pairs</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "responseTopic",
-            "description": "<p>Customize the webhook response event name that your devices can subscribe to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "errorResponseTopic",
-            "description": "<p>Customize the webhook error response event name that your devices can subscribe to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "responseTemplate",
-            "description": "<p>Customize the webhook response body that your devices can subscribe to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "noDefaults",
-            "description": "<p>Set to <code>true</code> to not add the triggering Particle event's data to the webhook request</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "rejectUnauthorized",
-            "description": "<p>Set to <code>false</code> to skip SSL certificate validation of the target URL</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "integration_type",
+        "isArray": false,
+        "description": "<p>Must be set to <code>Webhook</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the webhook</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "url",
+        "isArray": false,
+        "description": "<p>The web address that will be targeted when the webhook is triggered</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for {domain}&quot; if omitted.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "requestType",
+        "isArray": false,
+        "description": "<p>Type of web request triggered by the webhook that can be set to GET, POST, PUT, or DELETE</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the webhook triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "body",
+        "isArray": false,
+        "description": "<p>Send a custom body along with the HTTP request</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "json",
+        "isArray": false,
+        "description": "<p>Send custom data as JSON with the request. This will change the Content-Type header of the request to application/json</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "form",
+        "isArray": false,
+        "description": "<p>Send custom data as a form with the request by including key/value pairs. This will change the Content-Type header of the request to application/x-www-form-urlencoded</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "query",
+        "isArray": false,
+        "description": "<p>Send query parameters in the URL of the request by including key/value pairs</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "auth",
+        "isArray": false,
+        "description": "<p>Add an HTTP basic auth header by including a JSON object with username/password set</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "headers",
+        "isArray": false,
+        "description": "<p>Add custom HTTP headers by including key/value pairs</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "responseTopic",
+        "isArray": false,
+        "description": "<p>Customize the webhook response event name that your devices can subscribe to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "errorResponseTopic",
+        "isArray": false,
+        "description": "<p>Customize the webhook error response event name that your devices can subscribe to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "responseTemplate",
+        "isArray": false,
+        "description": "<p>Customize the webhook response body that your devices can subscribe to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "noDefaults",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to not add the triggering Particle event's data to the webhook request</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this webhook</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "rejectUnauthorized",
+        "isArray": false,
+        "description": "<p>Set to <code>false</code> to skip SSL certificate validation of the target URL</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "template",
+        "isArray": false,
+        "description": "<p>The template that was used to create this webhook</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\ integration_type=Webhook \\",
-        "content": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\ integration_type=Webhook \\\n       -d event=hello \\\n       -d url=https://samplesite.com \\\n       -d requestType=POST",
+        "title": "$ curl https://api.particle.io/v1/integrations \\",
+        "content": "$ curl https://api.particle.io/v1/integrations \\\n       -d integration_type=Webhook \\\n       -d event=hello \\\n       -d url=https://samplesite.com \\\n       -d requestType=POST \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Create a Product Webhook",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/integrations?access_token=12345\" \\\n       -d integration_type=Webhook \\\n       -d event=hello \\\n       -d url=https://samplesite.com \\\n       -d requestType=POST",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations \\\n       -d integration_type=Webhook \\\n       -d event=hello \\\n       -d url=https://samplesite.com \\\n       -d requestType=POST \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -5971,6 +7993,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
+            "isArray": false,
             "description": ""
           },
           {
@@ -5978,6 +8001,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Webhook ID</p>"
           },
           {
@@ -5985,6 +8009,7 @@
             "type": "String",
             "optional": false,
             "field": "url",
+            "isArray": false,
             "description": "<p>Web address that will be targeted when the webhook is triggered</p>"
           },
           {
@@ -5992,6 +8017,7 @@
             "type": "String",
             "optional": false,
             "field": "created_at",
+            "isArray": false,
             "description": "<p>Timestamp of when the webhook was created</p>"
           },
           {
@@ -5999,6 +8025,7 @@
             "type": "String",
             "optional": false,
             "field": "integration_type",
+            "isArray": false,
             "description": "<p>Should be set to <code>Webhook</code></p>"
           },
           {
@@ -6006,6 +8033,7 @@
             "type": "String",
             "optional": false,
             "field": "hookUrl",
+            "isArray": false,
             "description": "<p>Particle API endpoint to GET info on the webhook</p>"
           }
         ]
@@ -6019,14 +8047,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_1"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.1"
   },
   {
     "type": "post",
     "url": "/v1/integrations",
     "title": "Enable Azure IoT Hub integration",
-    "group": "Integrations_2",
+    "group": "Integrations.2",
     "permission": [
       {
         "name": "integrations:create"
@@ -6040,85 +8068,98 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "integration_type",
-            "description": "<p>Must be set to <code>AzureIotHub</code></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "hub_name",
-            "description": "<p>The name of your Azure IoT Hub</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for {hub_name}&quot; if omitted.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "policy_name",
-            "description": "<p>The name of the shared access policy used for authentication</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "policy_key",
-            "description": "<p>The shared access policy key used for authentication</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the integration triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "json",
-            "description": "<p>A custom JSON payload to send along with the request</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "integration_type",
+        "isArray": false,
+        "description": "<p>Must be set to <code>AzureIotHub</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the integration</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "hub_name",
+        "isArray": false,
+        "description": "<p>The name of your Azure IoT Hub</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for {hub_name}&quot; if omitted.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "policy_name",
+        "isArray": false,
+        "description": "<p>The name of the shared access policy used for authentication</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "policy_key",
+        "isArray": false,
+        "description": "<p>The shared access policy key used for authentication</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the integration triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "json",
+        "isArray": false,
+        "description": "<p>A custom JSON payload to send along with the request</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\\n       -d integration_type=AzureIotHub \\\n       -d event=hello hub_name=myHubName policy_name=particle policy_key=123abc",
+        "title": "$ curl https://api.particle.io/v1/integrations \\",
+        "content": "$ curl https://api.particle.io/v1/integrations \\\n       -d integration_type=AzureIotHub \\\n       -d event=hello \\\n       -d hub_name=myHubName \\\n       -d policy_name=particle \\\n       -d policy_key=123abc \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Enable integration for a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/integrations?access_token=12345\" \\\n       -d integration_type=AzureIotHub \\\n       -d event=hello hub_name=myHubName policy_name=particle policy_key=123abc",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations \\\n       -d integration_type=AzureIotHub \\\n       -d event=hello \\\n       -d hub_name=myHubName \\\n       -d policy_name=particle \\\n       -d policy_key=123abc \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6130,6 +8171,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
+            "isArray": false,
             "description": ""
           },
           {
@@ -6137,6 +8179,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Integration ID</p>"
           },
           {
@@ -6144,6 +8187,7 @@
             "type": "String",
             "optional": false,
             "field": "created_at",
+            "isArray": false,
             "description": "<p>Timestamp of when the integration was created</p>"
           },
           {
@@ -6151,6 +8195,7 @@
             "type": "String",
             "optional": false,
             "field": "integration_type",
+            "isArray": false,
             "description": "<p>Should be set to <code>AzureIotHub</code></p>"
           },
           {
@@ -6158,6 +8203,7 @@
             "type": "String",
             "optional": false,
             "field": "integrationUrl",
+            "isArray": false,
             "description": "<p>URL to fetch information about the integration</p>"
           },
           {
@@ -6165,6 +8211,7 @@
             "type": "String",
             "optional": false,
             "field": "hub_name",
+            "isArray": false,
             "description": "<p>The name of your Azure IoT Hub</p>"
           },
           {
@@ -6172,6 +8219,7 @@
             "type": "String",
             "optional": false,
             "field": "policy_name",
+            "isArray": false,
             "description": "<p>The name of the shared access policy used for authentication</p>"
           },
           {
@@ -6179,6 +8227,7 @@
             "type": "String",
             "optional": false,
             "field": "policy_key",
+            "isArray": false,
             "description": "<p>The shared access policy key used for authentication</p>"
           }
         ]
@@ -6192,14 +8241,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_2"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.2"
   },
   {
     "type": "post",
     "url": "/v1/integrations",
     "title": "Enable Google Cloud Platform integration",
-    "group": "Integrations_3",
+    "group": "Integrations.3",
     "permission": [
       {
         "name": "integrations:create"
@@ -6213,64 +8262,74 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "integration_type",
-            "description": "<p>Must be set to <code>GoogleCloudPubSub</code></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "topic",
-            "description": "<p>The Google Cloud Pub Sub topic name for publishing messages</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for {topic}&quot; if omitted.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the integration triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "integration_type",
+        "isArray": false,
+        "description": "<p>Must be set to <code>GoogleCloudPubSub</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the integration</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "topic",
+        "isArray": false,
+        "description": "<p>The Google Cloud Pub Sub topic name for publishing messages</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for {topic}&quot; if omitted.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the integration triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\\n       -d integration_type=GoogleCloudPubSub \\\n       -d event=hello \\\n       -d topic=your/topic/name",
+        "title": "$ curl https://api.particle.io/v1/integrations \\",
+        "content": "$ curl https://api.particle.io/v1/integrations \\\n       -d integration_type=GoogleCloudPubSub \\\n       -d event=hello \\\n       -d topic=your/topic/name \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Enable integration for a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/integrations?access_token=12345\" \\\n       -d integration_type=GoogleCloudPubSub \\\n       -d event=hello \\\n       -d topic=your/topic/name",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations \\\n       -d integration_type=GoogleCloudPubSub \\\n       -d event=hello \\\n       -d topic=your/topic/name \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6282,6 +8341,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
+            "isArray": false,
             "description": ""
           },
           {
@@ -6289,6 +8349,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Integration ID</p>"
           },
           {
@@ -6296,6 +8357,7 @@
             "type": "String",
             "optional": false,
             "field": "created_at",
+            "isArray": false,
             "description": "<p>Timestamp of when the integration was created</p>"
           },
           {
@@ -6303,6 +8365,7 @@
             "type": "String",
             "optional": false,
             "field": "integration_type",
+            "isArray": false,
             "description": "<p>Should be set to <code>GoogleCloudPubSub</code></p>"
           },
           {
@@ -6310,6 +8373,7 @@
             "type": "String",
             "optional": false,
             "field": "integrationUrl",
+            "isArray": false,
             "description": "<p>URL to fetch information about the integration</p>"
           },
           {
@@ -6317,6 +8381,7 @@
             "type": "String",
             "optional": false,
             "field": "topic",
+            "isArray": false,
             "description": "<p>The Google Cloud Pub Sub topic name for publishing messages</p>"
           }
         ]
@@ -6330,14 +8395,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_3"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.3"
   },
   {
     "type": "post",
     "url": "/v1/integrations",
     "title": "Enable Google Maps integration",
-    "group": "Integrations_4",
+    "group": "Integrations.4",
     "permission": [
       {
         "name": "integrations:create"
@@ -6351,64 +8416,74 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "integration_type",
-            "description": "<p>Must be set to <code>GoogleMaps</code></p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for Google Maps&quot; if omitted.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "api_key",
-            "description": "<p>Your Google Maps Geolocation API key. Check out <a href=\"https://developers.google.com/maps/documentation/geolocation/get-api-key\">these docs</a> for details</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the integration triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "integration_type",
+        "isArray": false,
+        "description": "<p>Must be set to <code>GoogleMaps</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the integration</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook. Defaults to &quot;{event} for Google Maps&quot; if omitted.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "api_key",
+        "isArray": false,
+        "description": "<p>Your Google Maps Geolocation API key. Check out <a href=\"https://developers.google.com/maps/documentation/geolocation/get-api-key\">these docs</a> for details</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the integration triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/integrations?access_token=12345\" \\\n       -d integration_type=GoogleMaps \\\n       -d event=hello \\\n       -d api_key=123abc",
+        "title": "$ curl https://api.particle.io/v1/integrations \\",
+        "content": "$ curl https://api.particle.io/v1/integrations \\\n       -d integration_type=GoogleMaps \\\n       -d event=hello \\\n       -d api_key=123abc \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Enable integration for a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/integrations?access_token=12345\" \\\n       -d integration_type=GoogleMaps \\\n       -d event=hello \\\n       -d api_key=123abc",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations \\\n       -d integration_type=GoogleMaps \\\n       -d event=hello \\\n       -d api_key=123abc \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6420,6 +8495,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
+            "isArray": false,
             "description": ""
           },
           {
@@ -6427,6 +8503,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Integration ID</p>"
           },
           {
@@ -6434,6 +8511,7 @@
             "type": "String",
             "optional": false,
             "field": "created_at",
+            "isArray": false,
             "description": "<p>Timestamp of when the integration was created</p>"
           },
           {
@@ -6441,6 +8519,7 @@
             "type": "String",
             "optional": false,
             "field": "api_key",
+            "isArray": false,
             "description": "<p>Your Google Maps Geolocation API key</p>"
           },
           {
@@ -6448,6 +8527,7 @@
             "type": "String",
             "optional": false,
             "field": "integration_type",
+            "isArray": false,
             "description": "<p>Should be set to <code>GoogleCloudPubSub</code></p>"
           },
           {
@@ -6455,6 +8535,7 @@
             "type": "String",
             "optional": false,
             "field": "integrationUrl",
+            "isArray": false,
             "description": "<p>URL to fetch information about the integration</p>"
           }
         ]
@@ -6468,15 +8549,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_4"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.4"
   },
   {
     "type": "put",
     "url": "/v1/integrations/:integrationId",
     "title": "Edit a Webhook",
     "description": "<p>Edit a Webhook. Subsequent triggering of this integration will be sent with the new attributes.</p> <p>The configuration replaces the entire previous webhook configuration. It does not merge in changes.</p>",
-    "group": "Integrations_5",
+    "group": "Integrations.5",
     "permission": [
       {
         "name": "integrations:update"
@@ -6490,146 +8571,178 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the webhook triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "url",
-            "description": "<p>The web address that will be targeted when the webhook is triggered</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "requestType",
-            "description": "<p>Type of web request triggered by the webhook that can be set to GET, POST, PUT, or DELETE</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "body",
-            "description": "<p>Send a custom body along with the HTTP request</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "json",
-            "description": "<p>Send custom data as JSON with the request. This will change the Content-Type header of the request to application/json</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "form",
-            "description": "<p>Send custom data as a form with the request by including key/value pairs. This will change the Content-Type header of the request to application/x-www-form-urlencoded</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "query",
-            "description": "<p>Send query parameters in the URL of the request by including key/value pairs</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "auth",
-            "description": "<p>Add an HTTP basic auth header by including a JSON object with username/password set</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "headers",
-            "description": "<p>Add custom HTTP headers by including key/value pairs</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "responseTopic",
-            "description": "<p>Customize the webhook response event name that your devices can subscribe to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "errorResponseTopic",
-            "description": "<p>Customize the webhook error response event name that your devices can subscribe to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "responseTemplate",
-            "description": "<p>Customize the webhook response body that your devices can subscribe to</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "noDefaults",
-            "description": "<p>Set to <code>true</code> to not add the triggering Particle event's data to the webhook request</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "rejectUnauthorized",
-            "description": "<p>Set to <code>false</code> to skip SSL certificate validation of the target URL</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the webhook</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the webhook triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "url",
+        "isArray": false,
+        "description": "<p>The web address that will be targeted when the webhook is triggered</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "requestType",
+        "isArray": false,
+        "description": "<p>Type of web request triggered by the webhook that can be set to GET, POST, PUT, or DELETE</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "body",
+        "isArray": false,
+        "description": "<p>Send a custom body along with the HTTP request</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "json",
+        "isArray": false,
+        "description": "<p>Send custom data as JSON with the request. This will change the Content-Type header of the request to application/json</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "form",
+        "isArray": false,
+        "description": "<p>Send custom data as a form with the request by including key/value pairs. This will change the Content-Type header of the request to application/x-www-form-urlencoded</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "query",
+        "isArray": false,
+        "description": "<p>Send query parameters in the URL of the request by including key/value pairs</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "auth",
+        "isArray": false,
+        "description": "<p>Add an HTTP basic auth header by including a JSON object with username/password set</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "headers",
+        "isArray": false,
+        "description": "<p>Add custom HTTP headers by including key/value pairs</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "responseTopic",
+        "isArray": false,
+        "description": "<p>Customize the webhook response event name that your devices can subscribe to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "errorResponseTopic",
+        "isArray": false,
+        "description": "<p>Customize the webhook error response event name that your devices can subscribe to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "responseTemplate",
+        "isArray": false,
+        "description": "<p>Customize the webhook response body that your devices can subscribe to</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "noDefaults",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to not add the triggering Particle event's data to the webhook request</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this webhook</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "rejectUnauthorized",
+        "isArray": false,
+        "description": "<p>Set to <code>false</code> to skip SSL certificate validation of the target URL</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "template",
+        "isArray": false,
+        "description": "<p>The template that was used to create this webhook</p>"
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d event=foo \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d event=foo \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Edit product webhook",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d event=foo \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d event=foo \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6641,6 +8754,7 @@
             "type": "Object",
             "optional": false,
             "field": "integration",
+            "isArray": false,
             "description": "<p>An integration object.</p>"
           }
         ]
@@ -6654,8 +8768,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_5",
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.5",
     "name": "PutV1IntegrationsIntegrationid"
   },
   {
@@ -6663,7 +8777,7 @@
     "url": "/v1/integrations/:integrationId",
     "title": "Edit Azure IoT Hub Integration",
     "description": "<p>Edit an Azure IoT Hub integration. Subsequent triggering of this integration will be sent with the new attributes.</p> <p>The configuration replaces the entire previous webhook configuration. It does not merge in changes.</p>",
-    "group": "Integrations_6",
+    "group": "Integrations.6",
     "permission": [
       {
         "name": "integrations:update"
@@ -6677,83 +8791,96 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the integration triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "hub_name",
-            "description": "<p>The name of your Azure IoT Hub</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "policy_name",
-            "description": "<p>The name of the shared access policy used for authentication</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "policy_key",
-            "description": "<p>The shared access policy key used for authentication</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": true,
-            "field": "json",
-            "description": "<p>A custom JSON payload to send along with the request</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the integration</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the integration triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "hub_name",
+        "isArray": false,
+        "description": "<p>The name of your Azure IoT Hub</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "policy_name",
+        "isArray": false,
+        "description": "<p>The name of the shared access policy used for authentication</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "policy_key",
+        "isArray": false,
+        "description": "<p>The shared access policy key used for authentication</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": true,
+        "field": "json",
+        "isArray": false,
+        "description": "<p>A custom JSON payload to send along with the request</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d event=foo \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d event=foo \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Edit product integration",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d event=foo \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d event=foo \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6765,6 +8892,7 @@
             "type": "Object",
             "optional": false,
             "field": "integration",
+            "isArray": false,
             "description": "<p>An integration object.</p>"
           }
         ]
@@ -6778,8 +8906,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_6",
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.6",
     "name": "PutV1IntegrationsIntegrationid"
   },
   {
@@ -6787,7 +8915,7 @@
     "url": "/v1/integrations/:integrationId",
     "title": "Edit Google Cloud Platform Integration",
     "description": "<p>Edit a Google Cloud platform integration. Subsequent triggering of this integration will be sent with the new attributes.</p> <p>The configuration replaces the entire previous webhook configuration. It does not merge in changes.</p>",
-    "group": "Integrations_7",
+    "group": "Integrations.7",
     "permission": [
       {
         "name": "integrations:update"
@@ -6801,62 +8929,72 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the integration triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "topic",
-            "description": "<p>The Google Cloud Pub Sub topic name for publishing messages</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the integration</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the integration triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "topic",
+        "isArray": false,
+        "description": "<p>The Google Cloud Pub Sub topic name for publishing messages</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d event=foo \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d event=foo \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Edit product integration",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d event=foo \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d event=foo \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6868,6 +9006,7 @@
             "type": "Object",
             "optional": false,
             "field": "integration",
+            "isArray": false,
             "description": "<p>An integration object.</p>"
           }
         ]
@@ -6881,8 +9020,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_7",
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.7",
     "name": "PutV1IntegrationsIntegrationid"
   },
   {
@@ -6890,7 +9029,7 @@
     "url": "/v1/integrations/:integrationId",
     "title": "Edit Google Maps Integration",
     "description": "<p>Edit a Google Maps integration. Subsequent triggering of this integration will be sent with the new attributes.</p> <p>The configuration replaces the entire previous webhook configuration. It does not merge in changes.</p>",
-    "group": "Integrations_8",
+    "group": "Integrations.8",
     "permission": [
       {
         "name": "integrations:update"
@@ -6904,62 +9043,72 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
-            "field": "event",
-            "description": "<p>The name of the Particle event that should trigger the integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "name",
-            "description": "<p>A human-readable description of the webhook</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceID",
-            "description": "<p>Limits the integration triggering to a single device</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "api_key",
-            "description": "<p>Your Google Maps Geolocation API key. Check out <a href=\"https://developers.google.com/maps/documentation/geolocation/get-api-key\">these docs</a> for details</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "disabled",
-            "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>The name of the Particle event that should trigger the integration</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>A human-readable description of the webhook</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "deviceID",
+        "isArray": false,
+        "description": "<p>Limits the integration triggering to a single device</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "api_key",
+        "isArray": false,
+        "description": "<p>Your Google Maps Geolocation API key. Check out <a href=\"https://developers.google.com/maps/documentation/geolocation/get-api-key\">these docs</a> for details</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "disabled",
+        "isArray": false,
+        "description": "<p>Set to <code>true</code> to stop events from being sent to this integration</p>",
+        "checked": false
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d api_key=123abc \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/integrations/12345 \\\n       -d api_key=123abc \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Edit product integration",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d api_key=123abc \\\n       -d access_token=12345",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -d api_key=123abc \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -6971,6 +9120,7 @@
             "type": "Object",
             "optional": false,
             "field": "integration",
+            "isArray": false,
             "description": "<p>An integration object.</p>"
           }
         ]
@@ -6984,8 +9134,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_8",
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.8",
     "name": "PutV1IntegrationsIntegrationid"
   },
   {
@@ -6993,7 +9143,7 @@
     "url": "/v1/integrations/:integrationId",
     "title": "Get integration",
     "name": "Get_Integration",
-    "group": "Integrations_9",
+    "group": "Integrations.9",
     "permission": [
       {
         "name": "integrations:get"
@@ -7008,6 +9158,7 @@
             "type": "String",
             "optional": false,
             "field": "integrationId",
+            "isArray": false,
             "description": "<p>The ID of the desired integration</p>"
           },
           {
@@ -7015,6 +9166,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
@@ -7022,13 +9174,13 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/integrations/12345?access_token=12345\"",
-        "content": "$ curl \"https://api.particle.io/v1/integrations/12345?access_token=12345\"",
+        "title": "$ curl https://api.particle.io/v1/integrations/12345 \\",
+        "content": "$ curl https://api.particle.io/v1/integrations/12345 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Get a product integration",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/integrations/12345 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -7040,13 +9192,21 @@
             "type": "Object",
             "optional": false,
             "field": "integration",
+            "isArray": false,
             "description": "<p>An integration object. The object will vary in its attributes depending on integration type. For information on specific integration type response bodies, please see creation docs for <a href=\"#create-a-webhook\">Webhooks</a>, <a href=\"#enable-azure-iot-hub-integration\">Azure IoT Hub</a>, and <a href=\"#enable-google-cloud-platform-integration\">Google Cloud Platform</a>.</p>"
           },
           {
             "group": "Success 200",
             "type": "Object[]",
             "optional": false,
+            "parentNode": {
+              "path": "integration",
+              "field": "integration",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "integration.logs",
+            "isArray": true,
             "description": "<p>Contains information about the last 10 HTTP request/responses sent from this integration. A useful debugging tool.</p>"
           }
         ]
@@ -7060,30 +9220,32 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/event.js",
-    "groupTitle": "Integrations_9"
+    "filename": "src/views/event.js",
+    "groupTitle": "Integrations.9"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions",
+    "url": "/v1/users/ledgers/:ledgerName/instances/:scopeValue/versions",
     "title": "List ledger instance versions",
     "description": "<p>Lists all ledger instance versions.</p>",
-    "group": "Ledger_10",
+    "group": "Ledger.10",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           },
           {
@@ -7091,128 +9253,151 @@
             "type": "String",
             "optional": false,
             "field": "scopeValue",
+            "isArray": false,
             "description": "<p>Scope value</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "replaced_before",
-            "description": "<p>List only versions replaced before this date</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "replaced_after",
-            "description": "<p>List only versions replaced after this date</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "replaced_before",
+        "isArray": false,
+        "description": "<p>List only versions replaced before this date</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "replaced_after",
+        "isArray": false,
+        "description": "<p>List only versions replaced after this date</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue/versions\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue/versions\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue/versions\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue/versions\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "List ledger instance versions for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue/versions\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue/versions",
-          "content": "GET /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue/versions\nHTTP/1.1 200 OK\n{\n  \"versions\": [\n    {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"123\",\n        \"name\": \"My Product\"\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    }, {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"123\",\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n      \"replaced_at\": \"2023-11-28T15:02:04.799Z\"\n    }\n  ],\n  \"meta\": {\n    \"has_more\": false\n   }\n}",
+          "title": "GET /v1/users/ledgers/:ledgerName/instances/:scopeValue/versions",
+          "content": "GET /v1/users/ledgers/:ledgerName/instances/:scopeValue/versions\nHTTP/1.1 200 OK\n{\n  \"versions\": [\n    {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"123\",\n        \"name\": \"My Product\"\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    }, {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"123\",\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n      \"replaced_at\": \"2023-11-28T15:02:04.799Z\"\n    }\n  ],\n  \"meta\": {\n    \"has_more\": false\n   }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_10",
-    "name": "GetV1OrgsOrgidorslugLedgersLedgernameInstancesScopevalueVersions"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.10",
+    "name": "GetV1UsersLedgersLedgernameInstancesScopevalueVersions"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers",
+    "url": "/v1/users/ledgers",
     "title": "List ledger definitions",
-    "description": "<p>Lists all ledger definitions belonging to the specified org.</p>",
-    "group": "Ledger_1",
+    "description": "<p>Lists all ledger definitions belonging to the Sandbox or organization.</p>",
+    "group": "Ledger.1",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
             "optional": true,
-            "field": "page",
-            "description": "<p>Page number</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "perPage",
-            "description": "<p>Number of definitions per page</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "archived",
-            "description": "<p>Filter for archived definitions</p>"
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "page",
+        "isArray": false,
+        "description": "<p>Page number</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "perPage",
+        "isArray": false,
+        "description": "<p>Number of definitions per page</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Boolean",
+        "optional": true,
+        "field": "archived",
+        "isArray": false,
+        "description": "<p>Filter for archived definitions</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "List ledger definitions for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgSlugOrId/ledgers",
-          "content": "GET /v1/orgs/:orgSlugOrId/ledgers\nHTTP/1.1 200 OK\n{\n  \"ledgers\": [\n    {\n      \"scope\": \"Owner\",\n      \"name\": \"My Ledger\",\n      \"description\": \"My Ledger Description\",\n      \"direction\": \"Downstream\",\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n      \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n    }\n  ],\n  \"meta\": {\n    \"page\": 1,\n    \"per_page\": 100,\n    \"total_pages\": 1,\n    \"total\": 1\n   }\n}",
+          "title": "GET /v1/users/ledgers",
+          "content": "GET /v1/users/ledgers\nHTTP/1.1 200 OK\n{\n  \"ledgers\": [\n    {\n      \"scope\": \"Owner\",\n      \"name\": \"My Ledger\",\n      \"description\": \"My Ledger Description\",\n      \"direction\": \"Downstream\",\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n      \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n    }\n  ],\n  \"meta\": {\n    \"page\": 1,\n    \"per_page\": 100,\n    \"total_pages\": 1,\n    \"total\": 1\n   }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_1",
-    "name": "GetV1OrgsOrgidorslugLedgers"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.1",
+    "name": "GetV1UsersLedgers"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName",
+    "url": "/v1/users/ledgers/:ledgerName",
     "title": "Get ledger definition",
     "description": "<p>Returns the specified ledger definition.</p>",
-    "group": "Ledger_2",
+    "group": "Ledger.2",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           }
         ]
@@ -7220,133 +9405,173 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get ledger definition for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/ledgers/:ledgerName",
-          "content": "GET /v1/orgs/:orgIdOrSlug/ledgers/:ledgerName\nHTTP/1.1 200 OK\n{\n  \"ledger\": {\n    \"scope\": \"Owner\",\n    \"name\": \"My Ledger\",\n    \"description\": \"My Ledger Description\",\n    \"direction\": \"Downstream\",\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n  }\n}",
+          "title": "GET /v1/users/ledgers/:ledgerName",
+          "content": "GET /v1/users/ledgers/:ledgerName\nHTTP/1.1 200 OK\n{\n  \"ledger\": {\n    \"scope\": \"Owner\",\n    \"name\": \"My Ledger\",\n    \"description\": \"My Ledger Description\",\n    \"direction\": \"Downstream\",\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_2",
-    "name": "GetV1OrgsOrgidorslugLedgersLedgername"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.2",
+    "name": "GetV1UsersLedgersLedgername"
   },
   {
     "type": "post",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers",
+    "url": "/v1/users/ledgers",
     "title": "Create a new ledger definition",
     "description": "<p>Creates a ledger definition.</p>",
-    "group": "Ledger_3",
+    "group": "Ledger.3",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "definition",
+        "isArray": false,
+        "description": "<p>Ledger definition</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       --data @definition.json",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       --data @definition.json",
+        "type": "bash"
+      },
+      {
+        "title": "Create a new ledger definition for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       --data @definition.json",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "POST /v1/orgs/:orgSlugOrId/ledgers",
-          "content": "POST /v1/orgs/:orgSlugOrId/ledgers\nHTTP/1.1 201 Created\n{\n  \"ledger\": {\n    \"scope\": \"Owner\",\n    \"name\": \"My Ledger\",\n    \"description\": \"My Ledger Description\",\n    \"direction\": \"Downstream\",\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n  }\n}",
+          "title": "POST /v1/users/ledgers",
+          "content": "POST /v1/users/ledgers\nHTTP/1.1 201 Created\n{\n  \"ledger\": {\n    \"scope\": \"Owner\",\n    \"name\": \"My Ledger\",\n    \"description\": \"My Ledger Description\",\n    \"direction\": \"Downstream\",\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_3",
-    "name": "PostV1OrgsOrgidorslugLedgers"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.3",
+    "name": "PostV1UsersLedgers"
   },
   {
     "type": "put",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName",
+    "url": "/v1/users/ledgers/:ledgerName",
     "title": "Update ledger definition",
     "description": "<p>Updates the ledger definition.</p>",
-    "group": "Ledger_4",
+    "group": "Ledger.4",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "definition",
+        "isArray": false,
+        "description": "<p>Ledger definition</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName\" \\",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       --data @definition.json",
+        "title": "$ curl -X PUT \"https://api.particle.io/v1/users/ledgers/:ledgerName\" \\",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/users/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       --data @definition.json",
+        "type": "bash"
+      },
+      {
+        "title": "Update ledger definition for an organization",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       --data @definition.json",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "PUT /v1/orgs/:orgSlugOrId/ledgers/:ledgerName",
-          "content": "PUT /v1/orgs/:orgSlugOrId/ledgers/:ledgerName\nHTTP/1.1 201 Created\n{\n  \"ledger\": {\n    \"scope\": \"Owner\",\n    \"name\": \"My Ledger\",\n    \"description\": \"My Ledger Description\",\n    \"direction\": \"Downstream\",\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n  }\n}",
+          "title": "PUT /v1/users/ledgers/:ledgerName",
+          "content": "PUT /v1/users/ledgers/:ledgerName\nHTTP/1.1 201 Created\n{\n  \"ledger\": {\n    \"scope\": \"Owner\",\n    \"name\": \"My Ledger\",\n    \"description\": \"My Ledger Description\",\n    \"direction\": \"Downstream\",\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    \"archived_at\": \"2023-01-01T00:00:00.000Z\" | null\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_4",
-    "name": "PutV1OrgsOrgidorslugLedgersLedgername"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.4",
+    "name": "PutV1UsersLedgersLedgername"
   },
   {
     "type": "delete",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName",
+    "url": "/v1/users/ledgers/:ledgerName",
     "title": "Archive a ledger definition",
     "description": "<p>Archives a ledger definition.</p>",
-    "group": "Ledger_5",
+    "group": "Ledger.5",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           }
         ]
@@ -7354,107 +9579,125 @@
     },
     "examples": [
       {
-        "title": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName\" \\",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl -X DELETE \"https://api.particle.io/v1/users/ledgers/:ledgerName\" \\",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/users/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Archive a ledger definition for an organization",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "DELETE /v1/orgs/:orgSlugOrId/ledgers/:ledgerName",
-          "content": "DELETE /v1/orgs/:orgSlugOrId/ledgers/:ledgerName\nHTTP/1.1 204 No content",
+          "title": "DELETE /v1/users/ledgers/:ledgerName",
+          "content": "DELETE /v1/users/ledgers/:ledgerName\nHTTP/1.1 204 No content",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_5",
-    "name": "DeleteV1OrgsOrgidorslugLedgersLedgername"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.5",
+    "name": "DeleteV1UsersLedgersLedgername"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances",
+    "url": "/v1/users/ledgers/:ledgerName/instances",
     "title": "List ledger instances",
     "description": "<p>Lists all ledger instances.</p>",
-    "group": "Ledger_6",
+    "group": "Ledger.6",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "page",
-            "description": "<p>Page number</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "perPage",
-            "description": "<p>Number of instances per page</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "page",
+        "isArray": false,
+        "description": "<p>Page number</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "perPage",
+        "isArray": false,
+        "description": "<p>Number of instances per page</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "List ledger instances for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances",
-          "content": "GET /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances\nHTTP/1.1 200 OK\n{\n  \"instances\": [\n    {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"123\",\n        \"name\": \"My Product\"\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    }, {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"456\",\n        \"not_owned\": true\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    }\n  ],\n  \"meta\": {\n    \"page\": 1,\n    \"per_page\": 100,\n    \"total_pages\": 1,\n    \"total\": 1\n   }\n}",
+          "title": "GET /v1/users/ledgers/:ledgerName/instances",
+          "content": "GET /v1/users/ledgers/:ledgerName/instances\nHTTP/1.1 200 OK\n{\n  \"instances\": [\n    {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"123\",\n        \"name\": \"My Product\"\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    }, {\n      \"name\": \"prodledger\",\n      \"scope\": {\n        \"type\": \"Product\",\n        \"value\": \"456\",\n        \"not_owned\": true\n      },\n      \"size_bytes\": 1234,\n      \"data\": {},\n      \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n      \"created_at\": \"2023-01-01T00:00:00.000Z\",\n    }\n  ],\n  \"meta\": {\n    \"page\": 1,\n    \"per_page\": 100,\n    \"total_pages\": 1,\n    \"total\": 1\n   }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_6",
-    "name": "GetV1OrgsOrgidorslugLedgersLedgernameInstances"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.6",
+    "name": "GetV1UsersLedgersLedgernameInstances"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue",
+    "url": "/v1/users/ledgers/:ledgerName/instances/:scopeValue",
     "title": "Get ledger instance",
     "description": "<p>Returns the specified ledger instance.</p>",
-    "group": "Ledger_7",
+    "group": "Ledger.7",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           },
           {
@@ -7462,6 +9705,7 @@
             "type": "String",
             "optional": false,
             "field": "scopeValue",
+            "isArray": false,
             "description": "<p>Scope value</p>"
           }
         ]
@@ -7469,46 +9713,53 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get ledger instance for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue",
-          "content": "GET /v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue\nHTTP/1.1 200 OK\n{\n  \"instance\": {\n    \"scope\": {\n      \"type\": \"Product\",\n      \"value\": \"123\",\n    },\n    \"name\": \"prodledger\",\n    \"size_bytes\": 1234,\n    \"data\": {},\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n  }\n}",
+          "title": "GET /v1/users/ledgers/:ledgerName/instances/:scopeValue",
+          "content": "GET /v1/users/ledgers/:ledgerName/instances/:scopeValue\nHTTP/1.1 200 OK\n{\n  \"instance\": {\n    \"scope\": {\n      \"type\": \"Product\",\n      \"value\": \"123\",\n    },\n    \"name\": \"prodledger\",\n    \"size_bytes\": 1234,\n    \"data\": {},\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_7",
-    "name": "GetV1OrgsOrgidorslugLedgersLedgernameInstancesScopevalue"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.7",
+    "name": "GetV1UsersLedgersLedgernameInstancesScopevalue"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions/:version",
+    "url": "/v1/users/ledgers/:ledgerName/instances/:scopeValue/versions/:version",
     "title": "Get ledger instance version",
     "description": "<p>Returns the specified version of a ledger instance.</p>",
-    "group": "Ledger_7",
+    "group": "Ledger.7",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           },
           {
@@ -7516,6 +9767,7 @@
             "type": "String",
             "optional": false,
             "field": "scopeValue",
+            "isArray": false,
             "description": "<p>Scope value</p>"
           },
           {
@@ -7523,6 +9775,7 @@
             "type": "String",
             "optional": false,
             "field": "version",
+            "isArray": false,
             "description": "<p>Version ID</p>"
           }
         ]
@@ -7530,46 +9783,53 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions/:version\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions/:version\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue/versions/:version\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue/versions/:version\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get ledger instance version for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions/:version\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions/:version",
-          "content": "GET /v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue/versions/:version\nHTTP/1.1 200 OK\n{\n  \"instance\": {\n    \"scope\": {\n      \"type\": \"Product\",\n      \"value\": \"123\",\n    },\n    \"name\": \"prodledger\",\n    \"size_bytes\": 1234,\n    \"data\": {},\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n  }\n}",
+          "title": "GET /v1/users/ledgers/:ledgerName/instances/:scopeValue/versions/:version",
+          "content": "GET /v1/users/ledgers/:ledgerName/instances/:scopeValue/versions/:version\nHTTP/1.1 200 OK\n{\n  \"instance\": {\n    \"scope\": {\n      \"type\": \"Product\",\n      \"value\": \"123\",\n    },\n    \"name\": \"prodledger\",\n    \"size_bytes\": 1234,\n    \"data\": {},\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_7",
-    "name": "GetV1OrgsOrgidorslugLedgersLedgernameInstancesScopevalueVersionsVersion"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.7",
+    "name": "GetV1UsersLedgersLedgernameInstancesScopevalueVersionsVersion"
   },
   {
     "type": "put",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/:scopeValue",
+    "url": "/v1/users/ledgers/:ledgerName/instances/:scopeValue",
     "title": "Set the ledger instance data",
     "description": "<p>Sets the data of the specified ledger instance.</p>",
-    "group": "Ledger_8",
+    "group": "Ledger.8",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           },
           {
@@ -7577,53 +9837,71 @@
             "type": "String",
             "optional": false,
             "field": "scopeValue",
+            "isArray": false,
             "description": "<p>Scope value</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "data",
+        "isArray": false,
+        "description": "<p>Ledger instance data</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\" \\",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       --data @data.json",
+        "title": "$ curl -X PUT \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue\" \\",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       --data @data.json",
+        "type": "bash"
+      },
+      {
+        "title": "Set the ledger instance data for an organization",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       --data @data.json",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "PUT /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue",
-          "content": "PUT /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\nHTTP/1.1 201 Created\n{\n  \"instance\": {\n    \"scope\": {\n      \"type\": \"Product\",\n      \"value\": \"123\",\n    },\n    \"name\": \"prodledger\",\n    \"size_bytes\": 1234,\n    \"data\": {\n      \"foo\": \"bar\"\n    },\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n  }\n}",
+          "title": "PUT /v1/users/ledgers/:ledgerName/instances/:scopeValue",
+          "content": "PUT /v1/users/ledgers/:ledgerName/instances/:scopeValue\nHTTP/1.1 201 Created\n{\n  \"instance\": {\n    \"scope\": {\n      \"type\": \"Product\",\n      \"value\": \"123\",\n    },\n    \"name\": \"prodledger\",\n    \"size_bytes\": 1234,\n    \"data\": {\n      \"foo\": \"bar\"\n    },\n    \"updated_at\": \"2023-01-01T00:00:00.000Z\",\n    \"created_at\": \"2023-01-01T00:00:00.000Z\",\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_8",
-    "name": "PutV1OrgsOrgidorslugLedgersLedgernameInstancesScopevalue"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.8",
+    "name": "PutV1UsersLedgersLedgernameInstancesScopevalue"
   },
   {
     "type": "delete",
-    "url": "/v1/orgs/:orgIdOrSlug/ledgers/:ledgerName/instances/scopeValue",
+    "url": "/v1/users/ledgers/:ledgerName/instances/:scopeValue",
     "title": "Delete ledger instance",
     "description": "<p>Deletes the specified ledger instance.</p>",
-    "group": "Ledger_9",
+    "group": "Ledger.9",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "ledgerName",
+            "isArray": false,
             "description": "<p>Ledger name</p>"
           },
           {
@@ -7631,6 +9909,7 @@
             "type": "String",
             "optional": false,
             "field": "scopeValue",
+            "isArray": false,
             "description": "<p>Scope value</p>"
           }
         ]
@@ -7638,31 +9917,36 @@
     },
     "examples": [
       {
-        "title": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\" \\",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl -X DELETE \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue\" \\",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/users/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Delete ledger instance for an organization",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "DELETE /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue",
-          "content": "DELETE /v1/orgs/:orgSlugOrId/ledgers/:ledgerName/instances/:scopeValue\nHTTP/1.1 204 No content",
+          "title": "DELETE /v1/users/ledgers/:ledgerName/instances/:scopeValue",
+          "content": "DELETE /v1/users/ledgers/:ledgerName/instances/:scopeValue\nHTTP/1.1 204 No content",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Ledger_9",
-    "name": "DeleteV1OrgsOrgidorslugLedgersLedgernameInstancesScopevalue"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Ledger.9",
+    "name": "DeleteV1UsersLedgersLedgernameInstancesScopevalue"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/location",
     "title": "Query location for devices within a product",
     "name": "GetLocations",
-    "group": "Location_1",
+    "group": "Location.1",
     "description": "<p>Get latest or historical location data for devices. Date range and bounding box can be specified to narrow the query.</p>",
     "parameter": {
       "fields": {
@@ -7670,62 +9954,80 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": true,
-            "field": "date_range",
-            "description": "<p>Start and end date in ISO8601 format, separated by comma, to query. Omitting date_range will return last known location.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "rect_bl",
-            "description": "<p>Bottom left of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "rect_tr",
-            "description": "<p>Top right of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "device_id",
-            "description": "<p>Device ID prefix to include in the query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "device_name",
-            "description": "<p>Device name prefix to include in the query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Array",
-            "optional": true,
-            "field": "groups",
-            "description": "<p>Array of group names to include in the query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "page",
-            "description": "<p>Page of results to display. Defaults to 1</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "per_page",
-            "description": "<p>Number of results per page. Defaults to 20. Maximum of 100</p>"
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "date_range",
+        "isArray": false,
+        "description": "<p>Start and end date in ISO8601 format, separated by comma, to query. Omitting date_range will return last known location.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "rect_bl",
+        "isArray": false,
+        "description": "<p>Bottom left of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "rect_tr",
+        "isArray": false,
+        "description": "<p>Top right of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "device_id",
+        "isArray": false,
+        "description": "<p>Device ID prefix to include in the query</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "device_name",
+        "isArray": false,
+        "description": "<p>Device name prefix to include in the query</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String[]",
+        "optional": true,
+        "field": "groups",
+        "isArray": true,
+        "description": "<p>Array of group names to include in the query</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "page",
+        "isArray": false,
+        "description": "<p>Page of results to display. Defaults to 1</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "per_page",
+        "isArray": false,
+        "description": "<p>Number of results per page. Defaults to 20. Maximum of 100</p>"
+      }
+    ],
     "permission": [
       {
         "name": "locations:get"
@@ -7734,12 +10036,12 @@
     "examples": [
       {
         "title": "Historical locations query with selected geo region, date range and device name filter",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations?access_token=abc123&rect_bl=30.5,30.0&rect_tr=36.2,35.6&date_range=2020-12-05T20:00:00Z,2020-12-05T20:07:39Z&device_name=service-truck\"",
+        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations?rect_bl=30.5,30.0&rect_tr=36.2,35.6&date_range=2020-12-05T20:00:00Z,2020-12-05T20:07:39Z&device_name=service-truck\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Last known locations query with selected geo region",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations?access_token=abc123&rect_bl=30.5,30.0&rect_tr=36.2,35.6\"",
+        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations?rect_bl=30.5,30.0&rect_tr=36.2,35.6\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -7758,15 +10060,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/location.js",
-    "groupTitle": "Location_1"
+    "filename": "src/views/location.js",
+    "groupTitle": "Location.1"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/location/:deviceId",
     "title": "Query location for one device within a product",
     "name": "getLocation",
-    "group": "Location_2",
+    "group": "Location.2",
     "description": "<p>Get last known or historical location data for one device. Date range and bounding box can be specified to narrow down the query. Properties and custom data will be returned by default.</p>",
     "parameter": {
       "fields": {
@@ -7774,27 +10076,48 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": true,
-            "field": "date_range",
-            "description": "<p>Start and end date in ISO8601 format, separated by comma, to query. Omitting date_range will return last known location.</p>"
+            "optional": false,
+            "field": "productIdOrSlug",
+            "isArray": false,
+            "description": "<p>Product ID or slug.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
-            "optional": true,
-            "field": "rect_bl",
-            "description": "<p>Bottom left of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "rect_tr",
-            "description": "<p>Top right of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
+            "optional": false,
+            "field": "deviceId",
+            "isArray": false,
+            "description": "<p>Device ID</p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "date_range",
+        "isArray": false,
+        "description": "<p>Start and end date in ISO8601 format, separated by comma, to query. Omitting date_range will return last known location.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "rect_bl",
+        "isArray": false,
+        "description": "<p>Bottom left of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "rect_tr",
+        "isArray": false,
+        "description": "<p>Top right of the rectangular bounding box to query. Latitude and longitude separated by comma.</p>"
+      }
+    ],
     "permission": [
       {
         "name": "locations:get"
@@ -7803,12 +10126,12 @@
     "examples": [
       {
         "title": "Historical locations query for a single device with selected geo region and date range",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations/123456?access_token=abc123&rect_bl=10.5,11&rect_tr=11.0,11.5&date_range=2020-12-05T20:00:00Z,2020-12-05T20:07:39Z\"",
+        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations/123456?rect_bl=10.5,11&rect_tr=11.0,11.5&date_range=2020-12-05T20:00:00Z,2020-12-05T20:07:39Z\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Last known location query for a single device",
-        "content": "$ curl \"https://api.particle.io/v1/products/1234/locations/123456?access_token=abc123\"",
+        "content": "$ curl https://api.particle.io/v1/products/1234/locations/123456 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -7827,30 +10150,32 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/location.js",
-    "groupTitle": "Location_2"
+    "filename": "src/views/location.js",
+    "groupTitle": "Location.2"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/stats",
+    "url": "/v1/users/logic/functions/:logicFunctionId/stats",
     "title": "Get logic function stats",
     "description": "<p>Returns the specified logic function stats.</p>",
-    "group": "Logic_10",
+    "group": "Logic.10",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           }
         ]
@@ -7858,133 +10183,258 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/stats\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/stats\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/stats\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/stats\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get logic function stats for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/stats\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/stats",
-          "content": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/stats\nHTTP/1.1 200 OK\n{\n   \"logic_function_stats\": [\n     {\n       \"date\": \"20231106\",\n       \"success\": 175,\n       \"failure\": 168,\n       \"timeout\": 0\n     }\n   ]\n}",
+          "title": "GET /v1/users/logic/functions/:logicFunctionId/stats",
+          "content": "GET /v1/users/logic/functions/:logicFunctionId/stats\nHTTP/1.1 200 OK\n{\n   \"logic_function_stats\": [\n     {\n       \"date\": \"20231106\",\n       \"success\": 175,\n       \"failure\": 168,\n       \"timeout\": 0\n     }\n   ]\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_10",
-    "name": "GetV1OrgsOrgidorslugLogicFunctionsLogicfunctionidStats"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.10",
+    "name": "GetV1UsersLogicFunctionsLogicfunctionidStats"
   },
   {
     "type": "post",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/execute",
+    "url": "/v1/users/logic/execute",
     "title": "Execute logic function",
     "description": "<p>Executes the provided logic function.</p>",
-    "group": "Logic_1",
+    "group": "Logic.1",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
-          }
-        ]
-      }
-    },
-    "examples": [
-      {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/execute\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/execute\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       --data @debug_function.json",
-        "type": "bash"
-      }
-    ],
-    "success": {
-      "examples": [
-        {
-          "title": "POST /v1/orgs/:orgIdOrSlug/logic/execute",
-          "content": "POST /v1/orgs/:orgIdOrSlug/logic/execute\nHTTP/1.1 200 OK\n{\n  \"result\": {\n    \"status\": \"Success\",\n    \"logs\": []\n  }\n}",
-          "type": "json"
-        }
-      ]
-    },
-    "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_1",
-    "name": "PostV1OrgsOrgidorslugLogicExecute"
-  },
-  {
-    "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions",
-    "title": "List logic functions",
-    "description": "<p>Lists all logic functions belonging to the specified org.</p>",
-    "group": "Logic_2",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
             "optional": true,
-            "field": "today_stats",
-            "description": "<p>Include today's stats</p>"
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "source",
+        "isArray": false,
+        "description": "<p>Logic function code to debug</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "parentNode": {
+          "path": "source",
+          "field": "source",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "source.type",
+        "isArray": false,
+        "defaultValue": "Javascript",
+        "description": "<p>Type of code (always Javascript)</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "parentNode": {
+          "path": "source",
+          "field": "source",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "source.code",
+        "isArray": false,
+        "description": "<p>Code to execute</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "event",
+        "isArray": false,
+        "description": "<p>Event to trigger the logic function</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "parentNode": {
+          "path": "event",
+          "field": "event",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "event.event_data",
+        "isArray": false,
+        "description": "<p>Event name</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "parentNode": {
+          "path": "event",
+          "field": "event",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "event.event_data",
+        "isArray": false,
+        "description": "<p>Event data</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "parentNode": {
+          "path": "event",
+          "field": "event",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "event.device_id",
+        "isArray": false,
+        "description": "<p>Device ID that triggered the event</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "parentNode": {
+          "path": "event",
+          "field": "event",
+          "type": "Object",
+          "isArray": false
+        },
+        "field": "event.product_id",
+        "isArray": false,
+        "description": "<p>Product ID that triggered the event</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions?today_stats=true\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions?today_stats=true\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/execute\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/execute\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       --data @debug_function.json",
+        "type": "bash"
+      },
+      {
+        "title": "Execute logic function for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/execute\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       --data @debug_function.json",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgSlugOrId/logic/functions?today_stats=true",
-          "content": "GET /v1/orgs/:orgSlugOrId/logic/functions?today_stats=true\nHTTP/1.1 200 OK\n{\n  \"logic_functions\": [\n    {\n      \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n      \"owner_id\": \"org:deadbeef\",\n      \"version\": 4,\n      \"enabled\": false,\n      \"name\": \"My Logic Function\",\n      \"description\": \"\",\n      \"template_slug\": null,\n      \"source\": {\n        \"type\": \"JavaScript\",\n        \"code\": \"export default function main() {}\"\n      },\n      \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n      \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n      \"created_by\": \"user:deadbeef\",\n      \"updated_by\": \"user:deadbeef\",\n      \"logic_triggers\": [\n        {\n          \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n          \"type\": \"Scheduled\",\n          \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n          \"enabled\": true,\n          \"version\": 4,\n          \"cron\": \"0 0 0 0 0\",\n          \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n          \"end_at\": null,\n          \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n          \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n        }\n      ],\n      \"today_stats\": {\n        \"success\": 0,\n        \"failure\": 0,\n        \"timeout\": 0\n      }\n    }\n  ]\n}",
+          "title": "POST /v1/users/logic/execute",
+          "content": "POST /v1/users/logic/execute\nHTTP/1.1 200 OK\n{\n  \"result\": {\n    \"status\": \"Success\",\n    \"logs\": []\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_2",
-    "name": "GetV1OrgsOrgidorslugLogicFunctions"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.1",
+    "name": "PostV1UsersLogicExecute"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId",
+    "url": "/v1/users/logic/functions",
+    "title": "List logic functions",
+    "description": "<p>Lists all logic functions belonging to the specified Sandbox or organization.</p>",
+    "group": "Logic.2",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
+          }
+        ]
+      }
+    },
+    "query": [
+      {
+        "group": "Query",
+        "type": "Boolean",
+        "optional": true,
+        "field": "today_stats",
+        "isArray": false,
+        "description": "<p>Include today's stats</p>"
+      }
+    ],
+    "examples": [
+      {
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions?today_stats=true\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions?today_stats=true\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "List logic functions for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions?today_stats=true\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      }
+    ],
+    "success": {
+      "examples": [
+        {
+          "title": "GET /v1/users/logic/functions?today_stats=true",
+          "content": "GET /v1/users/logic/functions?today_stats=true\nHTTP/1.1 200 OK\n{\n  \"logic_functions\": [\n    {\n      \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n      \"owner_id\": \"user:deadbeef\",\n      \"version\": 4,\n      \"enabled\": false,\n      \"name\": \"My Logic Function\",\n      \"description\": \"\",\n      \"template_slug\": null,\n      \"source\": {\n        \"type\": \"JavaScript\",\n        \"code\": \"export default function main() {}\"\n      },\n      \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n      \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n      \"created_by\": \"user:deadbeef\",\n      \"updated_by\": \"user:deadbeef\",\n      \"logic_triggers\": [\n        {\n          \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n          \"type\": \"Scheduled\",\n          \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n          \"enabled\": true,\n          \"version\": 4,\n          \"cron\": \"0 0 0 0 0\",\n          \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n          \"end_at\": null,\n          \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n          \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n        }\n      ],\n      \"today_stats\": {\n        \"success\": 0,\n        \"failure\": 0,\n        \"timeout\": 0\n      }\n    }\n  ]\n}",
+          "type": "json"
+        }
+      ]
+    },
+    "version": "0.0.0",
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.2",
+    "name": "GetV1UsersLogicFunctions"
+  },
+  {
+    "type": "get",
+    "url": "/v1/users/logic/functions/:logicFunctionId",
     "title": "Get logic function",
     "description": "<p>Returns the specified logic function.</p>",
-    "group": "Logic_3",
+    "group": "Logic.3",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           }
         ]
@@ -7992,133 +10442,173 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get logic function for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId",
-          "content": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId\nHTTP/1.1 200 OK\n{\n  \"logic_function\": {\n    \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n    \"owner_id\": \"org:deadbeef\",\n    \"version\": 4,\n    \"enabled\": false,\n    \"name\": \"My Logic Function\",\n    \"description\": \"\",\n    \"template_slug\": null,\n    \"source\": {\n      \"type\": \"JavaScript\",\n      \"code\": \"export default function main() {}\"\n    },\n    \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n    \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n    \"created_by\": \"user:deadbeef\",\n    \"updated_by\": \"user:deadbeef\",\n    \"logic_triggers\": [\n      {\n        \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n        \"type\": \"Scheduled\",\n        \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n        \"enabled\": true,\n        \"version\": 4,\n        \"cron\": \"0 0 0 0 0\",\n        \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n        \"end_at\": null,\n        \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n        \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n      }\n    ]\n  }\n}",
+          "title": "GET /v1/users/logic/functions/:logicFunctionId",
+          "content": "GET /v1/users/logic/functions/:logicFunctionId\nHTTP/1.1 200 OK\n{\n  \"logic_function\": {\n    \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n    \"owner_id\": \"user:deadbeef\",\n    \"version\": 4,\n    \"enabled\": false,\n    \"name\": \"My Logic Function\",\n    \"description\": \"\",\n    \"template_slug\": null,\n    \"source\": {\n      \"type\": \"JavaScript\",\n      \"code\": \"export default function main() {}\"\n    },\n    \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n    \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n    \"created_by\": \"user:deadbeef\",\n    \"updated_by\": \"user:deadbeef\",\n    \"logic_triggers\": [\n      {\n        \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n        \"type\": \"Scheduled\",\n        \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n        \"enabled\": true,\n        \"version\": 4,\n        \"cron\": \"0 0 0 0 0\",\n        \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n        \"end_at\": null,\n        \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n        \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n      }\n    ]\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_3",
-    "name": "GetV1OrgsOrgidorslugLogicFunctionsLogicfunctionid"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.3",
+    "name": "GetV1UsersLogicFunctionsLogicfunctionid"
   },
   {
     "type": "post",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions",
+    "url": "/v1/users/logic/functions",
     "title": "Create a new logic function",
     "description": "<p>Creates a logic function.</p>",
-    "group": "Logic_4",
+    "group": "Logic.4",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "logic_function",
+        "isArray": false,
+        "description": "<p>Logic function</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       --data @logicFunction.json",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       --data @logicFunction.json",
+        "type": "bash"
+      },
+      {
+        "title": "Create a new logic function for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       --data @logicFunction.json",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "POST /v1/orgs/:orgSlugOrId/logic/functions",
-          "content": "POST /v1/orgs/:orgSlugOrId/logic/functions\nHTTP/1.1 201 Created\n{\n  \"logic_function\": {\n    \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n    \"owner_id\": \"org:deadbeef\",\n    \"version\": 4,\n    \"enabled\": false,\n    \"name\": \"My Logic Function\",\n    \"description\": \"\",\n    \"template_slug\": null,\n    \"source\": {\n      \"type\": \"JavaScript\",\n      \"code\": \"export default function main() {}\"\n    },\n    \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n    \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n    \"created_by\": \"user:deadbeef\",\n    \"updated_by\": \"user:deadbeef\",\n    \"logic_triggers\": [\n      {\n        \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n        \"type\": \"Scheduled\",\n        \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n        \"enabled\": true,\n        \"version\": 4,\n        \"cron\": \"0 0 0 0 0\",\n        \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n        \"end_at\": null,\n        \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n        \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n      }\n    ]\n  }\n}",
+          "title": "POST /v1/users/logic/functions",
+          "content": "POST /v1/users/logic/functions\nHTTP/1.1 201 Created\n{\n  \"logic_function\": {\n    \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n    \"owner_id\": \"user:deadbeef\",\n    \"version\": 4,\n    \"enabled\": false,\n    \"name\": \"My Logic Function\",\n    \"description\": \"\",\n    \"template_slug\": null,\n    \"source\": {\n      \"type\": \"JavaScript\",\n      \"code\": \"export default function main() {}\"\n    },\n    \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n    \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n    \"created_by\": \"user:deadbeef\",\n    \"updated_by\": \"user:deadbeef\",\n    \"logic_triggers\": [\n      {\n        \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n        \"type\": \"Scheduled\",\n        \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n        \"enabled\": true,\n        \"version\": 4,\n        \"cron\": \"0 0 0 0 0\",\n        \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n        \"end_at\": null,\n        \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n        \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n      }\n    ]\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_4",
-    "name": "PostV1OrgsOrgidorslugLogicFunctions"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.4",
+    "name": "PostV1UsersLogicFunctions"
   },
   {
     "type": "put",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId",
+    "url": "/v1/users/logic/functions/:logicFunctionId",
     "title": "Update logic function",
     "description": "<p>Updates the logic function.</p>",
-    "group": "Logic_5",
+    "group": "Logic.5",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "logic_function",
+        "isArray": false,
+        "description": "<p>Logic function</p>"
+      }
+    ],
     "examples": [
       {
-        "title": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\" \\",
-        "content": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       --data @logicFunction.json",
+        "title": "$ curl -X PUT \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId\" \\",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       --data @logicFunction.json",
+        "type": "bash"
+      },
+      {
+        "title": "Update logic function for an organization",
+        "content": "$ curl -X PUT \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       --data @logicFunction.json",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "PUT /v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId",
-          "content": "PUT /v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\nHTTP/1.1 201 Created\n{\n  \"logic_function\": {\n    \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n    \"owner_id\": \"org:deadbeef\",\n    \"version\": 4,\n    \"enabled\": false,\n    \"name\": \"My Logic Function\",\n    \"description\": \"\",\n    \"template_slug\": null,\n    \"source\": {\n      \"type\": \"JavaScript\",\n      \"code\": \"export default function main() {}\"\n    },\n    \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n    \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n    \"created_by\": \"user:deadbeef\",\n    \"updated_by\": \"user:deadbeef\",\n    \"logic_triggers\": [\n      {\n        \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n        \"type\": \"Scheduled\",\n        \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n        \"enabled\": true,\n        \"version\": 4,\n        \"cron\": \"0 0 0 0 0\",\n        \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n        \"end_at\": null,\n        \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n        \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n      }\n    ],\n    \"today_stats\": {\n      \"success\": 0,\n      \"failure\": 0,\n      \"timeout\": 0\n    }\n  }\n}",
+          "title": "PUT /v1/users/logic/functions/:logicFunctionId",
+          "content": "PUT /v1/users/logic/functions/:logicFunctionId\nHTTP/1.1 201 Created\n{\n  \"logic_function\": {\n    \"id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n    \"owner_id\": \"user:deadbeef\",\n    \"version\": 4,\n    \"enabled\": false,\n    \"name\": \"My Logic Function\",\n    \"description\": \"\",\n    \"template_slug\": null,\n    \"source\": {\n      \"type\": \"JavaScript\",\n      \"code\": \"export default function main() {}\"\n    },\n    \"created_at\": \"2023-08-08T18:37:20.355177Z\",\n    \"updated_at\": \"2023-10-25T21:10:44.240143Z\",\n    \"created_by\": \"user:deadbeef\",\n    \"updated_by\": \"user:deadbeef\",\n    \"logic_triggers\": [\n      {\n        \"id\": \"08c6cfc4-e7d6-4b75-aa9e-8690d5c7aa5d\",\n        \"type\": \"Scheduled\",\n        \"logic_function_id\": \"79c1c82b-6dc5-49a1-b678-559b3e53a44d\",\n        \"enabled\": true,\n        \"version\": 4,\n        \"cron\": \"0 0 0 0 0\",\n        \"start_at\": \"2023-10-25T21:10:44.268743Z\",\n        \"end_at\": null,\n        \"last_scheduled_at\": \"2023-10-25T21:15:00Z\",\n        \"next_unscheduled_at\": \"2023-10-25T21:20:00Z\"\n      }\n    ],\n    \"today_stats\": {\n      \"success\": 0,\n      \"failure\": 0,\n      \"timeout\": 0\n    }\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_5",
-    "name": "PutV1OrgsOrgidorslugLogicFunctionsLogicfunctionid"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.5",
+    "name": "PutV1UsersLogicFunctionsLogicfunctionid"
   },
   {
     "type": "delete",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId",
+    "url": "/v1/users/logic/functions/:logicFunctionId",
     "title": "Delete logic function",
     "description": "<p>Deletes the specified logic function.</p>",
-    "group": "Logic_6",
+    "group": "Logic.6",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           }
         ]
@@ -8126,46 +10616,53 @@
     },
     "examples": [
       {
-        "title": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\" \\",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl -X DELETE \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId\" \\",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Delete logic function for an organization",
+        "content": "$ curl -X DELETE \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "DELETE /v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId",
-          "content": "DELETE /v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId\nHTTP/1.1 204 No content",
+          "title": "DELETE /v1/users/logic/functions/:logicFunctionId",
+          "content": "DELETE /v1/users/logic/functions/:logicFunctionId\nHTTP/1.1 204 No content",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_6",
-    "name": "DeleteV1OrgsOrgidorslugLogicFunctionsLogicfunctionid"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.6",
+    "name": "DeleteV1UsersLogicFunctionsLogicfunctionid"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs",
+    "url": "/v1/users/logic/functions/:logicFunctionId/runs",
     "title": "List logic functions runs",
     "description": "<p>Lists all runs for the specified logic function.</p>",
-    "group": "Logic_7",
+    "group": "Logic.7",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           }
         ]
@@ -8173,46 +10670,53 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId/runs\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId/runs\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/runs\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/runs\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "List logic functions runs for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId/runs\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId/runs",
-          "content": "GET /v1/orgs/:orgSlugOrId/logic/functions/:logicFunctionId/runs\nHTTP/1.1 200 OK\n{\n  \"logic_runs\": [\n    {\n      \"id\": \"f1540276-63df-44a7-9f1b-b0dfec9640ea\",\n      \"owner_id\": \"org:deadbeef\",\n      \"logic_function_id\": \"f3635877-3106-49c0-84ea-28781d9371fe\",\n      \"logic_trigger_type\": \"Scheduled\",\n      \"logic_trigger_id\": \"899944c2-ff3f-4f6a-a135-c4bc624ec382\",\n      \"status\": \"Success\",\n      \"started_at\": \"2023-11-07T18:20:59.462214Z\",\n      \"finished_at\": \"2023-11-07T18:20:59.581605Z\",\n      \"log_filename\": \"org:deadbeef/function-f3635877-3106-49c0-84ea-28781d9371fe/Scheduled-899944c2-ff3f-4f6a-a135-c4bc624ec382/1699381259462:1699381259581_1f32a920-7690-41c0-9585-0bbcab7846e9.json\"\n    }\n  ]\n}",
+          "title": "GET /v1/users/logic/functions/:logicFunctionId/runs",
+          "content": "GET /v1/users/logic/functions/:logicFunctionId/runs\nHTTP/1.1 200 OK\n{\n  \"logic_runs\": [\n    {\n      \"id\": \"f1540276-63df-44a7-9f1b-b0dfec9640ea\",\n      \"owner_id\": \"user:deadbeef\",\n      \"logic_function_id\": \"f3635877-3106-49c0-84ea-28781d9371fe\",\n      \"logic_trigger_type\": \"Scheduled\",\n      \"logic_trigger_id\": \"899944c2-ff3f-4f6a-a135-c4bc624ec382\",\n      \"status\": \"Success\",\n      \"started_at\": \"2023-11-07T18:20:59.462214Z\",\n      \"finished_at\": \"2023-11-07T18:20:59.581605Z\",\n      \"log_filename\": \"user:deadbeef/function-f3635877-3106-49c0-84ea-28781d9371fe/Scheduled-899944c2-ff3f-4f6a-a135-c4bc624ec382/1699381259462:1699381259581_1f32a920-7690-41c0-9585-0bbcab7846e9.json\"\n    }\n  ]\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_7",
-    "name": "GetV1OrgsOrgidorslugLogicFunctionsLogicfunctionidRuns"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.7",
+    "name": "GetV1UsersLogicFunctionsLogicfunctionidRuns"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId",
+    "url": "/v1/users/logic/functions/:logicFunctionId/runs/:logicRunId",
     "title": "Get logic function run",
     "description": "<p>Returns the specified logic function run.</p>",
-    "group": "Logic_8",
+    "group": "Logic.8",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           },
           {
@@ -8220,6 +10724,7 @@
             "type": "String",
             "optional": false,
             "field": "logicRunId",
+            "isArray": false,
             "description": "<p>Logic run ID</p>"
           }
         ]
@@ -8227,46 +10732,53 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/runs/:logicRunId\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/runs/:logicRunId\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get logic function run for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId",
-          "content": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId\nHTTP/1.1 200 OK\n{\n  \"logic_run\": {\n    \"id\": \"f1540276-63df-44a7-9f1b-b0dfec9640ea\",\n    \"owner_id\": \"org:deadbeef\",\n    \"logic_function_id\": \"f3635877-3106-49c0-84ea-28781d9371fe\",\n    \"logic_trigger_type\": \"Scheduled\",\n    \"logic_trigger_id\": \"899944c2-ff3f-4f6a-a135-c4bc624ec382\",\n    \"status\": \"Success\",\n    \"started_at\": \"2023-11-07T18:20:59.462214Z\",\n    \"finished_at\": \"2023-11-07T18:20:59.581605Z\",\n    \"log_filename\": \"org:deadbeef/function-f3635877-3106-49c0-84ea-28781d9371fe/Scheduled-899944c2-ff3f-4f6a-a135-c4bc624ec382/1699381259462:1699381259581_1f32a920-7690-41c0-9585-0bbcab7846e9.json\"\n  }\n}",
+          "title": "GET /v1/users/logic/functions/:logicFunctionId/runs/:logicRunId",
+          "content": "GET /v1/users/logic/functions/:logicFunctionId/runs/:logicRunId\nHTTP/1.1 200 OK\n{\n  \"logic_run\": {\n    \"id\": \"f1540276-63df-44a7-9f1b-b0dfec9640ea\",\n    \"owner_id\": \"users:deadbeef\",\n    \"logic_function_id\": \"f3635877-3106-49c0-84ea-28781d9371fe\",\n    \"logic_trigger_type\": \"Scheduled\",\n    \"logic_trigger_id\": \"899944c2-ff3f-4f6a-a135-c4bc624ec382\",\n    \"status\": \"Success\",\n    \"started_at\": \"2023-11-07T18:20:59.462214Z\",\n    \"finished_at\": \"2023-11-07T18:20:59.581605Z\",\n    \"log_filename\": \"users:deadbeef/function-f3635877-3106-49c0-84ea-28781d9371fe/Scheduled-899944c2-ff3f-4f6a-a135-c4bc624ec382/1699381259462:1699381259581_1f32a920-7690-41c0-9585-0bbcab7846e9.json\"\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_8",
-    "name": "GetV1OrgsOrgidorslugLogicFunctionsLogicfunctionidRunsLogicrunid"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.8",
+    "name": "GetV1UsersLogicFunctionsLogicfunctionidRunsLogicrunid"
   },
   {
     "type": "get",
-    "url": "/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId/logs",
-    "title": "Get logic function run",
+    "url": "/v1/users/logic/functions/:logicFunctionId/runs/:logicRunId/logs",
+    "title": "Get logic function run logs",
     "description": "<p>Returns the specified logic function run logs.</p>",
-    "group": "Logic_9",
+    "group": "Logic.9",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
+            "optional": true,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug. <em>Organization endpoint only</em>.</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "logicFunctionId",
+            "isArray": false,
             "description": "<p>Logic function ID</p>"
           },
           {
@@ -8274,6 +10786,7 @@
             "type": "String",
             "optional": false,
             "field": "logicRunId",
+            "isArray": false,
             "description": "<p>Logic run ID</p>"
           }
         ]
@@ -8281,30 +10794,35 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId/logs\" \\",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId/logs\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "title": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/runs/:logicRunId/logs\" \\",
+        "content": "$ curl \"https://api.particle.io/v1/users/logic/functions/:logicFunctionId/runs/:logicRunId/logs\" \\\n       -H \"Authorization: Bearer :access_token\"",
+        "type": "bash"
+      },
+      {
+        "title": "Get logic function run logs for an organization",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId/logs\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
     "success": {
       "examples": [
         {
-          "title": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId/logs",
-          "content": "GET /v1/orgs/:orgIdOrSlug/logic/functions/:logicFunctionId/runs/:logicRunId/logs\nHTTP/1.1 200 OK\n{\n  \"logic_run_logs\": {\n    \"logs\": [\n      {\n        \"level\": \"Info\",\n        \"timestamp\": \"2023-11-07T18:20:59.470Z\",\n        \"args\": [\n          \"Hello\"\n        ]\n      }\n    ]\n  }\n}",
+          "title": "GET /v1/users/logic/functions/:logicFunctionId/runs/:logicRunId/logs",
+          "content": "GET /v1/users/logic/functions/:logicFunctionId/runs/:logicRunId/logs\nHTTP/1.1 200 OK\n{\n  \"logic_run_logs\": {\n    \"logs\": [\n      {\n        \"level\": \"Info\",\n        \"timestamp\": \"2023-11-07T18:20:59.470Z\",\n        \"args\": [\n          \"Hello\"\n        ]\n      }\n    ]\n  }\n}",
           "type": "json"
         }
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/subspace.js",
-    "groupTitle": "Logic_9",
-    "name": "GetV1OrgsOrgidorslugLogicFunctionsLogicfunctionidRunsLogicrunidLogs"
+    "filename": "src/views/subspace.js",
+    "groupTitle": "Logic.9",
+    "name": "GetV1UsersLogicFunctionsLogicfunctionidRunsLogicrunidLogs"
   },
   {
     "type": "get",
     "url": "/v1/clients",
     "title": "List clients",
-    "group": "OAuth_1",
+    "group": "OAuth.1",
     "permission": [
       {
         "name": "clients:list"
@@ -8316,8 +10834,10 @@
         "Parameter": [
           {
             "group": "Parameter",
+            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
@@ -8325,13 +10845,13 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/clients?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/clients?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/clients \\",
+        "content": "$ curl https://api.particle.io/v1/clients \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List product OAuth clients",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/clients?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/clients \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8343,6 +10863,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
+            "isArray": false,
             "description": ""
           },
           {
@@ -8350,34 +10871,63 @@
             "type": "Object[]",
             "optional": false,
             "field": "clients",
+            "isArray": true,
             "description": "<p>An array of OAuth clients</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "clients",
+              "field": "clients",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "clients.id",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "clients",
+              "field": "clients",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "clients.name",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "clients",
+              "field": "clients",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "clients.type",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "clients",
+              "field": "clients",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "clients.redirect_uri",
+            "isArray": false,
             "description": "<p>Only for clients with <code>type: &quot;web&quot;</code></p>"
           }
         ]
@@ -8391,8 +10941,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/client.js",
-    "groupTitle": "OAuth_1",
+    "filename": "src/views/client.js",
+    "groupTitle": "OAuth.1",
     "name": "GetV1Clients"
   },
   {
@@ -8405,43 +10955,50 @@
           {
             "group": "Parameter",
             "type": "String",
-            "optional": false,
-            "field": "name",
-            "description": "<p>The name of the OAuth client</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "type",
-            "description": "<p><code>web</code> or <code>installed</code>. <code>web</code> is used for the authorization code grant flow similar to Facebook, and Twitter use.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "redirect_uri",
-            "description": "<p>Only required for <code>web</code> type. URL that you wish us to redirect to after the OAuth flow.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "scope",
-            "description": "<p>Limits the scope of what the access tokens created using the client are allowed to do. Provide a space separated list of scopes. The only current valid scopes are <code>customers:create</code> and <code>\\*:\\*</code> for full control.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>The name of the OAuth client</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "type",
+        "isArray": false,
+        "description": "<p><code>web</code> or <code>installed</code>. <code>web</code> is used for the authorization code grant flow similar to Facebook, and Twitter use.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "redirect_uri",
+        "isArray": false,
+        "description": "<p>Only required for <code>web</code> type. URL that you wish us to redirect to after the OAuth flow.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "scope",
+        "isArray": false,
+        "description": "<p>Limits the scope of what the access tokens created using the client are allowed to do. Provide a space separated list of scopes. The only current valid scopes are <code>customers:create</code> and <code>\\*:\\*</code> for full control.</p>"
+      }
+    ],
     "name": "CreateOAuthClient",
-    "group": "OAuth_2",
+    "group": "OAuth.2",
     "permission": [
       {
         "name": "clients:create"
@@ -8451,12 +11008,12 @@
     "examples": [
       {
         "title": "$ curl https://api.particle.io/v1/clients \\",
-        "content": "$ curl https://api.particle.io/v1/clients \\\n       -d name=MyApp \\\n       -d type=installed \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/clients \\\n       -d name=MyApp \\\n       -d type=installed \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Create an OAuth client for a product",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/clients \\\n       -d name=MyApp \\\n       -d type=installed \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/clients \\\n       -d name=MyApp \\\n       -d type=installed \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8468,6 +11025,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "ok",
+            "isArray": false,
             "description": ""
           },
           {
@@ -8475,41 +11033,77 @@
             "type": "Object",
             "optional": false,
             "field": "client",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "client",
+              "field": "client",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "client.name",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "client",
+              "field": "client",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "client.type",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "client",
+              "field": "client",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "client.id",
+            "isArray": false,
             "description": ""
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "client",
+              "field": "client",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "client.secret",
+            "isArray": false,
             "description": "<p>Save this! It will never be shown again.</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "client",
+              "field": "client",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "client.redirect_uri",
+            "isArray": false,
             "description": "<p>Only for clients with <code>type: &quot;web&quot;</code></p>"
           }
         ]
@@ -8523,15 +11117,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/client.js",
-    "groupTitle": "OAuth_2"
+    "filename": "src/views/client.js",
+    "groupTitle": "OAuth.2"
   },
   {
     "type": "put",
     "url": "/v1/clients/:clientId",
     "title": "Update a client",
     "description": "<p>Update the <code>name</code> or <code>scope</code> of an existing OAuth client.</p>",
-    "group": "OAuth_3",
+    "group": "OAuth.3",
     "permission": [
       {
         "name": "clients:update"
@@ -8543,42 +11137,50 @@
         "Parameter": [
           {
             "group": "Parameter",
+            "type": "String",
             "optional": false,
             "field": "clientId",
+            "isArray": false,
             "description": "<p>The client ID to update</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
-            "field": "name",
-            "description": "<p>Give the OAuth client a new name</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "scope",
-            "description": "<p>Update the scope of the OAuth client. to only allow customer creation from the client or pass <code>none</code> to remove all scopes (full permissions)</p>"
-          },
-          {
-            "group": "Parameter",
-            "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "name",
+        "isArray": false,
+        "description": "<p>Give the OAuth client a new name</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "scope",
+        "isArray": false,
+        "description": "<p>Update the scope of the OAuth client. to only allow customer creation from the client or pass <code>none</code> to remove all scopes (full permissions)</p>"
+      }
+    ],
     "examples": [
       {
         "title": "$ curl -X PUT https://api.particle.io/v1/clients/client-123 \\",
-        "content": "$ curl -X PUT https://api.particle.io/v1/clients/client-123 \\\n       -d name=\"My App 2\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/clients/client-123 \\\n       -d name=\"My App 2\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Update a product OAuth client",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/clients/client-123 \\\n       -d name=\"My App 2\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/clients/client-123 \\\n       -d name=\"My App 2\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8590,6 +11192,7 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The updated client</p>"
           }
         ]
@@ -8603,15 +11206,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/client.js",
-    "groupTitle": "OAuth_3"
+    "filename": "src/views/client.js",
+    "groupTitle": "OAuth.3"
   },
   {
     "type": "delete",
     "url": "/v1/clients/:clientId",
     "title": "Delete a client",
     "description": "<p>Remove an OAuth client</p>",
-    "group": "OAuth_4",
+    "group": "OAuth.4",
     "permission": [
       {
         "name": "clients:remove"
@@ -8622,14 +11225,18 @@
         "Parameter": [
           {
             "group": "Parameter",
+            "type": "String",
             "optional": false,
             "field": "clientId",
+            "isArray": false,
             "description": "<p>The client ID to delete</p>"
           },
           {
             "group": "Parameter",
+            "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em>.</p>"
           }
         ]
@@ -8638,12 +11245,12 @@
     "examples": [
       {
         "title": "$ curl -X DELETE https://api.particle.io/v1/clients/client-123 \\",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/clients/client-123 \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/clients/client-123 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Delete a product OAuth client",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/clients/client-123 \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/clients/client-123 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8657,8 +11264,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/client.js",
-    "groupTitle": "OAuth_4",
+    "filename": "src/views/client.js",
+    "groupTitle": "OAuth.4",
     "name": "DeleteV1ClientsClientid"
   },
   {
@@ -8667,31 +11274,11 @@
     "title": "List organizations",
     "name": "listOrganizationsForUser",
     "description": "<p>List organizations the currently authenticated user has access to</p>",
-    "group": "Organizations_1",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
+    "group": "Organizations.1",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/orgs?access_token=12345\"",
-        "content": "$ curl \"https://api.particle.io/v1/orgs?access_token=12345\"",
+        "title": "$ curl https://api.particle.io/v1/orgs \\",
+        "content": "$ curl https://api.particle.io/v1/orgs \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8702,7 +11289,8 @@
             "group": "Success 200",
             "type": "Object[]",
             "optional": false,
-            "field": "-",
+            "field": "organizations",
+            "isArray": true,
             "description": "<p>An array of organizations</p>"
           }
         ]
@@ -8716,8 +11304,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Organizations_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "Organizations.1"
   },
   {
     "type": "get",
@@ -8733,6 +11321,7 @@
             "type": "String",
             "optional": false,
             "field": "orgIdOrSlug",
+            "isArray": false,
             "description": "<p>Organization ID or Slug</p>"
           }
         ]
@@ -8743,15 +11332,16 @@
         "name": "organization:get"
       }
     ],
-    "group": "Organizations_2",
+    "group": "Organizations.2",
     "success": {
       "fields": {
         "Success 200": [
           {
             "group": "Success 200",
-            "type": "Object[]",
+            "type": "Object",
             "optional": false,
             "field": "organization",
+            "isArray": false,
             "description": ""
           }
         ]
@@ -8765,8 +11355,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Organizations_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "Organizations.2"
   },
   {
     "type": "get",
@@ -8774,36 +11364,30 @@
     "title": "List organization products",
     "name": "listOrgProducts",
     "description": "<p>List products which belong the the organization</p>",
-    "group": "Organizations_3",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "orgIdOrSlug",
+            "isArray": false,
+            "description": "<p>Organization ID or Slug</p>"
+          }
+        ]
+      }
+    },
+    "group": "Organizations.3",
     "permission": [
       {
         "name": "products:list"
       }
     ],
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
         "title": "List Organization Products",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/particle/products?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/orgs/particle/products \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8815,6 +11399,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "products",
+            "isArray": true,
             "description": "<p>List of Products</p>"
           }
         ]
@@ -8828,15 +11413,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Organizations_3"
+    "filename": "src/views/product.js",
+    "groupTitle": "Organizations.3"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/firmware/:version",
     "title": "Get product firmware",
     "name": "getProductFirmwareVersion",
-    "group": "ProductFirmware_1",
+    "group": "ProductFirmware.1",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -8845,6 +11430,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -8852,6 +11438,7 @@
             "type": "Number",
             "optional": false,
             "field": "version",
+            "isArray": false,
             "description": "<p>Version number of firmware to retrieve</p>"
           }
         ]
@@ -8866,7 +11453,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/firmware/1?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/firmware/1 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -8878,6 +11465,7 @@
             "type": "String",
             "optional": false,
             "field": "_id",
+            "isArray": false,
             "description": "<p>The ID of the firmware</p>"
           },
           {
@@ -8885,6 +11473,7 @@
             "type": "Number",
             "optional": false,
             "field": "version",
+            "isArray": false,
             "description": "<p>The version number of the firmware</p>"
           },
           {
@@ -8892,6 +11481,7 @@
             "type": "String",
             "optional": false,
             "field": "title",
+            "isArray": false,
             "description": "<p>The title of the firmware</p>"
           },
           {
@@ -8899,6 +11489,7 @@
             "type": "String",
             "optional": false,
             "field": "description",
+            "isArray": false,
             "description": "<p>A description of the firmware</p>"
           },
           {
@@ -8906,6 +11497,7 @@
             "type": "String",
             "optional": false,
             "field": "name",
+            "isArray": false,
             "description": "<p>The firmware's file name</p>"
           },
           {
@@ -8913,6 +11505,7 @@
             "type": "Number",
             "optional": false,
             "field": "size",
+            "isArray": false,
             "description": "<p>The size of the firmware in bytes</p>"
           },
           {
@@ -8920,6 +11513,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "product_default",
+            "isArray": false,
             "description": "<p>Whether the firmware is released as the product default</p>"
           },
           {
@@ -8927,6 +11521,7 @@
             "type": "Object",
             "optional": false,
             "field": "groups",
+            "isArray": false,
             "description": "<p>An array of group names representing the groups the firmware version has been released to</p>"
           },
           {
@@ -8934,6 +11529,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "mandatory",
+            "isArray": false,
             "description": "<p>[Enterprise only] Product upgrades and downgrades apply this version of firmware before flashing the targeted version.</p>"
           },
           {
@@ -8941,6 +11537,7 @@
             "type": "Date",
             "optional": false,
             "field": "uploaded_on",
+            "isArray": false,
             "description": "<p>Timestamp of when the firmware was uploaded</p>"
           },
           {
@@ -8948,6 +11545,7 @@
             "type": "Number",
             "optional": false,
             "field": "product_id",
+            "isArray": false,
             "description": "<p>The ID of the product that owns the firmware</p>"
           },
           {
@@ -8955,6 +11553,7 @@
             "type": "Object",
             "optional": false,
             "field": "uploaded_by",
+            "isArray": false,
             "description": "<p>The user who uploaded the firmware</p>"
           }
         ]
@@ -8968,15 +11567,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.1"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/firmware",
     "title": "List all product firmwares",
     "name": "listAllProductFirmwares",
-    "group": "ProductFirmware_2",
+    "group": "ProductFirmware.2",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -8985,6 +11584,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           }
         ]
@@ -8999,7 +11599,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/firmware?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/firmware \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9011,6 +11611,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "-",
+            "isArray": true,
             "description": "<p>An array of product firmware objects. See <a href=\"#get-product-firmware\">above</a> for details on the firmware object.</p>"
           }
         ]
@@ -9024,64 +11625,81 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.2"
   },
   {
     "type": "post",
     "url": "/v1/products/:productIdOrSlug/firmware",
     "title": "Upload product firmware",
     "name": "uploadProductFirmware",
-    "group": "ProductFirmware_3",
+    "group": "ProductFirmware.3",
     "description": "<p>Upload a new firmware version to a product</p>",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
-            "type": "Number",
-            "optional": false,
-            "field": "version",
-            "description": "<p>The version number of the firmware binary you are uploading</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "title",
-            "description": "<p>Title of the firmware version. Handy for quickly identifying the firmware</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "File",
-            "optional": false,
-            "field": "file",
-            "description": "<p>A binary file encoded in <code>multipart/form-data</code> format containing the contents of the product firmware (<code>binary</code> is also accepted for backwards compatibility). When uploading a bundle, the MIME type must be <code>application/zip</code></p>"
-          },
-          {
-            "group": "Parameter",
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "description",
-            "description": "<p>Optionally provide a description for the new firmware version</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": false,
-            "field": "mandatory",
-            "description": "<p>[Enterprise only] Flag this firmware release as a mandatory release so that product upgrades and downgrades apply this version of firmware before flashing the targeted version.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": false,
+        "field": "version",
+        "isArray": false,
+        "description": "<p>The version number of the firmware binary you are uploading</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "title",
+        "isArray": false,
+        "description": "<p>Title of the firmware version. Handy for quickly identifying the firmware</p>"
+      },
+      {
+        "group": "Body",
+        "type": "File",
+        "optional": false,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>A binary file encoded in <code>multipart/form-data</code> format containing the contents of the product firmware (<code>binary</code> is also accepted for backwards compatibility). When uploading a bundle, the MIME type must be <code>application/zip</code></p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "productIdOrSlug",
+        "isArray": false,
+        "description": "<p>Product ID or slug</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "description",
+        "isArray": false,
+        "description": "<p>Optionally provide a description for the new firmware version</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "mandatory",
+        "isArray": false,
+        "description": "<p>[Enterprise only] Flag this firmware release as a mandatory release so that product upgrades and downgrades apply this version of firmware before flashing the targeted version.</p>",
+        "checked": false
+      }
+    ],
     "permission": [
       {
         "name": "firmware:create"
@@ -9090,12 +11708,12 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/firmware?access_token=1234\" \\\n       -F file=@firmware.bin \\\n       -F version=1 \\\n       -F title=firmware",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/firmware \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -F file=@firmware.bin \\\n       -F version=1 \\\n       -F title=firmware",
         "type": "bash"
       },
       {
         "title": "Uploading a bundle",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/firmware?access_token=1234\" \\\n       -F \"file=@bundle.zip;type=application/zip\" \\\n       -F version=1 \\\n       -F title=firmware",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/firmware \\\n       -H \"Authorization: Bearer :access_token\"\n       -F \"file=@bundle.zip;type=application/zip\" \\\n       -F version=1 \\\n       -F title=firmware",
         "type": "bash"
       }
     ],
@@ -9107,6 +11725,7 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The newly created firmware object. See <a href=\"#get-product-firmware\">above</a> for details on the firmware object.</p>"
           }
         ]
@@ -9120,49 +11739,64 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_3"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.3"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/firmware/:version",
     "title": "Edit product firmware",
     "name": "editProductFirmware",
-    "group": "ProductFirmware_4",
+    "group": "ProductFirmware.4",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
             "type": "String",
-            "optional": true,
-            "field": "title",
-            "description": "<p>Provide a new title for the firmware</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "description",
-            "description": "<p>Provide a new description for the firmware</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": false,
-            "field": "mandatory",
-            "description": "<p>[Enterprise only] Flag this firmware release as a mandatory release so that product upgrades and downgrades apply this version of firmware before flashing the targeted version.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "version",
+            "isArray": false,
+            "description": "<p>Version number of the firmware to edit</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "title",
+        "isArray": false,
+        "description": "<p>Provide a new title for the firmware</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "description",
+        "isArray": false,
+        "description": "<p>Provide a new description for the firmware</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "mandatory",
+        "isArray": false,
+        "description": "<p>[Enterprise only] Flag this firmware release as a mandatory release so that product upgrades and downgrades apply this version of firmware before flashing the targeted version.</p>",
+        "checked": false
+      }
+    ],
     "permission": [
       {
         "name": "firmware:update"
@@ -9172,7 +11806,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/firmware/1 \\\n       -d title=\"New title\" \\\n       -d description=\"New description\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/firmware/1 \\\n       -d title=\"New title\" \\\n       -d description=\"New description\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9184,6 +11818,7 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The updated firmware object. See <a href=\"#get-product-firmware\">above</a> for details on the firmware object.</p>"
           }
         ]
@@ -9197,15 +11832,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_4"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.4"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/firmware/:version/binary",
     "title": "Download firmware binary",
     "name": "downloadProductFirmwareBinary",
-    "group": "ProductFirmware_5",
+    "group": "ProductFirmware.5",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -9214,6 +11849,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -9221,6 +11857,7 @@
             "type": "Number",
             "optional": false,
             "field": "version",
+            "isArray": false,
             "description": "<p>Version number of firmware to retrieve</p>"
           }
         ]
@@ -9235,7 +11872,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/firmware/1/binary?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/firmware/1/binary \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9247,21 +11884,22 @@
             "type": "File",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The binary file of the requested product firmware version</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_5"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.5"
   },
   {
     "type": "put",
     "url": "/v1/products/:productIdOrSlug/firmware/release",
     "title": "Release product firmware",
     "name": "releaseProductFirmware",
-    "group": "ProductFirmware_6",
+    "group": "ProductFirmware.6",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -9270,39 +11908,48 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": false,
-            "field": "version",
-            "description": "<p>firmware version number to release to the fleet</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": true,
-            "field": "product_default",
-            "description": "<p>Pass <code>true</code> to set the firmware version as the product default release</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "groups",
-            "description": "<p>An array of device groups to release the firmware to.</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "optional": false,
-            "field": "intelligent",
-            "description": "<p>Flag this firmware release as an intelligent release so that devices do not need to reconnect to the cloud to receive the update and that they are informed of pending updates when devices are not available for updating.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "Number",
+        "optional": false,
+        "field": "version",
+        "isArray": false,
+        "description": "<p>firmware version number to release to the fleet</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": true,
+        "field": "product_default",
+        "isArray": false,
+        "description": "<p>Pass <code>true</code> to set the firmware version as the product default release</p>",
+        "checked": false
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": true,
+        "field": "groups",
+        "isArray": false,
+        "description": "<p>An array of device groups to release the firmware to.</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "intelligent",
+        "isArray": false,
+        "description": "<p>Flag this firmware release as an intelligent release so that devices do not need to reconnect to the cloud to receive the update and that they are informed of pending updates when devices are not available for updating.</p>",
+        "checked": false
+      }
+    ],
     "permission": [
       {
         "name": "firmware:release"
@@ -9312,7 +11959,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/firmware/release \\\n       -d version=1 \\\n       -d groups[]=\"foo&groups[]=bar&groups[]=baz\"\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/firmware/release \\\n       -d version=1 \\\n       -d groups[]=\"foo&groups[]=bar&groups[]=baz\"\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9324,6 +11971,7 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The released firmware object. See <a href=\"#get-product-firmware\">above</a> for details on the firmware object.</p>"
           }
         ]
@@ -9337,15 +11985,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_6"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.6"
   },
   {
     "type": "delete",
     "url": "/v1/products/:productIdOrSlug/firmware/:version",
     "title": "Delete unreleased firmware binary",
     "name": "deleteProductFirmware",
-    "group": "ProductFirmware_7",
+    "group": "ProductFirmware.7",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -9354,6 +12002,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           },
           {
@@ -9361,6 +12010,7 @@
             "type": "Number",
             "optional": false,
             "field": "version",
+            "isArray": false,
             "description": "<p>Version number of firmware to delete</p>"
           }
         ]
@@ -9375,7 +12025,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X DELETE \"https://api.particle.io/v1/products/:productIdOrSlug/firmware/1?access_token=1234\"",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/firmware/1 \\\n                 -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9389,8 +12039,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ProductFirmware_7"
+    "filename": "src/views/product.js",
+    "groupTitle": "ProductFirmware.7"
   },
   {
     "type": "get",
@@ -9398,41 +12048,21 @@
     "title": "List products",
     "name": "listProducts",
     "description": "<p>List products the currently authenticated user has access to</p>",
-    "group": "Products_1",
+    "group": "Products.1",
     "permission": [
       {
         "name": "products:list"
       }
     ],
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/user/products?access_token=12345\"",
-        "content": "$ curl \"https://api.particle.io/v1/user/products?access_token=12345\"",
+        "title": "$ curl https://api.particle.io/v1/user/products \\",
+        "content": "$ curl https://api.particle.io/v1/user/products \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List Organization Products",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/particle/products?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/orgs/particle/products \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9444,6 +12074,7 @@
             "type": "Object[]",
             "optional": false,
             "field": "products",
+            "isArray": true,
             "description": "<p>List of Products</p>"
           }
         ]
@@ -9457,8 +12088,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.1"
   },
   {
     "type": "get",
@@ -9474,6 +12105,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           }
         ]
@@ -9484,15 +12116,16 @@
         "name": "products:get"
       }
     ],
-    "group": "Products_2",
+    "group": "Products.2",
     "success": {
       "fields": {
         "Success 200": [
           {
             "group": "Success 200",
-            "type": "Object[]",
+            "type": "Object",
             "optional": false,
             "field": "product",
+            "isArray": false,
             "description": ""
           },
           {
@@ -9500,6 +12133,7 @@
             "type": "String",
             "optional": false,
             "field": "product.id",
+            "isArray": false,
             "description": "<p>Product Unique ID</p>"
           },
           {
@@ -9507,6 +12141,7 @@
             "type": "Number",
             "optional": false,
             "field": "product.product_id",
+            "isArray": false,
             "description": "<p>Product Firmware ID</p>"
           },
           {
@@ -9514,6 +12149,7 @@
             "type": "String",
             "optional": false,
             "field": "product.name",
+            "isArray": false,
             "description": "<p>Product Name</p>"
           },
           {
@@ -9521,6 +12157,7 @@
             "type": "String",
             "optional": false,
             "field": "product.slug",
+            "isArray": false,
             "description": "<p>URL compatible version of name</p>"
           },
           {
@@ -9528,6 +12165,7 @@
             "type": "String",
             "optional": false,
             "field": "product.description",
+            "isArray": false,
             "description": ""
           },
           {
@@ -9535,6 +12173,7 @@
             "type": "Number",
             "optional": false,
             "field": "product.platform_id",
+            "isArray": false,
             "description": "<p>Product Platform ID</p>"
           },
           {
@@ -9542,6 +12181,7 @@
             "type": "String",
             "optional": false,
             "field": "product.organization",
+            "isArray": false,
             "description": "<p>Organization Unique ID</p>"
           },
           {
@@ -9549,6 +12189,7 @@
             "type": "Boolean",
             "optional": false,
             "field": "product.requires_activation_codes",
+            "isArray": false,
             "description": ""
           },
           {
@@ -9556,6 +12197,7 @@
             "type": "String",
             "optional": false,
             "field": "product.device_protection",
+            "isArray": false,
             "description": "<p>The set device protection status of the devices in this product</p>"
           }
         ]
@@ -9569,15 +12211,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.2"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/team",
     "title": "List team members",
     "name": "listUsersForProductOrOrg",
-    "group": "Products_3",
+    "group": "Products.3",
     "description": "<p>List all team members that are part of a given product</p>",
     "parameter": {
       "fields": {
@@ -9587,6 +12229,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           }
         ]
@@ -9599,13 +12242,13 @@
     ],
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/team?access_token=123abc\"",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/team?access_token=123abc\"",
+        "title": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/team \\",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/team \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List organization team members",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgIdOrSlug/team?access_token=123abc\"",
+        "content": "$ curl https://api.particle.io/v1/orgs/:orgIdOrSlug/team \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9616,21 +12259,36 @@
             "group": "Success 200",
             "type": "Object[]",
             "optional": false,
-            "field": "-",
+            "field": "team",
+            "isArray": true,
             "description": "<p>An array of team members</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
-            "field": "-._id",
+            "parentNode": {
+              "path": "team",
+              "field": "team",
+              "type": "Object[]",
+              "isArray": true
+            },
+            "field": "team._id",
+            "isArray": false,
             "description": "<p>ID of the team member</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
-            "field": "-.username",
+            "parentNode": {
+              "path": "team",
+              "field": "team",
+              "type": "Object[]",
+              "isArray": true
+            },
+            "field": "team.username",
+            "isArray": false,
             "description": "<p>Username of the team member</p>"
           }
         ]
@@ -9644,15 +12302,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_3"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.3"
   },
   {
     "type": "post",
     "url": "/v1/products/:productIdOrSlug/team",
     "title": "Invite team member",
     "name": "inviteUserToProductOrOrgTeam",
-    "group": "Products_4",
+    "group": "Products.4",
     "description": "<p>Invite a new member to a product team. Invitee will receive an email with a link to accept the invitation and join the team.</p>",
     "parameter": {
       "fields": {
@@ -9662,25 +12320,30 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "username",
-            "description": "<p>Username of the invitee. Must be a valid email associated with an Particle user</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "role",
-            "description": "<p>The role for the invited user. One of Administrator, Developer, View-only, Support.</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "username",
+        "isArray": false,
+        "description": "<p>Username of the invitee. Must be a valid email associated with an Particle user</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "role",
+        "isArray": false,
+        "description": "<p>The role for the invited user. One of Administrator, Developer, View-only, Support.</p>"
+      }
+    ],
     "permission": [
       {
         "name": "teams.users:invite"
@@ -9692,12 +12355,12 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/products/:productIdOrSlug/team\" \\\n       -d username=test@example.com \\\n       -d role=Administrator \\\n       -d access_token=123abc",
+        "content": "$ curl \"https://api.particle.io/products/:productIdOrSlug/team\" \\\n       -d username=test@example.com \\\n       -d role=Administrator \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Invite user to organization",
-        "content": "$ curl \"https://api.particle.io/orgs/:orgIdOrSlug/team\" \\\n       -d username=test@example.com \\\n       -d role=Administrator \\\n       -d access_token=123abc",
+        "content": "$ curl \"https://api.particle.io/orgs/:orgIdOrSlug/team\" \\\n       -d username=test@example.com \\\n       -d role=Administrator \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9709,6 +12372,7 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The invited user</p>"
           }
         ]
@@ -9722,15 +12386,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_4"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.4"
   },
   {
     "type": "post",
     "url": "/v1/products/:productIdOrSlug/team",
     "title": "Create an API user",
     "name": "createProgrammaticUser",
-    "group": "Products_5",
+    "group": "Products.5",
     "permission": [
       {
         "name": "teams.users:invite"
@@ -9745,29 +12409,34 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "friendly_name",
-            "description": "<p>A friendly name used to recognise the user</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "[String]",
-            "optional": false,
-            "field": "scopes",
-            "description": "<p>List of scopes to grant for this user</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "friendly_name",
+        "isArray": false,
+        "description": "<p>A friendly name used to recognise the user</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": false,
+        "field": "scopes",
+        "isArray": true,
+        "description": "<p>List of scopes to grant for this user</p>"
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl \"https://api.particle.io/products/:productIdOrSlug/team?access_token=123abc\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\n             \"friendly_name\": \"MyToken\",\n             \"scopes: [\"foo:bar\"]\n           }'",
+        "content": "$ curl https://api.particle.io/products/:productIdOrSlug/team \\\n       -H \"Authorization: Bearer :access_token\"\n       -H \"Content-Type: application/json\" \\\n       -d '{\n             \"friendly_name\": \"MyToken\",\n             \"scopes: [\"foo:bar\"]\n           }'",
         "type": "bash"
       }
     ],
@@ -9779,6 +12448,7 @@
             "type": "Object",
             "optional": false,
             "field": "-",
+            "isArray": false,
             "description": "<p>The created API user</p>"
           }
         ]
@@ -9792,15 +12462,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_5"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.5"
   },
   {
     "type": "post",
     "url": "/v1/products/:productIdOrSlug/team/:username",
     "title": "Update team member",
     "name": "updateProductOrOrgTeamMember",
-    "group": "Products_6",
+    "group": "Products.6",
     "description": "<p>Update a current team member.</p>",
     "parameter": {
       "fields": {
@@ -9810,6 +12480,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           },
           {
@@ -9817,6 +12488,7 @@
             "type": "String",
             "optional": false,
             "field": "username",
+            "isArray": false,
             "description": "<p>Username of the team member to be updated</p>"
           }
         ]
@@ -9827,36 +12499,16 @@
         "name": "teams.users:update"
       }
     ],
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_6"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.6"
   },
   {
     "type": "delete",
     "url": "/v1/products/:productIdOrSlug/team/:username",
     "title": "Remove team member",
     "name": "removeTeamMember",
-    "group": "Products_7",
+    "group": "Products.7",
     "description": "<p>Remove a current team member.</p>",
     "parameter": {
       "fields": {
@@ -9866,6 +12518,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           },
           {
@@ -9873,6 +12526,7 @@
             "type": "String",
             "optional": false,
             "field": "username",
+            "isArray": false,
             "description": "<p>Username of the team member to be removed</p>"
           }
         ]
@@ -9883,35 +12537,15 @@
         "name": "teams.users:remove"
       }
     ],
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
         "title": "Delete product user",
-        "content": "$ curl -X DELETE \"https://api.particle.io/products/:productIdOrSlug/team/test@example.com?access_token=123abc\"",
+        "content": "$ curl -X DELETE https://api.particle.io/products/:productIdOrSlug/team/test@example.com \\\n                 -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Delete organization user",
-        "content": "$ curl -X DELETE \"https://api.particle.io/orgs/:orgIdOrSlug/team/test@example.com?access_token=123abc\"",
+        "content": "$ curl -X DELETE https://api.particle.io/orgs/:orgIdOrSlug/team/test@example.com \\\n                 -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -9925,8 +12559,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Products_7"
+    "filename": "src/views/product.js",
+    "groupTitle": "Products.7"
   },
   {
     "type": "post",
@@ -9947,39 +12581,23 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "id",
-            "description": "<p>ID of the device to be denied</p>"
           }
         ]
       }
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
-    "group": "Quarantine_1",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "id",
+        "isArray": false,
+        "description": "<p>ID of the device to be denied</p>"
+      }
+    ],
+    "group": "Quarantine.1",
     "success": {
       "examples": [
         {
@@ -9990,12 +12608,12 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Quarantine_1"
+    "filename": "src/views/product.js",
+    "groupTitle": "Quarantine.1"
   },
   {
     "type": "delete",
-    "url": "/v1/products/:productIdOrSlug/devices/:deviceID",
+    "url": "/v1/products/:productIdOrSlug/devices/:deviceId",
     "title": "Deny a quarantined device",
     "name": "denyQuarantinedDevice",
     "permission": [
@@ -10012,49 +12630,35 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or Slug</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "deviceID",
+            "field": "deviceId",
+            "isArray": false,
             "description": "<p>ID of the device to be denied</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Boolean",
-            "allowedValues": [
-              "true"
-            ],
-            "optional": false,
-            "field": "deny",
-            "description": "<p>Flag indicating you wish to deny this device, instead of removing an already approved device.</p>"
           }
         ]
       }
     },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
-    "group": "Quarantine_2",
+    "body": [
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "allowedValues": [
+          "true"
+        ],
+        "optional": false,
+        "field": "deny",
+        "isArray": false,
+        "description": "<p>Flag indicating you wish to deny this device, instead of removing an already approved device.</p>",
+        "checked": false
+      }
+    ],
+    "group": "Quarantine.2",
     "success": {
       "examples": [
         {
@@ -10065,8 +12669,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Quarantine_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "Quarantine.2"
   },
   {
     "type": "get",
@@ -10074,27 +12678,7 @@
     "title": "Get user service agreements",
     "name": "getServiceAgreements",
     "description": "<p>Get the service agreements related to a user</p>",
-    "group": "ServiceAgreements_1",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
-    },
+    "group": "ServiceAgreements.1",
     "success": {
       "examples": [
         {
@@ -10110,6 +12694,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Service agreement Unique ID</p>"
           },
           {
@@ -10117,6 +12702,7 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
@@ -10124,119 +12710,261 @@
             "type": "Object",
             "optional": false,
             "field": "attributes",
+            "isArray": false,
             "description": "<p>Service agreement attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.owner_id",
+            "isArray": false,
             "description": "<p>Service agreement owner</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.agreement_type",
+            "isArray": false,
             "description": "<p>Service agreement type</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.duration",
+            "isArray": false,
             "description": "<p>Billing period duration</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>Indicates if the service agreement is active</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.starts_on",
+            "isArray": false,
             "description": "<p>Date when the service agreement started</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.ends_on",
+            "isArray": false,
             "description": "<p>service Agreements ends date</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_billing_period_start",
+            "isArray": false,
             "description": "<p>Current billing period start date</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_usage_summary",
+            "isArray": false,
             "description": "<p>Usage summary for the period</p>"
           },
           {
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.current_usage_summary",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.current_usage_summary",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_usage_summary.device_limit_reached",
+            "isArray": false,
             "description": "<p>Indicates if the device limit was reached</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.current_usage_summary",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.current_usage_summary",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_usage_summary.connectivity",
+            "isArray": false,
             "description": "<p>Info about the connectivity devices grouped by device type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms",
+            "isArray": false,
             "description": "<p>All related with the selected pricing model</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.rates",
+            "isArray": false,
             "description": "<p>Rates limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.device",
+            "isArray": false,
             "description": "<p>Device limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.messaging",
+            "isArray": false,
             "description": "<p>Message limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.device_data",
+            "isArray": false,
             "description": "<p>Device data limits and consumption period</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/serviceAgreement.js",
-    "groupTitle": "ServiceAgreements_1"
+    "filename": "src/views/serviceAgreement.js",
+    "groupTitle": "ServiceAgreements.1"
   },
   {
     "type": "get",
@@ -10244,7 +12972,7 @@
     "title": "Get organization service agreements",
     "name": "getServiceAgreementsForOrganization",
     "description": "<p>Get the service agreements related to an organization</p>",
-    "group": "ServiceAgreements_2",
+    "group": "ServiceAgreements.2",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -10253,30 +12981,11 @@
             "type": "String",
             "optional": false,
             "field": "orgIdOrSlug",
+            "isArray": false,
             "description": "<p>Org ID or Slug</p>"
           }
         ]
       }
-    },
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 01234567890ABCDEF\"",
-          "type": "json"
-        }
-      ]
     },
     "permission": [
       {
@@ -10298,6 +13007,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Service agreement Unique ID</p>"
           },
           {
@@ -10305,6 +13015,7 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
@@ -10312,126 +13023,281 @@
             "type": "Object",
             "optional": false,
             "field": "attributes",
+            "isArray": false,
             "description": "<p>Service agreement attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.owner_id",
+            "isArray": false,
             "description": "<p>Service agreement owner</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.agreement_type",
+            "isArray": false,
             "description": "<p>Service agreement type</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.duration",
+            "isArray": false,
             "description": "<p>Billing period duration</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>Indicates if the service agreement is active</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.starts_on",
+            "isArray": false,
             "description": "<p>Date when the service agreement started</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.ends_on",
+            "isArray": false,
             "description": "<p>service Agreements ends date</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_billing_period_start",
+            "isArray": false,
             "description": "<p>Current billing period start date</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_usage_summary",
+            "isArray": false,
             "description": "<p>Usage summary for the period</p>"
           },
           {
             "group": "Success 200",
             "type": "Boolean",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.current_usage_summary",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.current_usage_summary",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_usage_summary.device_limit_reached",
+            "isArray": false,
             "description": "<p>Indicates if the device limit was reached</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.current_usage_summary",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.current_usage_summary",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.current_usage_summary.connectivity",
+            "isArray": false,
             "description": "<p>Info about the connectivity devices grouped by device type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms",
+            "isArray": false,
             "description": "<p>All related with the selected pricing model</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.rates",
+            "isArray": false,
             "description": "<p>Rates limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.device",
+            "isArray": false,
             "description": "<p>Device limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.messaging",
+            "isArray": false,
             "description": "<p>Message limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.device_data",
+            "isArray": false,
             "description": "<p>Device data limits and consumption period</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.pricing_terms",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.pricing_terms",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.pricing_terms.support",
+            "isArray": false,
             "description": "<p>Email address for enterprise support</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "ServiceAgreements_2"
+    "filename": "src/views/product.js",
+    "groupTitle": "ServiceAgreements.2"
   },
   {
     "type": "get",
@@ -10447,6 +13313,7 @@
             "type": "Integer",
             "optional": false,
             "field": "usageReportId",
+            "isArray": false,
             "description": "<p>The usage report ID</p>"
           }
         ]
@@ -10455,24 +13322,11 @@
     "examples": [
       {
         "title": "Example Request",
-        "content": "$ curl \"https://api.particle.io/v1/user/usage_reports/:userReportId\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "content": "$ curl \"https://api.particle.io/v1/user/usage_reports/:userReportId\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
-    "group": "ServiceAgreements_3",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      }
-    },
+    "group": "ServiceAgreements.3",
     "success": {
       "examples": [
         {
@@ -10488,6 +13342,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Usage Report Unique ID</p>"
           },
           {
@@ -10495,6 +13350,7 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
@@ -10502,98 +13358,201 @@
             "type": "Object",
             "optional": false,
             "field": "attributes",
+            "isArray": false,
             "description": "<p>Usage Report attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>Usage Report current state</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.service_agreement_id",
+            "isArray": false,
             "description": "<p>Service Agreement Unique ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_start",
+            "isArray": false,
             "description": "<p>The start of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_end",
+            "isArray": false,
             "description": "<p>The end of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.created_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report request was created</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.expires_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report file expires</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_type",
+            "isArray": false,
             "description": "<p>Usage Report type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params",
+            "isArray": false,
             "description": "<p>Usage Report parameters</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.devices",
+            "isArray": false,
             "description": "<p>List of Device Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.products",
+            "isArray": false,
             "description": "<p>List of Product Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.recipient_list",
+            "isArray": false,
             "description": "<p>List of emails to send the report via email</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.download_url",
+            "isArray": false,
             "description": "<p>Usage Report file expirable download URL</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/usageReport.js",
-    "groupTitle": "ServiceAgreements_3"
+    "filename": "src/views/usageReport.js",
+    "groupTitle": "ServiceAgreements.3"
   },
   {
     "type": "get",
@@ -10609,6 +13568,7 @@
             "type": "Integer",
             "optional": false,
             "field": "usageReportId",
+            "isArray": false,
             "description": "<p>The usage report ID</p>"
           },
           {
@@ -10616,6 +13576,7 @@
             "type": "String",
             "optional": false,
             "field": "orgSlugOrId",
+            "isArray": false,
             "description": "<p>Organization Slug or ID</p>"
           }
         ]
@@ -10629,24 +13590,11 @@
     "examples": [
       {
         "title": "Example Request",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/usage_reports/:usageReportId\" \\\n       -H \"Authorization: Bearer <access_token>\"",
+        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/usage_reports/:usageReportId\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
-    "group": "ServiceAgreements_4",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      }
-    },
+    "group": "ServiceAgreements.4",
     "success": {
       "examples": [
         {
@@ -10662,6 +13610,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Usage Report Unique ID</p>"
           },
           {
@@ -10669,6 +13618,7 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
@@ -10676,98 +13626,201 @@
             "type": "Object",
             "optional": false,
             "field": "attributes",
+            "isArray": false,
             "description": "<p>Usage Report attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>Usage Report current state</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.service_agreement_id",
+            "isArray": false,
             "description": "<p>Service Agreement Unique ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_start",
+            "isArray": false,
             "description": "<p>The start of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_end",
+            "isArray": false,
             "description": "<p>The end of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.created_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report request was created</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.expires_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report file expires</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_type",
+            "isArray": false,
             "description": "<p>Usage Report type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params",
+            "isArray": false,
             "description": "<p>Usage Report parameters</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.devices",
+            "isArray": false,
             "description": "<p>List of Device Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.products",
+            "isArray": false,
             "description": "<p>List of Product Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.recipient_list",
+            "isArray": false,
             "description": "<p>List of emails to send the report via email</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.download_url",
+            "isArray": false,
             "description": "<p>Usage Report file expirable download URL</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/usageReport.js",
-    "groupTitle": "ServiceAgreements_4"
+    "filename": "src/views/usageReport.js",
+    "groupTitle": "ServiceAgreements.4"
   },
   {
     "type": "post",
@@ -10780,56 +13833,57 @@
         "Parameter": [
           {
             "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "orgSlugOrId",
-            "description": "<p>Organization Slug or ID</p>"
-          },
-          {
-            "group": "Parameter",
             "type": "Integer",
             "optional": false,
-            "field": "service_agreement_id",
+            "field": "serviceAgreementId",
+            "isArray": false,
             "description": "<p>Service Agreement ID</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "report_type",
-            "description": "<p>One of the supported report types, &quot;devices&quot; or &quot;products&quot;</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "date_period_start",
-            "description": "<p>The start of the date period to query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "date_period_end",
-            "description": "<p>The end of the date period to query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String[]",
-            "optional": true,
-            "field": "devices",
-            "description": "<p>An optional array of Device IDs</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String[]",
-            "optional": true,
-            "field": "products",
-            "description": "<p>An optional array of Product IDs</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "report_type",
+        "isArray": false,
+        "description": "<p>One of the supported report types, &quot;devices&quot; or &quot;products&quot;</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "date_period_start",
+        "isArray": false,
+        "description": "<p>The start of the date period to query</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "date_period_end",
+        "isArray": false,
+        "description": "<p>The end of the date period to query</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "devices",
+        "isArray": true,
+        "description": "<p>An optional array of Device IDs</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "products",
+        "isArray": true,
+        "description": "<p>An optional array of Product IDs</p>"
+      }
+    ],
     "permission": [
       {
         "name": "service_agreements.usage_reports:create"
@@ -10838,24 +13892,11 @@
     "examples": [
       {
         "title": "Example Request",
-        "content": "$ curl -X POST \"https://api.particle.io/v1/user/service_agreements/:serviceAgreementId/usage_reports\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\n         \"report_type\": \"devices\",\n         \"date_period_start\": \"2022-01-01\",\n         \"date_period_end\": \"2022-01-31\",\n         \"devices\": [\"device1\", \"device2\"]\n       }'",
+        "content": "$ curl -X POST \"https://api.particle.io/v1/user/service_agreements/:serviceAgreementId/usage_reports\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\n         \"report_type\": \"devices\",\n         \"date_period_start\": \"2022-01-01\",\n         \"date_period_end\": \"2022-01-31\",\n         \"devices\": [\"device1\", \"device2\"]\n       }'",
         "type": "bash"
       }
     ],
-    "group": "ServiceAgreements_5",
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      }
-    },
+    "group": "ServiceAgreements.5",
     "success": {
       "examples": [
         {
@@ -10871,6 +13912,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Usage Report Unique ID</p>"
           },
           {
@@ -10878,6 +13920,7 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
@@ -10885,98 +13928,201 @@
             "type": "Object",
             "optional": false,
             "field": "attributes",
+            "isArray": false,
             "description": "<p>Usage Report attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>Usage Report current state</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.service_agreement_id",
+            "isArray": false,
             "description": "<p>Service Agreement Unique ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_start",
+            "isArray": false,
             "description": "<p>The start of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_end",
+            "isArray": false,
             "description": "<p>The end of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.created_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report request was created</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.expires_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report file expires</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_type",
+            "isArray": false,
             "description": "<p>Usage Report type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params",
+            "isArray": false,
             "description": "<p>Usage Report parameters</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.devices",
+            "isArray": false,
             "description": "<p>List of Device Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.products",
+            "isArray": false,
             "description": "<p>List of Product Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.recipient_list",
+            "isArray": false,
             "description": "<p>List of emails to send the report via email</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.download_url",
+            "isArray": false,
             "description": "<p>Usage Report file expirable download URL</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/usageReport.js",
-    "groupTitle": "ServiceAgreements_5"
+    "filename": "src/views/usageReport.js",
+    "groupTitle": "ServiceAgreements.5"
   },
   {
     "type": "post",
@@ -10992,74 +14138,70 @@
             "type": "String",
             "optional": false,
             "field": "orgSlugOrId",
+            "isArray": false,
             "description": "<p>Organization Slug or ID</p>"
           },
           {
             "group": "Parameter",
             "type": "Integer",
             "optional": false,
-            "field": "service_agreement_id",
+            "field": "serviceAgreementId",
+            "isArray": false,
             "description": "<p>Service Agreement ID</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "report_type",
-            "description": "<p>One of the supported report types, &quot;devices&quot; or &quot;products&quot;</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "date_period_start",
-            "description": "<p>The start of the date period to query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "date_period_end",
-            "description": "<p>The end of the date period to query</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String[]",
-            "optional": true,
-            "field": "devices",
-            "description": "<p>An optional array of Device IDs</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String[]",
-            "optional": true,
-            "field": "products",
-            "description": "<p>An optional array of Product IDs</p>"
           }
         ]
       }
     },
-    "group": "ServiceAgreements_6",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "report_type",
+        "isArray": false,
+        "description": "<p>One of the supported report types, &quot;devices&quot; or &quot;products&quot;</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "date_period_start",
+        "isArray": false,
+        "description": "<p>The start of the date period to query</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "date_period_end",
+        "isArray": false,
+        "description": "<p>The end of the date period to query</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "devices",
+        "isArray": true,
+        "description": "<p>An optional array of Device IDs</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "products",
+        "isArray": true,
+        "description": "<p>An optional array of Product IDs</p>"
+      }
+    ],
+    "group": "ServiceAgreements.6",
     "examples": [
       {
         "title": "Example Request",
-        "content": "$ curl -X POST \"https://api.particle.io/v1/orgs/:orgSlugOrId/service_agreements/:serviceAgreementId/usage_reports\" \\\n       -H \"Authorization: Bearer <access_token>\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\n         \"report_type\": \"devices\",\n         \"date_period_start\": \"2022-01-01\",\n         \"date_period_end\": \"2022-01-31\",\n         \"devices\": [\"device1\", \"device2\"]\n       }'",
+        "content": "$ curl -X POST \"https://api.particle.io/v1/orgs/:orgSlugOrId/service_agreements/:serviceAgreementId/usage_reports\" \\\n       -H \"Authorization: Bearer :access_token\" \\\n       -H \"Content-Type: application/json\" \\\n       -d '{\n         \"report_type\": \"devices\",\n         \"date_period_start\": \"2022-01-01\",\n         \"date_period_end\": \"2022-01-31\",\n         \"devices\": [\"device1\", \"device2\"]\n       }'",
         "type": "bash"
       }
     ],
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      }
-    },
     "success": {
       "examples": [
         {
@@ -11075,6 +14217,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Usage Report Unique ID</p>"
           },
           {
@@ -11082,6 +14225,7 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
@@ -11089,98 +14233,201 @@
             "type": "Object",
             "optional": false,
             "field": "attributes",
+            "isArray": false,
             "description": "<p>Usage Report attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>Usage Report current state</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.service_agreement_id",
+            "isArray": false,
             "description": "<p>Service Agreement Unique ID</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_start",
+            "isArray": false,
             "description": "<p>The start of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.date_period_end",
+            "isArray": false,
             "description": "<p>The end of the date period to query</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.created_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report request was created</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.expires_at",
+            "isArray": false,
             "description": "<p>UTC timestamp of when the Usage Report file expires</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_type",
+            "isArray": false,
             "description": "<p>Usage Report type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params",
+            "isArray": false,
             "description": "<p>Usage Report parameters</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.devices",
+            "isArray": false,
             "description": "<p>List of Device Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.products",
+            "isArray": false,
             "description": "<p>List of Product Unique IDs</p>"
           },
           {
             "group": "Success 200",
             "type": "Array",
             "optional": false,
+            "parentNode": {
+              "path": "attributes.report_params",
+              "parentNode": {
+                "path": "attributes",
+                "field": "attributes",
+                "type": "Object",
+                "isArray": false
+              },
+              "field": "attributes.report_params",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.report_params.recipient_list",
+            "isArray": false,
             "description": "<p>List of emails to send the report via email</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.download_url",
+            "isArray": false,
             "description": "<p>Usage Report file expirable download URL</p>"
           }
         ]
       }
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/usageReport.js",
-    "groupTitle": "ServiceAgreements_6"
+    "filename": "src/views/usageReport.js",
+    "groupTitle": "ServiceAgreements.6"
   },
   {
     "type": "get",
@@ -11188,41 +14435,35 @@
     "title": "Get notifications for current usage period",
     "name": "GetServiceAgreementNotifications",
     "description": "<p>Get user notifications related to a specific service agreement</p> <ul> <li>Usage reached a certain threshold (70%, 90%, 100%)</li> <li>Service was paused</li> <li>Service was unpaused</li> </ul>",
-    "group": "ServiceAgreements_7",
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": false,
+            "field": "serviceAgreementId",
+            "isArray": false,
+            "description": "<p>Service agreement ID</p>"
+          }
+        ]
+      }
+    },
+    "group": "ServiceAgreements.7",
     "permission": [
       {
         "name": "service_agreements.notifications:list"
       }
     ],
-    "header": {
-      "fields": {
-        "Header": [
-          {
-            "group": "Header",
-            "type": "String",
-            "optional": false,
-            "field": "Authorization",
-            "description": "<p>Access Token</p>"
-          }
-        ]
-      },
-      "examples": [
-        {
-          "title": "Authorization-Example",
-          "content": "Authorization: \"Bearer 555551111AWESOME\"",
-          "type": "json"
-        }
-      ]
-    },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/user/service_agreements/:serviceAgreementId/notifications?access_token=123abc\"",
-        "content": "$ curl \"https://api.particle.io/v1/user/service_agreements/:serviceAgreementId/notifications?access_token=123abc\"",
+        "title": "$ curl https://api.particle.io/v1/user/service_agreements/:serviceAgreementId/notifications \\",
+        "content": "$ curl https://api.particle.io/v1/user/service_agreements/:serviceAgreementId/notifications \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List notifications associated with an organization",
-        "content": "$ curl \"https://api.particle.io/v1/orgs/:orgSlugOrId/service_agreements/:serviceAgreementId/notifications?access_token=123abc\"",
+        "content": "$ curl https://api.particle.io/v1/orgs/:orgSlugOrId/service_agreements/:serviceAgreementId/notifications \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -11234,6 +14475,7 @@
             "type": "String",
             "optional": false,
             "field": "id",
+            "isArray": false,
             "description": "<p>Notification Unique ID</p>"
           },
           {
@@ -11241,69 +14483,133 @@
             "type": "String",
             "optional": false,
             "field": "type",
+            "isArray": false,
             "description": "<p>Object type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.",
+            "isArray": false,
             "description": "<p>Notification attributes</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.state",
+            "isArray": false,
             "description": "<p>indicates the state of the notification</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.event_name",
+            "isArray": false,
             "description": "<p>Notification event name</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.time_period",
+            "isArray": false,
             "description": "<p>Notification time period</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.created_at",
+            "isArray": false,
             "description": "<p>Notification created datetime</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.updated_at",
+            "isArray": false,
             "description": "<p>Notification updated datetime</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.resource_id",
+            "isArray": false,
             "description": "<p>Service agreement Id</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.resource_type",
+            "isArray": false,
             "description": "<p>Notification resource type</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
+            "parentNode": {
+              "path": "attributes",
+              "field": "attributes",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "attributes.details",
+            "isArray": false,
             "description": "<p>Notification details</p>"
           }
         ]
@@ -11317,15 +14623,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/serviceAgreement.js",
-    "groupTitle": "ServiceAgreements_7"
+    "filename": "src/views/serviceAgreement.js",
+    "groupTitle": "ServiceAgreements.7"
   },
   {
     "type": "delete",
     "url": "/v1/sims/:iccid",
     "title": "Release SIM from account",
     "name": "releaseSimFromAccount",
-    "group": "Sims_11",
+    "group": "Sims.11",
     "permission": [
       {
         "name": "sims:remove"
@@ -11340,6 +14646,7 @@
             "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>The ICCID of the desired SIM</p>"
           },
           {
@@ -11347,6 +14654,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
@@ -11355,12 +14663,12 @@
     "examples": [
       {
         "title": "Release ownership of a SIM you own",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/sims/1234 \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/sims/1234 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Release ownership of a SIM in a product",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/sims/1234 \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/products/:productIdOrSlug/sims/1234 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -11379,15 +14687,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_11"
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.11"
   },
   {
     "type": "get",
     "url": "/v1/sims",
     "title": "List SIM cards",
     "name": "listSims",
-    "group": "Sims_1",
+    "group": "Sims.1",
     "permission": [
       {
         "name": "sims:list"
@@ -11401,58 +14709,66 @@
             "group": "Parameter",
             "type": "String",
             "optional": true,
-            "field": "iccid",
-            "description": "<p>Filter results to SIMs with this ICCID (partial matching)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceId",
-            "description": "<p>Filter results to SIMs with this associated device ID (partial matching)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
-            "field": "deviceName",
-            "description": "<p>Filter results to SIMs with this associated device name (partial matching)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "page",
-            "defaultValue": "1",
-            "description": "<p>Current page of results</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "perPage",
-            "defaultValue": "25",
-            "description": "<p>Records per page</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
       }
     },
+    "query": [
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "iccid",
+        "isArray": false,
+        "description": "<p>Filter results to SIMs with this ICCID (partial matching)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "deviceId",
+        "isArray": false,
+        "description": "<p>Filter results to SIMs with this associated device ID (partial matching)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "String",
+        "optional": true,
+        "field": "deviceName",
+        "isArray": false,
+        "description": "<p>Filter results to SIMs with this associated device name (partial matching)</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "page",
+        "isArray": false,
+        "defaultValue": "1",
+        "description": "<p>Current page of results</p>"
+      },
+      {
+        "group": "Query",
+        "type": "Number",
+        "optional": true,
+        "field": "perPage",
+        "isArray": false,
+        "defaultValue": "25",
+        "description": "<p>Records per page</p>"
+      }
+    ],
     "examples": [
       {
         "title": "List SIM cards for a user",
-        "content": "$ curl \"https://api.particle.io/v1/sims?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/sims \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "List SIM cards for a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/sims?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -11464,146 +14780,287 @@
             "type": "Object[]",
             "optional": false,
             "field": "sims",
+            "isArray": true,
             "description": "<p>An array of SIM card objects</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims._id",
+            "isArray": false,
             "description": "<p>ICCID of the SIM</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.activations_count",
+            "isArray": false,
             "description": "<p>Number of times the SIM has been activated</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.base_country_code",
+            "isArray": false,
             "description": "<p>The ISO Alpha-2 code of the country where the SIM card is based</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.base_monthly_rate",
+            "isArray": false,
             "description": "<p>The monthly rate of the 1 MB data plan for this SIM card, in cents</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.deactivations_count",
+            "isArray": false,
             "description": "<p>Number of times the SIM has been deactivated</p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.first_activated_on",
+            "isArray": false,
             "description": "<p>Timestamp of the first activation date of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.last_activated_on",
+            "isArray": false,
             "description": "<p>Timestamp of the last activation date of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.last_activated_via",
+            "isArray": false,
             "description": "<p>The method used to activate the SIM card. <em>Internal use only, will be deprecated</em></p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.last_status_change_action",
+            "isArray": false,
             "description": "<p>The last state change of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.last_status_change_action_error",
+            "isArray": false,
             "description": "<p>Whether the last action change resulted in an error. Set to &quot;yes&quot; or &quot;no&quot;</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.msisdn",
+            "isArray": false,
             "description": "<p>MSISDN number of the Ublox modem</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.overage_monthly_rate",
+            "isArray": false,
             "description": "<p>The per-MB overage rate for this SIM card, in cents</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.status",
+            "isArray": false,
             "description": "<p>The current connectivity status of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.stripe_plan_slug",
+            "isArray": false,
             "description": "<p>Data plan type. <em>Internal use only, will be deprecated</em></p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the SIM was updated</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.user_id",
+            "isArray": false,
             "description": "<p>The ID of the user who owns the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.product_id",
+            "isArray": false,
             "description": "<p>The ID of the product who owns the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.carrier",
+            "isArray": false,
             "description": "<p>The Telefony provider for the SIM card's connectivity</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.last_device_id",
+            "isArray": false,
             "description": "<p>The device ID of the SIM card's last associated device</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sims",
+              "field": "sims",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "sims.last_device_name",
+            "isArray": false,
             "description": "<p>The device name of the SIM card's last associated device</p>"
           },
           {
@@ -11611,6 +15068,7 @@
             "type": "Object",
             "optional": false,
             "field": "meta",
+            "isArray": false,
             "description": "<p>An object containing the total number of pages of records <em>Product endpoint only</em></p>"
           }
         ]
@@ -11624,15 +15082,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_1"
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.1"
   },
   {
     "type": "get",
     "url": "/v1/sims/:iccid",
     "title": "Get SIM information",
     "name": "listSim",
-    "group": "Sims_2",
+    "group": "Sims.2",
     "permission": [
       {
         "name": "sims:get"
@@ -11647,6 +15105,7 @@
             "type": "String",
             "optional": true,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>Filter results to SIMs with this ICCID (partial matching) <em>Product endpoint only</em></p>"
           },
           {
@@ -11654,6 +15113,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
@@ -11662,12 +15122,12 @@
     "examples": [
       {
         "title": "Retrieve info on a single SIM card owned by a user",
-        "content": "$ curl \"https://api.particle.io/v1/sims?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/sims \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Retrieve info on a single SIM card that belongs to a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/sims?access_token=12345\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -11679,153 +15139,301 @@
             "type": "Object",
             "optional": false,
             "field": "sim",
+            "isArray": false,
             "description": "<p>The SIM card data object</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim._id",
+            "isArray": false,
             "description": "<p>ICCID of the SIM</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.activations_count",
+            "isArray": false,
             "description": "<p>Number of times the SIM has been activated</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.base_country_code",
+            "isArray": false,
             "description": "<p>The ISO Alpha-2 code of the country where the SIM card is based</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.base_monthly_rate",
+            "isArray": false,
             "description": "<p>The monthly rate of the 1 MB data plan for this SIM card, in cents</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.deactivations_count",
+            "isArray": false,
             "description": "<p>Number of times the SIM has been deactivated</p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.first_activated_on",
+            "isArray": false,
             "description": "<p>Timestamp of the first activation date of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.last_activated_on",
+            "isArray": false,
             "description": "<p>Timestamp of the last activation date of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.last_activated_via",
+            "isArray": false,
             "description": "<p>The method used to activate the SIM card. <em>Internal use only, will be deprecated</em></p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.last_status_change_action",
+            "isArray": false,
             "description": "<p>The last state change of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.last_status_change_action_error",
+            "isArray": false,
             "description": "<p>Whether the last action change resulted in an error. Set to &quot;yes&quot; or &quot;no&quot;</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.msisdn",
+            "isArray": false,
             "description": "<p>MSISDN number of the Ublox modem</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.overage_monthly_rate",
+            "isArray": false,
             "description": "<p>The per-MB overage rate for this SIM card, in cents</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.status",
+            "isArray": false,
             "description": "<p>The current connectivity status of the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.stripe_plan_slug",
+            "isArray": false,
             "description": "<p>Data plan type. <em>Internal use only, will be deprecated</em></p>"
           },
           {
             "group": "Success 200",
             "type": "Date",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.updated_at",
+            "isArray": false,
             "description": "<p>Timestamp representing the last time the SIM was updated</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.user_id",
+            "isArray": false,
             "description": "<p>The ID of the user who owns the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.product_id",
+            "isArray": false,
             "description": "<p>The ID of the product who owns the SIM card</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.carrier",
+            "isArray": false,
             "description": "<p>The Telefony provider for the SIM card's connectivity</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.last_device_id",
+            "isArray": false,
             "description": "<p>The device ID of the SIM card's last associated device</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.last_device_name",
+            "isArray": false,
             "description": "<p>The device name of the SIM card's last associated device</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "sim",
+              "field": "sim",
+              "type": "Object",
+              "isArray": false
+            },
             "field": "sim.owner",
+            "isArray": false,
             "description": "<p>Particle username for the user who claimed this SIM card</p>"
           }
         ]
@@ -11839,15 +15447,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_2"
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.2"
   },
   {
     "type": "get",
     "url": "/v1/sims/:iccid/data_usage",
     "title": "Get data usage",
     "name": "simDataUsage",
-    "group": "Sims_3",
+    "group": "Sims.3",
     "description": "<p>Get SIM card data usage for the current billing period, broken out by day. Note that date usage reports can be delayed by up to 1 hour.</p>",
     "parameter": {
       "fields": {
@@ -11857,6 +15465,7 @@
             "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>The ICCID of the desired SIM</p>"
           },
           {
@@ -11864,6 +15473,7 @@
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
@@ -11872,12 +15482,12 @@
     "examples": [
       {
         "title": "Data usage for a SIM you own",
-        "content": "$ curl \"https://api.particle.io/v1/sims/1234/data_usage?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/sims/1234/data_usage \\\n      -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Data usage for a SIM in a product",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/sims/1234/data_usage?access_token=1234\"",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims/1234/data_usage \\\n      -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -11889,6 +15499,7 @@
             "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>ICCID of the SIM</p>"
           },
           {
@@ -11896,27 +15507,49 @@
             "type": "Object[]",
             "optional": false,
             "field": "usage_by_day",
+            "isArray": true,
             "description": "<p>An array of data usage by day</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "usage_by_day",
+              "field": "usage_by_day",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "usage_by_day.date",
+            "isArray": false,
             "description": "<p>The date of the usage day</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "usage_by_day",
+              "field": "usage_by_day",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "usage_by_day.mbs_used",
+            "isArray": false,
             "description": "<p>Megabytes used in the usage day</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "usage_by_day",
+              "field": "usage_by_day",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "usage_by_day.mbs_used_cumulative",
+            "isArray": false,
             "description": "<p>Total megabytes used in the billing period, inclusive of this usage day</p>"
           }
         ]
@@ -11930,15 +15563,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_3"
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.3"
   },
   {
     "type": "get",
     "url": "/v1/products/:productIdOrSlug/sims/data_usage",
     "title": "Get data usage for product fleet",
     "name": "simFleetDataUsage",
-    "group": "Sims_4",
+    "group": "Sims.4",
     "permission": [
       {
         "name": "sims.usage:get"
@@ -11953,6 +15586,7 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
           }
         ]
@@ -11960,8 +15594,8 @@
     },
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/sims/data_usage?access_token=1234\"",
-        "content": "$ curl \"https://api.particle.io/v1/products/:productIdOrSlug/sims/data_usage?access_token=1234\"",
+        "title": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims/data_usage \\",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims/data_usage \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -11973,6 +15607,7 @@
             "type": "Number",
             "optional": false,
             "field": "total_mbs_used",
+            "isArray": false,
             "description": "<p>The total number of megabytes consumed by the fleet in the current billing period</p>"
           },
           {
@@ -11980,6 +15615,7 @@
             "type": "Number",
             "optional": false,
             "field": "total_active_sim_cards",
+            "isArray": false,
             "description": "<p>The total number of active SIM cards in the product fleet. SIM cards that have been paused due to reaching their monthly data limit are included in this total.</p>"
           },
           {
@@ -11987,27 +15623,49 @@
             "type": "Object[]",
             "optional": false,
             "field": "usage_by_day",
+            "isArray": true,
             "description": "<p>An array of data usage by day</p>"
           },
           {
             "group": "Success 200",
             "type": "String",
             "optional": false,
+            "parentNode": {
+              "path": "usage_by_day",
+              "field": "usage_by_day",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "usage_by_day.date",
+            "isArray": false,
             "description": "<p>The date of the usage day</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "usage_by_day",
+              "field": "usage_by_day",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "usage_by_day.mbs_used",
+            "isArray": false,
             "description": "<p>Megabytes used in the usage day</p>"
           },
           {
             "group": "Success 200",
             "type": "Number",
             "optional": false,
+            "parentNode": {
+              "path": "usage_by_day",
+              "field": "usage_by_day",
+              "type": "Object[]",
+              "isArray": true
+            },
             "field": "usage_by_day.mbs_used_cumulative",
+            "isArray": false,
             "description": "<p>Total megabytes used in the billing period, inclusive of this usage day</p>"
           }
         ]
@@ -12021,38 +15679,43 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Sims_4"
+    "filename": "src/views/product.js",
+    "groupTitle": "Sims.4"
   },
   {
     "type": "put",
     "url": "/v1/sims/:iccid",
     "title": "Activate SIM",
-    "group": "Sims_6",
+    "group": "Sims.6",
     "description": "<p>Activates a SIM card for the first time.</p> <p><strong>Can not be used to activate Product SIM cards. Use the <a href=\"#import-and-activate-product-sims\">product import endpoint</a> instead.</strong></p>",
     "parameter": {
       "fields": {
         "Parameter": [
           {
             "group": "Parameter",
-            "optional": false,
-            "field": "iccid",
-            "description": "<p>The ICCID of the SIM to update</p>"
-          },
-          {
-            "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "action",
-            "description": "<p>Set to <code>activate</code> to trigger SIM activation</p>"
+            "field": "iccid",
+            "isArray": false,
+            "description": "<p>The ICCID of the SIM to update</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "action",
+        "isArray": false,
+        "description": "<p>Set to <code>activate</code> to trigger SIM activation</p>"
+      }
+    ],
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl -X PUT https://api.particle.io/v1/sims/1234 \\\n       -d action=activate \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/sims/1234 \\\n       -d action=activate \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -12066,8 +15729,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_6",
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.6",
     "name": "PutV1SimsIccid"
   },
   {
@@ -12076,7 +15739,7 @@
     "title": "Import and activate product SIMs",
     "name": "listProductSims",
     "description": "<p>Import a group of SIM cards into a product. SIM cards will be activated upon import. Either pass an array of ICCIDs or include a file containing a list of SIM cards.</p> <p>Import and activation will be queued for processing. You will receive an email with the import results when all SIM cards have been processed.</p> <p>Importing a SIM card associated with a device will also import the device into the product.</p>",
-    "group": "Sims_7",
+    "group": "Sims.7",
     "parameter": {
       "fields": {
         "Parameter": [
@@ -12085,25 +15748,30 @@
             "type": "String",
             "optional": false,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String[]",
-            "optional": true,
-            "field": "sims",
-            "description": "<p>An array of SIM ICCIDs to import</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "File",
-            "optional": true,
-            "field": "file",
-            "description": "<p>A .txt file containing a single-column list of ICCIDs</p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String[]",
+        "optional": true,
+        "field": "sims",
+        "isArray": true,
+        "description": "<p>An array of SIM ICCIDs to import</p>"
+      },
+      {
+        "group": "Body",
+        "type": "File",
+        "optional": true,
+        "field": "file",
+        "isArray": false,
+        "description": "<p>A .txt file containing a single-column list of ICCIDs</p>"
+      }
+    ],
     "permission": [
       {
         "name": "sims:import"
@@ -12112,7 +15780,7 @@
     "examples": [
       {
         "title": "Example request",
-        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims \\\n       -d sims[]=8934076500002586220 \\\n       -d access_token=1234",
+        "content": "$ curl https://api.particle.io/v1/products/:productIdOrSlug/sims \\\n       -d sims[]=8934076500002586220 \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -12126,14 +15794,14 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/product.js",
-    "groupTitle": "Sims_7"
+    "filename": "src/views/product.js",
+    "groupTitle": "Sims.7"
   },
   {
     "type": "put",
     "url": "/v1/sims/:iccid",
     "title": "Deactivate SIM",
-    "group": "Sims_8",
+    "group": "Sims.8",
     "permission": [
       {
         "name": "sims:update"
@@ -12145,35 +15813,42 @@
         "Parameter": [
           {
             "group": "Parameter",
+            "type": "String",
             "optional": false,
             "field": "iccid",
+            "isArray": false,
             "description": "<p>The ICCID of the SIM to update</p>"
-          },
-          {
-            "group": "Parameter",
-            "optional": false,
-            "field": "action",
-            "description": "<p>Set to <code>deactivate</code> to trigger SIM deactivation</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "action",
+        "isArray": false,
+        "description": "<p>Set to <code>deactivate</code> to trigger SIM deactivation</p>"
+      }
+    ],
     "examples": [
       {
         "title": "Deactivate SIM",
-        "content": "$ curl -X PUT https://api.particle.io/v1/sims/1234 \\\n       -d action=deactivate \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/sims/1234 \\\n       -d action=deactivate \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Deactivate product SIM",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/sims/1234 \\\n       -d action=deactivate \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/sims/1234 \\\n       -d action=deactivate \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "json"
       }
     ],
@@ -12187,15 +15862,15 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_8",
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.8",
     "name": "PutV1SimsIccid"
   },
   {
     "type": "put",
     "url": "/v1/sims/:iccid",
     "title": "Reactivate SIM",
-    "group": "Sims_9",
+    "group": "Sims.9",
     "permission": [
       {
         "name": "sims:update"
@@ -12210,36 +15885,42 @@
         "Parameter": [
           {
             "group": "Parameter",
-            "optional": false,
-            "field": "iccid",
-            "description": "<p>The ICCID of the SIM to update</p>"
-          },
-          {
-            "group": "Parameter",
             "type": "String",
             "optional": false,
-            "field": "action",
-            "description": "<p>Set to <code>reactivate</code> to trigger SIM reactivation</p>"
+            "field": "iccid",
+            "isArray": false,
+            "description": "<p>The ICCID of the SIM to update</p>"
           },
           {
             "group": "Parameter",
             "type": "String",
             "optional": true,
             "field": "productIdOrSlug",
+            "isArray": false,
             "description": "<p>Product ID or slug. <em>Product endpoint only</em></p>"
           }
         ]
       }
     },
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "action",
+        "isArray": false,
+        "description": "<p>Set to <code>reactivate</code> to trigger SIM reactivation</p>"
+      }
+    ],
     "examples": [
       {
         "title": "Reactivate SIM",
-        "content": "$ curl -X PUT https://api.particle.io/v1/sims/1234 \\\n       -d action=reactivate \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/sims/1234 \\\n       -d action=reactivate \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Reactivate product SIM",
-        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/sims/1234 \\\n       -d action=reactivate \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/products/:productIdOrSlug/sims/1234 \\\n       -d action=reactivate \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -12253,8 +15934,8 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "groupTitle": "Sims_9",
+    "filename": "src/views/api.js",
+    "groupTitle": "Sims.9",
     "name": "PutV1SimsIccid"
   },
   {
@@ -12263,11 +15944,11 @@
     "title": "Get user",
     "name": "GetUser",
     "description": "<p>Return the user resource for the currently authenticated user.</p>",
-    "group": "User_1",
+    "group": "User.1",
     "examples": [
       {
-        "title": "$ curl \"https://api.particle.io/v1/user?access_token=12345\"",
-        "content": "$ curl \"https://api.particle.io/v1/user?access_token=12345\"",
+        "title": "$ curl https://api.particle.io/v1/user -H \"Authorization: Bearer :access_token\"",
+        "content": "$ curl https://api.particle.io/v1/user -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -12279,6 +15960,7 @@
             "type": "String",
             "optional": false,
             "field": "username",
+            "isArray": false,
             "description": "<p>Email address for current user</p>"
           },
           {
@@ -12286,6 +15968,7 @@
             "type": "Array",
             "optional": false,
             "field": "subscription_ids",
+            "isArray": false,
             "description": "<p>Subscriptions for SIM cards and products</p>"
           },
           {
@@ -12293,13 +15976,15 @@
             "type": "Object",
             "optional": false,
             "field": "mfa",
-            "description": "<p>Includes whether or not MFA is enabled</p>"
+            "isArray": false,
+            "description": "<p>Includes whether MFA is enabled</p>"
           },
           {
             "group": "Success 200",
             "type": "Object",
             "optional": false,
             "field": "account_info",
+            "isArray": false,
             "description": "<p>An object that contains a first_name, last_name, and business_account</p>"
           },
           {
@@ -12307,6 +15992,7 @@
             "type": "Integer",
             "optional": false,
             "field": "wifi_device_count",
+            "isArray": false,
             "description": "<p>Number of devices that count against the Wi-Fi device cap</p>"
           },
           {
@@ -12314,6 +16000,7 @@
             "type": "Integer",
             "optional": false,
             "field": "cellular_device_count",
+            "isArray": false,
             "description": "<p>Number of devices that count against the cellular device cap</p>"
           }
         ]
@@ -12327,71 +16014,73 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/user.js",
-    "groupTitle": "User_1"
+    "filename": "src/views/user.js",
+    "groupTitle": "User.1"
   },
   {
     "type": "put",
     "url": "/user",
     "title": "Update user",
     "name": "UpdateUser",
-    "group": "User_2",
+    "group": "User.2",
     "description": "<p>Update the logged-in user. Allows changing email, password and other account information.</p>",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>The new password</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "username",
-            "description": "<p>The new account email address</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Object",
-            "optional": false,
-            "field": "account_info",
-            "description": "<p>The new account info</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "current_password",
-            "description": "<p>The current password. Required to change username or password</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "boolean",
-            "optional": false,
-            "field": "invalidate_tokens",
-            "description": "<p>Invalidate all access tokens for user</p>"
-          }
-        ]
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>The new password</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "username",
+        "isArray": false,
+        "description": "<p>The new account email address</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Object",
+        "optional": false,
+        "field": "account_info",
+        "isArray": false,
+        "description": "<p>The new account info</p>"
+      },
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "current_password",
+        "isArray": false,
+        "description": "<p>The current password. Required to change username or password</p>"
+      },
+      {
+        "group": "Body",
+        "type": "Boolean",
+        "optional": false,
+        "field": "invalidate_tokens",
+        "isArray": false,
+        "description": "<p>Invalidate all access tokens for user</p>",
+        "checked": false
       }
-    },
+    ],
     "examples": [
       {
         "title": "Changing the password:",
-        "content": "$ curl -X PUT https://api.particle.io/v1/user \\\n       -d \"password=I'm a really long password that no one would guess\" \\\n       -d \"current_password=My current password\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/user \\\n       -d \"password=I'm a really long password that no one would guess\" \\\n       -d \"current_password=My current password\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Changing the email:",
-        "content": "$ curl -X PUT https://api.particle.io/v1/user \\\n       -d \"username=testuser@example.com\" \\\n       -d \"current_password=My current password\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/user \\\n       -d \"username=testuser@example.com\" \\\n       -d \"current_password=My current password\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Changing the account info:",
-        "content": "$ curl -X PUT https://api.particle.io/v1/user \\\n       -d \"account_info[first_name]=Test\" \\\n       -d \"account_info[last_name]=User\" \\\n       -d access_token=1234",
+        "content": "$ curl -X PUT https://api.particle.io/v1/user \\\n       -d \"account_info[first_name]=Test\" \\\n       -d \"account_info[last_name]=User\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -12405,38 +16094,35 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/user.js",
-    "groupTitle": "User_2"
+    "filename": "src/views/user.js",
+    "groupTitle": "User.2"
   },
   {
     "type": "put",
     "url": "/user",
     "title": "Delete user",
     "name": "deleteUser",
-    "group": "User_2",
+    "group": "User.2",
     "description": "<p>Delete the logged-in user. Allows removing user account and artifacts from Particle system</p>",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "password",
-            "description": "<p>Current password verification</p>"
-          }
-        ]
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "password",
+        "isArray": false,
+        "description": "<p>Current password verification</p>"
       }
-    },
+    ],
     "examples": [
       {
         "title": "Changing the password:",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/user \\\n       -d \"password=mypassword\" \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/user \\\n       -d \"password=mypassword\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       },
       {
         "title": "Changing the email:",
-        "content": "$ curl -X DELETE https://api.particle.io/v1/user \\\n       -d \"password=mypassword\" \\\n       -d access_token=1234",
+        "content": "$ curl -X DELETE https://api.particle.io/v1/user \\\n       -d \"password=mypassword\" \\\n       -H \"Authorization: Bearer :access_token\"",
         "type": "bash"
       }
     ],
@@ -12450,29 +16136,26 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/user.js",
-    "groupTitle": "User_2"
+    "filename": "src/views/user.js",
+    "groupTitle": "User.2"
   },
   {
     "type": "post",
     "url": "/user/password-reset",
     "title": "Forgot password",
     "name": "UserPasswordForgot",
-    "description": "<p>Create a new password reset token and send the user an email with the token. Client doesn't need to be authenticated. This endpoint is rate-limited to prevent abuse.</p>",
-    "group": "User_3",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "username",
-            "description": ""
-          }
-        ]
+    "description": "<p>Create a new password reset token and send the user an email with the token. This endpoint is rate-limited to prevent abuse.</p> <p>Note: This endpoint does not require an access token.</p>",
+    "group": "User.3",
+    "body": [
+      {
+        "group": "Body",
+        "type": "String",
+        "optional": false,
+        "field": "username",
+        "isArray": false,
+        "description": ""
       }
-    },
+    ],
     "examples": [
       {
         "title": "$ curl -X POST https://api.particle.io/v1/user/password-reset \\",
@@ -12490,69 +16173,7 @@
       ]
     },
     "version": "0.0.0",
-    "filename": "api-service/src/views/user.js",
-    "groupTitle": "User_3"
-  },
-  {
-    "type": "get",
-    "url": "/v1/diagnostics/:deviceId/summary",
-    "title": "Get device vitals metadata",
-    "parameter": {
-      "fields": {
-        "Parameter": [
-          {
-            "group": "Parameter",
-            "type": "String",
-            "optional": false,
-            "field": "deviceId",
-            "description": "<p>Device ID</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Date",
-            "optional": true,
-            "field": "start_date",
-            "defaultValue": "",
-            "description": "<p>ISO86001 DateTime to start on (inclusive)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Date",
-            "optional": true,
-            "field": "end_date",
-            "defaultValue": "",
-            "description": "<p>ISO86001 DateTime to end on (inclusive)</p>"
-          },
-          {
-            "group": "Parameter",
-            "type": "Number",
-            "optional": true,
-            "field": "limit",
-            "defaultValue": "30",
-            "description": "<p>Number of samples to return, defaults to 30</p>"
-          }
-        ]
-      }
-    },
-    "permission": [
-      {
-        "name": "devices.diagnostics.summary:get"
-      }
-    ],
-    "name": "getSummaryForDeviceDiagnostics",
-    "description": "<p>Contextualizes and allows for interpretation of <a href=\"#refresh-device-vitals\">device vitals</a>. Builds an object for output to a graph</p>",
-    "success": {
-      "examples": [
-        {
-          "title": "Retrieve all stats for a given day (2019-04-03), with 1 datapoint per 5 mins:",
-          "content": "GET /v1/diagnostics/230021001847343338333633/summary?start_date=2019-04-03T00:00:00.000Z&end_date=2019-04-03T23:59:99.999Z&limit=288\nHTTP/1.1 200 OK\n{\n  \"deviceID\": \"230021001847343338333633\",\n  \"memoryAvailable\": 86808,\n  \"bucketSize\": 300000,\n  \"startDate\": \"2019-04-03T00:00:00.000Z\",\n  \"endDate\": \"2019-04-03T23:59:99.999Z\",\n  \"hasBattery\": false,\n  \"samples\": [\n    {\n       \"timestamp\": \"2019-04-03T00:00:00.000Z\",\n       \"batteryCharging\": false,\n       \"batteryConnected\": false,\n       \"signalStrength\": {\n         \"max\": 70,\n         \"min\": 12,\n         \"avg\": 64.93,\n         \"med\": 66,\n         \"warnings\": [\n           {\n             \"timestamp\": \"2019-04-03T15:12:00.942Z\",\n             \"value\": 44,\n             \"range\": {\n               \"lt\": 20\n             }\n           }\n         ]\n       },\n       \"signalStrengthValue\": {\n         \"max\": -65,\n         \"min\": -98,\n         \"avg\": -67.54,\n         \"med\": -67,\n         \"warnings\": []\n      },\n       \"signalQuality\": {\n         \"max\": 27,\n         \"min\": 14,\n         \"avg\": 24.46,\n         \"med\": 25,\n         \"warnings\": []\n      },\n       \"roundTripTime\": {\n         \"max\": 6820,\n         \"min\": 1489,\n         \"avg\": 3690.5,\n         \"med\": 3196,\n         \"warnings\": []\n      },\n       \"memoryUsed\": {\n         \"max\": 35448,\n         \"min\": 29120,\n         \"avg\": 30035.36,\n         \"med\": 29120,\n         \"warnings\": []\n      },\n      \"batteryCharge\": null\n    }\n  ]\n}",
-          "type": "json"
-        }
-      ]
-    },
-    "version": "0.0.0",
-    "filename": "api-service/src/views/api.js",
-    "group": "_Users_rickk_Documents_src_docs_api_service_src_views_api_js",
-    "groupTitle": "_Users_rickk_Documents_src_docs_api_service_src_views_api_js"
+    "filename": "src/views/user.js",
+    "groupTitle": "User.3"
   }
 ]

--- a/generated/javascript.md
+++ b/generated/javascript.md
@@ -135,10 +135,17 @@
     -   [delete](#delete)
     -   [request](#request)
 
-
 ## Particle
 
-[src/Particle.js:26-2772](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L26-L2772 "Source code on GitHub")
+[src/Particle.js:20-2756](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L20-L2756 "Source code on GitHub")
+
+Particle Cloud API wrapper.
+
+See <https://docs.particle.io/reference/javascript/> for examples
+of using the `Particle` class.
+
+Most Particle methods take a single unnamed argument object documented as
+`options` with key/value pairs for each option.
 
 **Parameters**
 
@@ -146,7 +153,7 @@
 
 ### constructor
 
-[src/Particle.js:39-48](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L39-L48 "Source code on GitHub")
+[src/Particle.js:33-42](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L33-L42 "Source code on GitHub")
 
 Contructor for the Cloud API wrapper.
 
@@ -163,7 +170,7 @@ Create a new Particle object and call methods below on it.
 
 ### login
 
-[src/Particle.js:85-102](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L85-L102 "Source code on GitHub")
+[src/Particle.js:79-96](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L79-L96 "Source code on GitHub")
 
 Login to Particle Cloud using an existing Particle acccount.
 
@@ -180,7 +187,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### sendOtp
 
-[src/Particle.js:113-129](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L113-L129 "Source code on GitHub")
+[src/Particle.js:107-123](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L107-L123 "Source code on GitHub")
 
 If login failed with an 'mfa_required' error, this must be called with a valid OTP code to login
 
@@ -196,7 +203,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### enableMfa
 
-[src/Particle.js:139-141](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L139-L141 "Source code on GitHub")
+[src/Particle.js:133-135](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L133-L135 "Source code on GitHub")
 
 Enable MFA on the currently logged in user
 
@@ -211,7 +218,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### confirmMfa
 
-[src/Particle.js:154-168](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L154-L168 "Source code on GitHub")
+[src/Particle.js:148-162](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L148-L162 "Source code on GitHub")
 
 Confirm MFA for the user. This must be called with current TOTP code, determined from the results of enableMfa(). You will be prompted to enter an OTP code every time you login after enrollment is confirmed.
 
@@ -229,7 +236,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### disableMfa
 
-[src/Particle.js:179-187](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L179-L187 "Source code on GitHub")
+[src/Particle.js:173-181](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L173-L181 "Source code on GitHub")
 
 Disable MFA for the user.
 
@@ -245,7 +252,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createCustomer
 
-[src/Particle.js:199-215](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L199-L215 "Source code on GitHub")
+[src/Particle.js:193-209](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L193-L209 "Source code on GitHub")
 
 Create Customer for Product.
 
@@ -262,7 +269,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### loginAsClientOwner
 
-[src/Particle.js:224-238](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L224-L238 "Source code on GitHub")
+[src/Particle.js:218-232](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L218-L232 "Source code on GitHub")
 
 Login to Particle Cloud using an OAuth client.
 
@@ -276,7 +283,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createUser
 
-[src/Particle.js:251-263](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L251-L263 "Source code on GitHub")
+[src/Particle.js:245-257](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L245-L257 "Source code on GitHub")
 
 Create a user account for the Particle Cloud
 
@@ -294,7 +301,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### verifyUser
 
-[src/Particle.js:273-280](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L273-L280 "Source code on GitHub")
+[src/Particle.js:267-274](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L267-L274 "Source code on GitHub")
 
 Verify new user account via verification email
 
@@ -309,7 +316,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### resetPassword
 
-[src/Particle.js:290-297](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L290-L297 "Source code on GitHub")
+[src/Particle.js:284-291](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L284-L291 "Source code on GitHub")
 
 Send reset password email for a Particle Cloud user account
 
@@ -324,7 +331,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteAccessToken
 
-[src/Particle.js:309-317](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L309-L317 "Source code on GitHub")
+[src/Particle.js:303-311](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L303-L311 "Source code on GitHub")
 
 Revoke an access token
 
@@ -341,7 +348,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteCurrentAccessToken
 
-[src/Particle.js:327-334](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L327-L334 "Source code on GitHub")
+[src/Particle.js:321-328](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L321-L328 "Source code on GitHub")
 
 Revoke the current session access token
 
@@ -356,7 +363,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteActiveAccessTokens
 
-[src/Particle.js:344-351](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L344-L351 "Source code on GitHub")
+[src/Particle.js:338-345](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L338-L345 "Source code on GitHub")
 
 Revoke all active access tokens
 
@@ -371,7 +378,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteUser
 
-[src/Particle.js:362-370](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L362-L370 "Source code on GitHub")
+[src/Particle.js:356-364](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L356-L364 "Source code on GitHub")
 
 Delete the current user
 
@@ -387,7 +394,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listAccessTokens
 
-[src/Particle.js:382-390](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L382-L390 "Source code on GitHub")
+[src/Particle.js:376-384](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L376-L384 "Source code on GitHub")
 
 List all valid access tokens for a Particle Cloud account
 
@@ -404,7 +411,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### trackingIdentity
 
-[src/Particle.js:402-410](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L402-L410 "Source code on GitHub")
+[src/Particle.js:396-404](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L396-L404 "Source code on GitHub")
 
 Retrieves the information that is used to identify the current login for tracking.
 
@@ -421,7 +428,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listDevices
 
-[src/Particle.js:428-447](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L428-L447 "Source code on GitHub")
+[src/Particle.js:422-441](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L422-L441 "Source code on GitHub")
 
 List devices claimed to the account or product
 
@@ -444,7 +451,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getDevice
 
-[src/Particle.js:459-462](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L459-L462 "Source code on GitHub")
+[src/Particle.js:453-456](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L453-L456 "Source code on GitHub")
 
 Get detailed informationa about a device
 
@@ -461,7 +468,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### claimDevice
 
-[src/Particle.js:474-485](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L474-L485 "Source code on GitHub")
+[src/Particle.js:468-479](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L468-L479 "Source code on GitHub")
 
 Claim a device to the account. The device must be online and unclaimed.
 
@@ -478,7 +485,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### addDeviceToProduct
 
-[src/Particle.js:499-517](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L499-L517 "Source code on GitHub")
+[src/Particle.js:493-511](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L493-L511 "Source code on GitHub")
 
 Add a device to a product or move device out of quarantine.
 
@@ -497,7 +504,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### removeDevice
 
-[src/Particle.js:530-534](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L530-L534 "Source code on GitHub")
+[src/Particle.js:524-528](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L524-L528 "Source code on GitHub")
 
 Unclaim / Remove a device from your account or product, or deny quarantine
 
@@ -515,7 +522,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### removeDeviceOwner
 
-[src/Particle.js:546-549](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L546-L549 "Source code on GitHub")
+[src/Particle.js:540-543](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L540-L543 "Source code on GitHub")
 
 Unclaim a product device its the owner, but keep it in the product
 
@@ -532,7 +539,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### renameDevice
 
-[src/Particle.js:562-564](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L562-L564 "Source code on GitHub")
+[src/Particle.js:556-558](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L556-L558 "Source code on GitHub")
 
 Rename a device
 
@@ -550,7 +557,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### signalDevice
 
-[src/Particle.js:577-579](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L577-L579 "Source code on GitHub")
+[src/Particle.js:571-573](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L571-L573 "Source code on GitHub")
 
 Instruct the device to turn on/off the LED in a rainbow pattern
 
@@ -568,7 +575,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### setDeviceNotes
 
-[src/Particle.js:592-594](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L592-L594 "Source code on GitHub")
+[src/Particle.js:586-588](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L586-L588 "Source code on GitHub")
 
 Store some notes about device
 
@@ -586,7 +593,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### markAsDevelopmentDevice
 
-[src/Particle.js:607-609](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L607-L609 "Source code on GitHub")
+[src/Particle.js:601-603](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L601-L603 "Source code on GitHub")
 
 Mark device as being used in development of a product so it opts out of automatic firmware updates
 
@@ -604,7 +611,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### lockDeviceProductFirmware
 
-[src/Particle.js:623-625](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L623-L625 "Source code on GitHub")
+[src/Particle.js:617-619](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L617-L619 "Source code on GitHub")
 
 Mark device as being used in development of a product, so it opts out of automatic firmware updates
 
@@ -623,7 +630,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### unlockDeviceProductFirmware
 
-[src/Particle.js:637-639](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L637-L639 "Source code on GitHub")
+[src/Particle.js:631-633](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L631-L633 "Source code on GitHub")
 
 Mark device as receiving automatic firmware updates
 
@@ -640,7 +647,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateDevice
 
-[src/Particle.js:658-670](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L658-L670 "Source code on GitHub")
+[src/Particle.js:652-664](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L652-L664 "Source code on GitHub")
 
 Update multiple device attributes at the same time
 
@@ -664,7 +671,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### provisionDevice
 
-[src/Particle.js:681-689](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L681-L689 "Source code on GitHub")
+[src/Particle.js:675-683](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L675-L683 "Source code on GitHub")
 
 Provision a new device for products that allow self-provisioning
 
@@ -680,7 +687,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getClaimCode
 
-[src/Particle.js:703-706](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L703-L706 "Source code on GitHub")
+[src/Particle.js:697-700](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L697-L700 "Source code on GitHub")
 
 Generate a claim code to use in the device claiming process.
 To generate a claim code for a product, the access token MUST belong to a
@@ -699,7 +706,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getVariable
 
-[src/Particle.js:738-744](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L738-L744 "Source code on GitHub")
+[src/Particle.js:722-728](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L722-L728 "Source code on GitHub")
 
 Get the value of a device variable
 
@@ -717,7 +724,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### flashDevice
 
-[src/Particle.js:758-769](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L758-L769 "Source code on GitHub")
+[src/Particle.js:742-753](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L742-L753 "Source code on GitHub")
 
 Compile and flash application firmware to a device. Pass a pre-compiled binary to flash it directly to the device.
 
@@ -736,7 +743,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### flashTinker
 
-[src/Particle.js:780-795](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L780-L795 "Source code on GitHub")
+[src/Particle.js:764-779](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L764-L779 "Source code on GitHub")
 
 DEPRECATED: Flash the Tinker application to a device. Instead compile and flash the Tinker source code.
 
@@ -752,7 +759,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### compileCode
 
-[src/Particle.js:808-826](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L808-L826 "Source code on GitHub")
+[src/Particle.js:792-810](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L792-L810 "Source code on GitHub")
 
 Compile firmware using the Particle Cloud
 
@@ -770,7 +777,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### downloadFirmwareBinary
 
-[src/Particle.js:837-846](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L837-L846 "Source code on GitHub")
+[src/Particle.js:821-830](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L821-L830 "Source code on GitHub")
 
 Download a firmware binary
 
@@ -786,7 +793,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### sendPublicKey
 
-[src/Particle.js:859-873](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L859-L873 "Source code on GitHub")
+[src/Particle.js:843-857](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L843-L857 "Source code on GitHub")
 
 Send a new device public key to the Particle Cloud
 
@@ -804,7 +811,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### callFunction
 
-[src/Particle.js:887-892](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L887-L892 "Source code on GitHub")
+[src/Particle.js:871-876](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L871-L876 "Source code on GitHub")
 
 Call a device function
 
@@ -823,7 +830,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getEventStream
 
-[src/Particle.js:905-930](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L905-L930 "Source code on GitHub")
+[src/Particle.js:889-914](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L889-L914 "Source code on GitHub")
 
 Get a stream of events
 
@@ -841,7 +848,7 @@ emit 'event' events.
 
 ### publishEvent
 
-[src/Particle.js:944-948](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L944-L948 "Source code on GitHub")
+[src/Particle.js:928-932](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L928-L932 "Source code on GitHub")
 
 Publish a event to the Particle Cloud
 
@@ -860,7 +867,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### Hook
 
-[src/Particle.js:979-1001](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L979-L1001 "Source code on GitHub")
+[src/Particle.js:963-985](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L963-L985 "Source code on GitHub")
 
 Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)
 
@@ -893,7 +900,7 @@ Type: [Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference
 
 ### createWebhook
 
-[src/Particle.js:979-1001](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L979-L1001 "Source code on GitHub")
+[src/Particle.js:963-985](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L963-L985 "Source code on GitHub")
 
 Create a webhook
 
@@ -915,7 +922,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteWebhook
 
-[src/Particle.js:1013-1016](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1013-L1016 "Source code on GitHub")
+[src/Particle.js:997-1000](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L997-L1000 "Source code on GitHub")
 
 Delete a webhook
 
@@ -932,7 +939,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listWebhooks
 
-[src/Particle.js:1027-1030](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1027-L1030 "Source code on GitHub")
+[src/Particle.js:1011-1014](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1011-L1014 "Source code on GitHub")
 
 List all webhooks owned by the account or product
 
@@ -948,7 +955,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createIntegration
 
-[src/Particle.js:1047-1051](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1047-L1051 "Source code on GitHub")
+[src/Particle.js:1031-1035](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1031-L1035 "Source code on GitHub")
 
 Create an integration to send events to an external service
 
@@ -969,7 +976,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### editIntegration
 
-[src/Particle.js:1069-1073](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1069-L1073 "Source code on GitHub")
+[src/Particle.js:1053-1057](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1053-L1057 "Source code on GitHub")
 
 Edit an integration to send events to an external service
 
@@ -991,7 +998,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteIntegration
 
-[src/Particle.js:1086-1089](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1086-L1089 "Source code on GitHub")
+[src/Particle.js:1070-1073](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1070-L1073 "Source code on GitHub")
 
 Delete an integration to send events to an external service
 
@@ -1008,7 +1015,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listIntegrations
 
-[src/Particle.js:1100-1103](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1100-L1103 "Source code on GitHub")
+[src/Particle.js:1084-1087](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1084-L1087 "Source code on GitHub")
 
 List all integrations owned by the account or product
 
@@ -1024,7 +1031,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getUserInfo
 
-[src/Particle.js:1113-1115](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1113-L1115 "Source code on GitHub")
+[src/Particle.js:1097-1099](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1097-L1099 "Source code on GitHub")
 
 Get details about the current user
 
@@ -1039,7 +1046,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### setUserInfo
 
-[src/Particle.js:1126-1129](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1126-L1129 "Source code on GitHub")
+[src/Particle.js:1110-1113](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1110-L1113 "Source code on GitHub")
 
 Set details on the current user
 
@@ -1055,7 +1062,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### changeUsername
 
-[src/Particle.js:1142-1150](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1142-L1150 "Source code on GitHub")
+[src/Particle.js:1126-1134](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1126-L1134 "Source code on GitHub")
 
 Change username (i.e, email)
 
@@ -1073,7 +1080,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### changeUserPassword
 
-[src/Particle.js:1163-1171](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1163-L1171 "Source code on GitHub")
+[src/Particle.js:1147-1155](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1147-L1155 "Source code on GitHub")
 
 Change user's password
 
@@ -1091,7 +1098,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listSIMs
 
-[src/Particle.js:1187-1191](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1187-L1191 "Source code on GitHub")
+[src/Particle.js:1171-1175](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1171-L1175 "Source code on GitHub")
 
 List SIM cards owned by a user or product
 
@@ -1112,7 +1119,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getSIMDataUsage
 
-[src/Particle.js:1203-1209](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1203-L1209 "Source code on GitHub")
+[src/Particle.js:1187-1193](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1187-L1193 "Source code on GitHub")
 
 Get data usage for one SIM card for the current billing period
 
@@ -1129,7 +1136,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getFleetDataUsage
 
-[src/Particle.js:1220-1227](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1220-L1227 "Source code on GitHub")
+[src/Particle.js:1204-1211](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1204-L1211 "Source code on GitHub")
 
 Get data usage for all SIM cards in a product the current billing period
 
@@ -1145,7 +1152,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### checkSIM
 
-[src/Particle.js:1238-1240](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1238-L1240 "Source code on GitHub")
+[src/Particle.js:1222-1224](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1222-L1224 "Source code on GitHub")
 
 Check SIM status
 
@@ -1161,7 +1168,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### activateSIM
 
-[src/Particle.js:1255-1265](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1255-L1265 "Source code on GitHub")
+[src/Particle.js:1239-1249](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1239-L1249 "Source code on GitHub")
 
 Activate and add SIM cards to an account or product
 
@@ -1181,7 +1188,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deactivateSIM
 
-[src/Particle.js:1277-1281](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1277-L1281 "Source code on GitHub")
+[src/Particle.js:1261-1265](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1261-L1265 "Source code on GitHub")
 
 Deactivate a SIM card so it doesn't incur data usage in future months.
 
@@ -1198,7 +1205,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### reactivateSIM
 
-[src/Particle.js:1294-1298](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1294-L1298 "Source code on GitHub")
+[src/Particle.js:1278-1282](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1278-L1282 "Source code on GitHub")
 
 Reactivate a SIM card the was deactivated or unpause a SIM card that was automatically paused
 
@@ -1216,7 +1223,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateSIM
 
-[src/Particle.js:1311-1315](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1311-L1315 "Source code on GitHub")
+[src/Particle.js:1295-1299](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1295-L1299 "Source code on GitHub")
 
 Update SIM card data limit
 
@@ -1234,7 +1241,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### removeSIM
 
-[src/Particle.js:1327-1330](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1327-L1330 "Source code on GitHub")
+[src/Particle.js:1311-1314](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1311-L1314 "Source code on GitHub")
 
 Remove a SIM card from an account so it can be activated by a different account
 
@@ -1251,7 +1258,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listBuildTargets
 
-[src/Particle.js:1341-1344](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1341-L1344 "Source code on GitHub")
+[src/Particle.js:1325-1328](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1325-L1328 "Source code on GitHub")
 
 List valid build targets to be used for compiling
 
@@ -1267,7 +1274,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listLibraries
 
-[src/Particle.js:1370-1387](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1370-L1387 "Source code on GitHub")
+[src/Particle.js:1354-1371](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1354-L1371 "Source code on GitHub")
 
 List firmware libraries
 
@@ -1297,7 +1304,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLibrary
 
-[src/Particle.js:1403-1411](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1403-L1411 "Source code on GitHub")
+[src/Particle.js:1387-1395](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1387-L1395 "Source code on GitHub")
 
 Get firmware library details
 
@@ -1314,7 +1321,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLibraryVersions
 
-[src/Particle.js:1424-1432](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1424-L1432 "Source code on GitHub")
+[src/Particle.js:1408-1416](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1408-L1416 "Source code on GitHub")
 
 Firmware library details for each version
 
@@ -1332,7 +1339,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### contributeLibrary
 
-[src/Particle.js:1444-1457](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1444-L1457 "Source code on GitHub")
+[src/Particle.js:1428-1441](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1428-L1441 "Source code on GitHub")
 
 Contribute a new library version from a compressed archive
 
@@ -1349,7 +1356,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### publishLibrary
 
-[src/Particle.js:1468-1477](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1468-L1477 "Source code on GitHub")
+[src/Particle.js:1452-1461](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1452-L1461 "Source code on GitHub")
 
 Publish the latest version of a library to the public
 
@@ -1365,7 +1372,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteLibrary
 
-[src/Particle.js:1489-1497](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1489-L1497 "Source code on GitHub")
+[src/Particle.js:1473-1481](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1473-L1481 "Source code on GitHub")
 
 Delete one version of a library or an entire private library
 
@@ -1382,7 +1389,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### downloadFile
 
-[src/Particle.js:1507-1509](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1507-L1509 "Source code on GitHub")
+[src/Particle.js:1491-1493](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1491-L1493 "Source code on GitHub")
 
 Download an external file that may not be on the API
 
@@ -1397,7 +1404,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listOAuthClients
 
-[src/Particle.js:1520-1523](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1520-L1523 "Source code on GitHub")
+[src/Particle.js:1504-1507](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1504-L1507 "Source code on GitHub")
 
 List OAuth client created by the account
 
@@ -1413,7 +1420,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createOAuthClient
 
-[src/Particle.js:1538-1542](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1538-L1542 "Source code on GitHub")
+[src/Particle.js:1522-1526](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1522-L1526 "Source code on GitHub")
 
 Create an OAuth client
 
@@ -1433,7 +1440,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateOAuthClient
 
-[src/Particle.js:1556-1560](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1556-L1560 "Source code on GitHub")
+[src/Particle.js:1540-1544](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1540-L1544 "Source code on GitHub")
 
 Update an OAuth client
 
@@ -1452,7 +1459,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteOAuthClient
 
-[src/Particle.js:1572-1575](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1572-L1575 "Source code on GitHub")
+[src/Particle.js:1556-1559](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1556-L1559 "Source code on GitHub")
 
 Delete an OAuth client
 
@@ -1469,7 +1476,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listProducts
 
-[src/Particle.js:1585-1587](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1585-L1587 "Source code on GitHub")
+[src/Particle.js:1569-1571](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1569-L1571 "Source code on GitHub")
 
 List products the account has access to
 
@@ -1484,7 +1491,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProduct
 
-[src/Particle.js:1598-1600](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1598-L1600 "Source code on GitHub")
+[src/Particle.js:1582-1584](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1582-L1584 "Source code on GitHub")
 
 Get detailed information about a product
 
@@ -1500,7 +1507,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listProductFirmware
 
-[src/Particle.js:1611-1613](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1611-L1613 "Source code on GitHub")
+[src/Particle.js:1595-1597](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1595-L1597 "Source code on GitHub")
 
 List product firmware versions
 
@@ -1516,7 +1523,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### uploadProductFirmware
 
-[src/Particle.js:1629-1645](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1629-L1645 "Source code on GitHub")
+[src/Particle.js:1613-1629](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1613-L1629 "Source code on GitHub")
 
 List product firmware versions
 
@@ -1537,7 +1544,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductFirmware
 
-[src/Particle.js:1657-1664](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1657-L1664 "Source code on GitHub")
+[src/Particle.js:1641-1648](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1641-L1648 "Source code on GitHub")
 
 Get information about a product firmware version
 
@@ -1554,7 +1561,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateProductFirmware
 
-[src/Particle.js:1678-1681](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1678-L1681 "Source code on GitHub")
+[src/Particle.js:1662-1665](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1662-L1665 "Source code on GitHub")
 
 Update information for a product firmware version
 
@@ -1573,7 +1580,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### downloadProductFirmware
 
-[src/Particle.js:1693-1702](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1693-L1702 "Source code on GitHub")
+[src/Particle.js:1677-1686](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1677-L1686 "Source code on GitHub")
 
 Download a product firmware binary
 
@@ -1590,7 +1597,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### releaseProductFirmware
 
-[src/Particle.js:1714-1717](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1714-L1717 "Source code on GitHub")
+[src/Particle.js:1698-1701](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1698-L1701 "Source code on GitHub")
 
 Release a product firmware version as the default version
 
@@ -1607,7 +1614,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listTeamMembers
 
-[src/Particle.js:1728-1735](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1728-L1735 "Source code on GitHub")
+[src/Particle.js:1712-1719](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1712-L1719 "Source code on GitHub")
 
 List product team members
 
@@ -1623,7 +1630,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### inviteTeamMember
 
-[src/Particle.js:1747-1755](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1747-L1755 "Source code on GitHub")
+[src/Particle.js:1731-1739](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1731-L1739 "Source code on GitHub")
 
 Invite Particle user to a product team
 
@@ -1640,7 +1647,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### removeTeamMember
 
-[src/Particle.js:1767-1774](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1767-L1774 "Source code on GitHub")
+[src/Particle.js:1751-1758](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1751-L1758 "Source code on GitHub")
 
 Remove Particle user to a product team
 
@@ -1657,7 +1664,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### lookupSerialNumber
 
-[src/Particle.js:1785-1792](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1785-L1792 "Source code on GitHub")
+[src/Particle.js:1769-1776](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1769-L1776 "Source code on GitHub")
 
 Fetch details about a serial number
 
@@ -1673,7 +1680,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createMeshNetwork
 
-[src/Particle.js:1805-1813](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1805-L1813 "Source code on GitHub")
+[src/Particle.js:1789-1797](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1789-L1797 "Source code on GitHub")
 
 Create a mesh network
 
@@ -1691,7 +1698,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### removeMeshNetwork
 
-[src/Particle.js:1824-1826](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1824-L1826 "Source code on GitHub")
+[src/Particle.js:1808-1810](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1808-L1810 "Source code on GitHub")
 
 Remove a mesh network.
 
@@ -1707,7 +1714,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listMeshNetworks
 
-[src/Particle.js:1838-1841](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1838-L1841 "Source code on GitHub")
+[src/Particle.js:1822-1825](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1822-L1825 "Source code on GitHub")
 
 List all mesh networks
 
@@ -1724,7 +1731,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getMeshNetwork
 
-[src/Particle.js:1852-1854](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1852-L1854 "Source code on GitHub")
+[src/Particle.js:1836-1838](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1836-L1838 "Source code on GitHub")
 
 Get information about a mesh network.
 
@@ -1740,7 +1747,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateMeshNetwork
 
-[src/Particle.js:1867-1875](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1867-L1875 "Source code on GitHub")
+[src/Particle.js:1851-1859](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1851-L1859 "Source code on GitHub")
 
 Modify a mesh network.
 
@@ -1758,7 +1765,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### addMeshNetworkDevice
 
-[src/Particle.js:1887-1896](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1887-L1896 "Source code on GitHub")
+[src/Particle.js:1871-1880](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1871-L1880 "Source code on GitHub")
 
 Add a device to a mesh network.
 
@@ -1775,7 +1782,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### removeMeshNetworkDevice
 
-[src/Particle.js:1908-1924](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1908-L1924 "Source code on GitHub")
+[src/Particle.js:1892-1908](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1892-L1908 "Source code on GitHub")
 
 Remove a device from a mesh network.
 
@@ -1792,7 +1799,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listMeshNetworkDevices
 
-[src/Particle.js:1938-1947](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1938-L1947 "Source code on GitHub")
+[src/Particle.js:1922-1931](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1922-L1931 "Source code on GitHub")
 
 List all devices of a mesh network.
 
@@ -1811,7 +1818,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductConfiguration
 
-[src/Particle.js:1958-1965](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1958-L1965 "Source code on GitHub")
+[src/Particle.js:1942-1949](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1942-L1949 "Source code on GitHub")
 
 Get product configuration
 
@@ -1827,7 +1834,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductConfigurationSchema
 
-[src/Particle.js:1976-1984](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1976-L1984 "Source code on GitHub")
+[src/Particle.js:1960-1968](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1960-L1968 "Source code on GitHub")
 
 Get product configuration schema
 
@@ -1843,7 +1850,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductDeviceConfiguration
 
-[src/Particle.js:1996-2003](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L1996-L2003 "Source code on GitHub")
+[src/Particle.js:1980-1987](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1980-L1987 "Source code on GitHub")
 
 Get product device's configuration
 
@@ -1860,7 +1867,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductDeviceConfigurationSchema
 
-[src/Particle.js:2015-2023](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2015-L2023 "Source code on GitHub")
+[src/Particle.js:1999-2007](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L1999-L2007 "Source code on GitHub")
 
 Get product device's configuration schema
 
@@ -1877,7 +1884,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### setProductConfiguration
 
-[src/Particle.js:2035-2043](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2035-L2043 "Source code on GitHub")
+[src/Particle.js:2019-2027](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2019-L2027 "Source code on GitHub")
 
 Set product configuration
 
@@ -1894,7 +1901,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### setProductDeviceConfiguration
 
-[src/Particle.js:2056-2064](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2056-L2064 "Source code on GitHub")
+[src/Particle.js:2040-2048](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2040-L2048 "Source code on GitHub")
 
 Set product configuration for a specific device within the product
 
@@ -1912,7 +1919,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductLocations
 
-[src/Particle.js:2083-2100](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2083-L2100 "Source code on GitHub")
+[src/Particle.js:2067-2084](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2067-L2084 "Source code on GitHub")
 
 Query location for devices within a product
 
@@ -1936,7 +1943,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getProductDeviceLocations
 
-[src/Particle.js:2117-2129](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2117-L2129 "Source code on GitHub")
+[src/Particle.js:2101-2113](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2101-L2113 "Source code on GitHub")
 
 Query location for one device within a product
 
@@ -1956,7 +1963,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### executeLogic
 
-[src/Particle.js:2145-2153](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2145-L2153 "Source code on GitHub")
+[src/Particle.js:2129-2137](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2129-L2137 "Source code on GitHub")
 
 Executes the provided logic function once and returns the result. No logs, runs, etc are saved
 
@@ -1975,7 +1982,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createLogicFunction
 
-[src/Particle.js:2173-2181](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2173-L2181 "Source code on GitHub")
+[src/Particle.js:2157-2165](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2157-L2165 "Source code on GitHub")
 
 Creates a new logic function in the specified organization or sandbox using the provided function data.
 
@@ -1998,7 +2005,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLogicFunction
 
-[src/Particle.js:2195-2202](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2195-L2202 "Source code on GitHub")
+[src/Particle.js:2179-2186](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2179-L2186 "Source code on GitHub")
 
 Get a logic function in the specified organization or sandbox by logic function ID.
 
@@ -2015,7 +2022,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateLogicFunction
 
-[src/Particle.js:2219-2227](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2219-L2227 "Source code on GitHub")
+[src/Particle.js:2203-2211](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2203-L2211 "Source code on GitHub")
 
 Updates an existing logic function in the specified organization or sandbox using the provided function data.
 
@@ -2035,7 +2042,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteLogicFunction
 
-[src/Particle.js:2241-2248](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2241-L2248 "Source code on GitHub")
+[src/Particle.js:2225-2232](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2225-L2232 "Source code on GitHub")
 
 Deletes a logic function in the specified organization or sandbox by logic function ID.
 
@@ -2052,7 +2059,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listLogicFunctions
 
-[src/Particle.js:2262-2272](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2262-L2272 "Source code on GitHub")
+[src/Particle.js:2246-2256](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2246-L2256 "Source code on GitHub")
 
 Lists all logic functions in the specified organization or sandbox.
 
@@ -2069,7 +2076,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listLogicRuns
 
-[src/Particle.js:2286-2293](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2286-L2293 "Source code on GitHub")
+[src/Particle.js:2270-2277](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2270-L2277 "Source code on GitHub")
 
 Lists all logic runs for the specified logic function in the specified organization or sandbox.
 
@@ -2086,7 +2093,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLogicRun
 
-[src/Particle.js:2308-2315](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2308-L2315 "Source code on GitHub")
+[src/Particle.js:2292-2299](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2292-L2299 "Source code on GitHub")
 
 Retrieves a logic run by its ID for the specified logic function in the specified organization or sandbox.
 
@@ -2104,7 +2111,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLogicRunLogs
 
-[src/Particle.js:2330-2337](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2330-L2337 "Source code on GitHub")
+[src/Particle.js:2314-2321](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2314-L2321 "Source code on GitHub")
 
 Retrieves the logs for a logic run by its ID for the specified logic function in the specified organization or sandbox.
 
@@ -2122,7 +2129,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### createLedger
 
-[src/Particle.js:2351-2359](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2351-L2359 "Source code on GitHub")
+[src/Particle.js:2335-2343](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2335-L2343 "Source code on GitHub")
 
 Creates a new ledger definition in the specified organization or sandbox.
 
@@ -2139,7 +2146,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLedger
 
-[src/Particle.js:2373-2380](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2373-L2380 "Source code on GitHub")
+[src/Particle.js:2357-2364](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2357-L2364 "Source code on GitHub")
 
 Get a ledger definition in the specified organization or sandbox by ledger name.
 
@@ -2156,7 +2163,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### updateLedger
 
-[src/Particle.js:2395-2403](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2395-L2403 "Source code on GitHub")
+[src/Particle.js:2379-2387](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2379-L2387 "Source code on GitHub")
 
 Updates an existing ledger definition in the specified organization or sandbox.
 
@@ -2174,7 +2181,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### archiveLedger
 
-[src/Particle.js:2417-2424](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2417-L2424 "Source code on GitHub")
+[src/Particle.js:2401-2408](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2401-L2408 "Source code on GitHub")
 
 Archives a ledger definition in the specified organization or sandbox by ledger name.
 
@@ -2191,7 +2198,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### Scope
 
-[src/Particle.js:2445-2458](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2445-L2458 "Source code on GitHub")
+[src/Particle.js:2429-2442](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2429-L2442 "Source code on GitHub")
 
 Type: (`"Owner"` \| `"Product"` \| `"Device"`)
 
@@ -2209,7 +2216,7 @@ Type: (`"Owner"` \| `"Product"` \| `"Device"`)
 
 ### listLedgers
 
-[src/Particle.js:2445-2458](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2445-L2458 "Source code on GitHub")
+[src/Particle.js:2429-2442](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2429-L2442 "Source code on GitHub")
 
 Lists all ledger definitions in the specified organization or sandbox.
 
@@ -2229,7 +2236,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLedgerInstance
 
-[src/Particle.js:2473-2480](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2473-L2480 "Source code on GitHub")
+[src/Particle.js:2457-2464](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2457-L2464 "Source code on GitHub")
 
 Get ledger instance data.
 
@@ -2247,7 +2254,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### SetMode
 
-[src/Particle.js:2501-2512](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2501-L2512 "Source code on GitHub")
+[src/Particle.js:2485-2496](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2485-L2496 "Source code on GitHub")
 
 Type: (`"Replace"` \| `"Merge"`)
 
@@ -2265,7 +2272,7 @@ Type: (`"Replace"` \| `"Merge"`)
 
 ### setLedgerInstance
 
-[src/Particle.js:2501-2512](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2501-L2512 "Source code on GitHub")
+[src/Particle.js:2485-2496](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2485-L2496 "Source code on GitHub")
 
 Set ledger instance data.
 
@@ -2285,7 +2292,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### deleteLedgerInstance
 
-[src/Particle.js:2527-2534](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2527-L2534 "Source code on GitHub")
+[src/Particle.js:2511-2518](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2511-L2518 "Source code on GitHub")
 
 Delete a ledger instance in the specified organization or sandbox by ledger name.
 
@@ -2303,7 +2310,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listLedgerInstances
 
-[src/Particle.js:2550-2561](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2550-L2561 "Source code on GitHub")
+[src/Particle.js:2534-2545](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2534-L2545 "Source code on GitHub")
 
 Lists ledger instances in the specified organization or sandbox.
 
@@ -2322,7 +2329,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### listLedgerInstanceVersions
 
-[src/Particle.js:2578-2589](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2578-L2589 "Source code on GitHub")
+[src/Particle.js:2562-2573](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2562-L2573 "Source code on GitHub")
 
 List ledger instance versions
 
@@ -2342,7 +2349,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### getLedgerInstanceVersion
 
-[src/Particle.js:2605-2612](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2605-L2612 "Source code on GitHub")
+[src/Particle.js:2589-2596](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2589-L2596 "Source code on GitHub")
 
 Get specific ledger instance version
 
@@ -2361,7 +2368,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### setDefaultAuth
 
-[src/Particle.js:2619-2627](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2619-L2627 "Source code on GitHub")
+[src/Particle.js:2603-2611](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2603-L2611 "Source code on GitHub")
 
 Set default auth token that will be used in each method if `auth` is not provided
 
@@ -2374,7 +2381,7 @@ Set default auth token that will be used in each method if `auth` is not provide
 
 ### get
 
-[src/Particle.js:2670-2674](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2670-L2674 "Source code on GitHub")
+[src/Particle.js:2654-2658](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2654-L2658 "Source code on GitHub")
 
 Make a GET request
 
@@ -2391,7 +2398,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### head
 
-[src/Particle.js:2686-2690](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2686-L2690 "Source code on GitHub")
+[src/Particle.js:2670-2674](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2670-L2674 "Source code on GitHub")
 
 Make a HEAD request
 
@@ -2408,7 +2415,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### post
 
-[src/Particle.js:2702-2706](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2702-L2706 "Source code on GitHub")
+[src/Particle.js:2686-2690](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2686-L2690 "Source code on GitHub")
 
 Make a POST request
 
@@ -2425,7 +2432,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### put
 
-[src/Particle.js:2719-2723](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2719-L2723 "Source code on GitHub")
+[src/Particle.js:2703-2707](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2703-L2707 "Source code on GitHub")
 
 Make a PUT request
 
@@ -2443,7 +2450,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### delete
 
-[src/Particle.js:2735-2739](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2735-L2739 "Source code on GitHub")
+[src/Particle.js:2719-2723](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2719-L2723 "Source code on GitHub")
 
 Make a DELETE request
 
@@ -2460,7 +2467,7 @@ Returns **[Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Refe
 
 ### request
 
-[src/Particle.js:2756-2760](https://github.com/particle-iot/particle-api-js/blob/d27b2ac02dc8b4f5aade49d851fb6815d6029455/src/Particle.js#L2756-L2760 "Source code on GitHub")
+[src/Particle.js:2740-2744](https://github.com/particle-iot/particle-api-js/blob/ca296d787dd3dd1f500e3173392078deb4182fc6/src/Particle.js#L2740-L2744 "Source code on GitHub")
 
 **Parameters**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.3.0",
             "license": "CC-BY-SA-3.0",
             "dependencies": {
-                "apidoc": "^0.17.5",
+                "apidoc": "^1.2.0",
                 "autoprefixer": "^7.1.5",
                 "binary-version-reader": "^2.0.1",
                 "del": "^3.0.0",
@@ -70,6 +70,414 @@
                 "npm": "8.15.0"
             }
         },
+        "node_modules/@colors/colors": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+            "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+            "engines": {
+                "node": ">=0.1.90"
+            }
+        },
+        "node_modules/@dabh/diagnostics": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+            "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+            "dependencies": {
+                "colorspace": "1.1.x",
+                "enabled": "2.0.x",
+                "kuler": "^2.0.0"
+            }
+        },
+        "node_modules/@discoveryjs/json-ext": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+            "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+            "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+            "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+            "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+            "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+            "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+            "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+            "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+            "cpu": [
+                "arm"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+            "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+            "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+            "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+            "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+            "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+            "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+            "cpu": [
+                "riscv64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+            "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+            "cpu": [
+                "s390x"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+            "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+            "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+            "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+            "cpu": [
+                "arm64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+            "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+            "cpu": [
+                "ia32"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+            "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+            "cpu": [
+                "x64"
+            ],
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@jridgewell/gen-mapping": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "dependencies": {
+                "@jridgewell/set-array": "^1.2.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            },
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/set-array": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+            "engines": {
+                "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
+            }
+        },
+        "node_modules/@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+        },
+        "node_modules/@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "dependencies": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "node_modules/@particle/device-constants": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
@@ -80,15 +488,230 @@
                 "npm": "8.x"
             }
         },
+        "node_modules/@types/eslint": {
+            "version": "8.56.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+            "dependencies": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "node_modules/@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "dependencies": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
+        "node_modules/@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+        },
+        "node_modules/@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+        },
         "node_modules/@types/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
         },
+        "node_modules/@types/node": {
+            "version": "20.12.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+            "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+            "dependencies": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "node_modules/@types/triple-beam": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+            "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+        },
         "node_modules/@ungap/promise-all-settled": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+        },
+        "node_modules/@webassemblyjs/ast": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+            "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+            "dependencies": {
+                "@webassemblyjs/helper-numbers": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+            }
+        },
+        "node_modules/@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+        },
+        "node_modules/@webassemblyjs/helper-api-error": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+        },
+        "node_modules/@webassemblyjs/helper-buffer": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+            "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+        },
+        "node_modules/@webassemblyjs/helper-numbers": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+            "dependencies": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+        },
+        "node_modules/@webassemblyjs/helper-wasm-section": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+            "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.12.1"
+            }
+        },
+        "node_modules/@webassemblyjs/ieee754": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+            "dependencies": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "node_modules/@webassemblyjs/leb128": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+            "dependencies": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webassemblyjs/utf8": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+        },
+        "node_modules/@webassemblyjs/wasm-edit": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+            "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/helper-wasm-section": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-opt": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1",
+                "@webassemblyjs/wast-printer": "1.12.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-gen": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+            "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-opt": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+            "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1"
+            }
+        },
+        "node_modules/@webassemblyjs/wasm-parser": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+            "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
+            }
+        },
+        "node_modules/@webassemblyjs/wast-printer": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+            "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+            "dependencies": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "node_modules/@webpack-cli/configtest": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+            "peerDependencies": {
+                "webpack": "4.x.x || 5.x.x",
+                "webpack-cli": "4.x.x"
+            }
+        },
+        "node_modules/@webpack-cli/info": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+            "dependencies": {
+                "envinfo": "^7.7.3"
+            },
+            "peerDependencies": {
+                "webpack-cli": "4.x.x"
+            }
+        },
+        "node_modules/@webpack-cli/serve": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+            "peerDependencies": {
+                "webpack-cli": "4.x.x"
+            },
+            "peerDependenciesMeta": {
+                "webpack-dev-server": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+        },
+        "node_modules/@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "node_modules/abbrev": {
             "version": "1.1.1",
@@ -297,48 +920,103 @@
             }
         },
         "node_modules/apidoc": {
-            "version": "0.17.5",
-            "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.17.5.tgz",
-            "integrity": "sha1-kc5yZLSMcX5MwYr7pkIne8aKIyU=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-1.2.0.tgz",
+            "integrity": "sha512-Qagoj7QnqNHbDUDNpU21eLP4hJSAXn6knHtEjRYWTlSEmpYDGSQijejyFXaWGByhfryW8B1gL+6B57UB/F1lxw==",
+            "os": [
+                "darwin",
+                "freebsd",
+                "linux",
+                "openbsd",
+                "win32"
+            ],
             "dependencies": {
-                "apidoc-core": "~0.8.1",
-                "fs-extra": "~2.0.0",
-                "lodash": "~4.17.4",
-                "markdown-it": "^8.2.2",
-                "nomnom": "~1.8.1",
-                "winston": "~2.3.1"
+                "bootstrap": "3.4.1",
+                "commander": "^10.0.0",
+                "diff-match-patch": "^1.0.5",
+                "esbuild-loader": "^2.16.0",
+                "expose-loader": "^4.0.0",
+                "fs-extra": "^11.0.0",
+                "glob": "^7.2.0",
+                "handlebars": "^4.7.7",
+                "iconv-lite": "^0.6.3",
+                "jquery": "^3.6.0",
+                "klaw-sync": "^6.0.0",
+                "lodash": "^4.17.21",
+                "markdown-it": "^12.2.0",
+                "nodemon": "^3.0.1",
+                "prismjs": "^1.25.0",
+                "semver": "^7.5.0",
+                "style-loader": "^3.3.1",
+                "webpack": "^5.64.2",
+                "webpack-cli": "^4.9.1",
+                "winston": "^3.3.3"
             },
             "bin": {
                 "apidoc": "bin/apidoc"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">=16.0.0"
             }
         },
-        "node_modules/apidoc-core": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/apidoc-core/-/apidoc-core-0.8.3.tgz",
-            "integrity": "sha1-2dY1RYKd8lDSzKBJaDqH53U2S5Y=",
+        "node_modules/apidoc/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/apidoc/node_modules/glob": {
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
             "dependencies": {
-                "fs-extra": "^3.0.1",
-                "glob": "^7.1.1",
-                "iconv-lite": "^0.4.17",
-                "klaw-sync": "^2.1.0",
-                "lodash": "~4.17.4",
-                "semver": "~5.3.0"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.1.1",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": "*"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/apidoc-core/node_modules/fs-extra": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-            "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+        "node_modules/apidoc/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
             "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^3.0.0",
-                "universalify": "^0.1.0"
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/apidoc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/apidoc/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/append-buffer": {
@@ -749,6 +1427,14 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "node_modules/big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -845,6 +1531,14 @@
                 "node": ">=0.10.40"
             }
         },
+        "node_modules/bootstrap": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+            "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -919,6 +1613,11 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+        },
         "node_modules/bytes": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -977,9 +1676,23 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30000814",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000814.tgz",
-            "integrity": "sha512-Kt4dBhVlnTZ+jj+C8Bd4WT6RT4EJoX5/tlktHQfpqIMgLVrG1KBQlLf010ipMvuNrpQiAJ2A54e6MMbA0BaKxg=="
+            "version": "1.0.30001618",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001618.tgz",
+            "integrity": "sha512-p407+D1tIkDvsEAPS22lJxLQQaG8OTBEqo0KhzfABGk0TU4juBNDSfH0hyAp/HRyx+M8L17z/ltyhxh27FTfQg==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ]
         },
         "node_modules/caseless": {
             "version": "0.12.0",
@@ -1101,6 +1814,14 @@
             },
             "optionalDependencies": {
                 "fsevents": "^1.2.7"
+            }
+        },
+        "node_modules/chrome-trace-event": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+            "engines": {
+                "node": ">=6.0"
             }
         },
         "node_modules/circular-json": {
@@ -1277,6 +1998,19 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "dependencies": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/cloneable-readable": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
@@ -1408,18 +2142,36 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+        "node_modules/color": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
             "dependencies": {
-                "color-name": "^1.1.1"
+                "color-convert": "^1.9.3",
+                "color-string": "^1.6.0"
+            }
+        },
+        "node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "dependencies": {
+                "color-name": "1.1.3"
             }
         },
         "node_modules/color-name": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        },
+        "node_modules/color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "dependencies": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
         },
         "node_modules/color-support": {
             "version": "1.1.3",
@@ -1429,12 +2181,26 @@
                 "color-support": "bin.js"
             }
         },
+        "node_modules/colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+        },
         "node_modules/colors": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
             "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
             "engines": {
                 "node": ">=0.1.90"
+            }
+        },
+        "node_modules/colorspace": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+            "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+            "dependencies": {
+                "color": "^3.1.3",
+                "text-hex": "1.0.x"
             }
         },
         "node_modules/combined-stream": {
@@ -1658,14 +2424,6 @@
                 "node": "*"
             }
         },
-        "node_modules/cycle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/d": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -1869,6 +2627,11 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+        },
         "node_modules/doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -1980,14 +2743,22 @@
             "integrity": "sha1-jJshKJjYzZ8alDZlDOe+ICyen/A="
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.37",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.37.tgz",
-            "integrity": "sha1-SpJzTgBEyM8LFVO+V+riGkxuX6s="
+            "version": "1.4.769",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.769.tgz",
+            "integrity": "sha512-bZu7p623NEA2rHTc9K1vykl57ektSPQYFFqQir8BOYf6EKOB+yIsbFB9Kpm7Cgt6tsLr9sRkqfqSZUw7LP1XxQ=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "node_modules/emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/enable": {
             "version": "1.3.2",
@@ -1997,6 +2768,11 @@
                 "node": ">= 0.10.0"
             }
         },
+        "node_modules/enabled": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+        },
         "node_modules/end-of-stream": {
             "version": "1.4.4",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -2005,10 +2781,33 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/enhanced-resolve": {
+            "version": "5.16.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
+            "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/entities": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
             "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+        },
+        "node_modules/envinfo": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
+            "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
+            "bin": {
+                "envinfo": "dist/cli.js"
+            },
+            "engines": {
+                "node": ">=4"
+            }
         },
         "node_modules/errno": {
             "version": "0.1.7",
@@ -2029,6 +2828,11 @@
             "dependencies": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.2.tgz",
+            "integrity": "sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA=="
         },
         "node_modules/es5-ext": {
             "version": "0.10.53",
@@ -2070,10 +2874,65 @@
                 "es6-symbol": "^3.1.1"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+            "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/android-arm": "0.16.17",
+                "@esbuild/android-arm64": "0.16.17",
+                "@esbuild/android-x64": "0.16.17",
+                "@esbuild/darwin-arm64": "0.16.17",
+                "@esbuild/darwin-x64": "0.16.17",
+                "@esbuild/freebsd-arm64": "0.16.17",
+                "@esbuild/freebsd-x64": "0.16.17",
+                "@esbuild/linux-arm": "0.16.17",
+                "@esbuild/linux-arm64": "0.16.17",
+                "@esbuild/linux-ia32": "0.16.17",
+                "@esbuild/linux-loong64": "0.16.17",
+                "@esbuild/linux-mips64el": "0.16.17",
+                "@esbuild/linux-ppc64": "0.16.17",
+                "@esbuild/linux-riscv64": "0.16.17",
+                "@esbuild/linux-s390x": "0.16.17",
+                "@esbuild/linux-x64": "0.16.17",
+                "@esbuild/netbsd-x64": "0.16.17",
+                "@esbuild/openbsd-x64": "0.16.17",
+                "@esbuild/sunos-x64": "0.16.17",
+                "@esbuild/win32-arm64": "0.16.17",
+                "@esbuild/win32-ia32": "0.16.17",
+                "@esbuild/win32-x64": "0.16.17"
+            }
+        },
+        "node_modules/esbuild-loader": {
+            "version": "2.21.0",
+            "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-2.21.0.tgz",
+            "integrity": "sha512-k7ijTkCT43YBSZ6+fBCW1Gin7s46RrJ0VQaM8qA7lq7W+OLsGgtLyFV8470FzYi/4TeDexniTBTPTwZUnXXR5g==",
+            "dependencies": {
+                "esbuild": "^0.16.17",
+                "joycon": "^3.0.1",
+                "json5": "^2.2.0",
+                "loader-utils": "^2.0.0",
+                "tapable": "^2.2.0",
+                "webpack-sources": "^1.4.3"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/esbuild-loader?sponsor=1"
+            },
+            "peerDependencies": {
+                "webpack": "^4.40.0 || ^5.0.0"
+            }
+        },
         "node_modules/escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
             "engines": {
                 "node": ">=6"
             }
@@ -2259,13 +3118,20 @@
             }
         },
         "node_modules/esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-            "dev": true,
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dependencies": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
             },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/esrecurse/node_modules/estraverse": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "engines": {
                 "node": ">=4.0"
             }
@@ -2274,7 +3140,6 @@
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
             "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -2300,6 +3165,14 @@
                 "split": "0.3",
                 "stream-combiner": "~0.0.4",
                 "through": "~2.3.1"
+            }
+        },
+        "node_modules/events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+            "engines": {
+                "node": ">=0.8.x"
             }
         },
         "node_modules/exit-hook": {
@@ -2359,6 +3232,21 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/expose-loader": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-4.1.0.tgz",
+            "integrity": "sha512-oLAesnzerwDGGADzBMnu0LPqqnlVz6e2V9lTa+/4X6VeW9W93x/nJpw05WBrcIdbqXm/EdnEQpiVDFFiQXuNfg==",
+            "engines": {
+                "node": ">= 14.15.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
             }
         },
         "node_modules/ext": {
@@ -2500,14 +3388,6 @@
             ],
             "optional": true
         },
-        "node_modules/eyes": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-            "engines": {
-                "node": "> 0.1.90"
-            }
-        },
         "node_modules/fancy-log": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
@@ -2530,14 +3410,21 @@
         "node_modules/fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "node_modules/fastest-levenshtein": {
+            "version": "1.0.16",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
+            "engines": {
+                "node": ">= 4.9.1"
+            }
         },
         "node_modules/faye-websocket": {
             "version": "0.7.3",
@@ -2549,6 +3436,11 @@
             "engines": {
                 "node": ">=0.4.0"
             }
+        },
+        "node_modules/fecha": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
         },
         "node_modules/figures": {
             "version": "2.0.0",
@@ -2604,6 +3496,18 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "dependencies": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/findup-sync": {
@@ -2741,6 +3645,11 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/fn.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+        },
         "node_modules/for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -2810,20 +3719,16 @@
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
         },
         "node_modules/fs-extra": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-            "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "dependencies": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0"
-            }
-        },
-        "node_modules/fs-extra/node_modules/jsonfile": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-            "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-            "optionalDependencies": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=14.14"
             }
         },
         "node_modules/fs-mkdirp-stream": {
@@ -2867,9 +3772,12 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/functional-red-black-tree": {
             "version": "1.0.1",
@@ -3005,6 +3913,11 @@
                 "safe-buffer": "~5.1.0"
             }
         },
+        "node_modules/glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+        },
         "node_modules/glob-watcher": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
@@ -3094,12 +4007,9 @@
             }
         },
         "node_modules/graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-            "engines": {
-                "node": ">=0.4.0"
-            }
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "node_modules/gray-matter": {
             "version": "2.1.1",
@@ -3725,6 +4635,17 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/hawk": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -3850,6 +4771,7 @@
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
             "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -3859,6 +4781,11 @@
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
             "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
             "dev": true
+        },
+        "node_modules/ignore-by-default": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+            "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
         },
         "node_modules/image-size": {
             "version": "0.5.5",
@@ -3876,6 +4803,24 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
             "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "node_modules/import-local": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+            "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+            "dependencies": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            },
+            "bin": {
+                "import-local-fixture": "fixtures/cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/imurmurhash": {
             "version": "0.1.4",
@@ -4051,11 +4996,11 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "node_modules/is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4249,6 +5194,17 @@
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
             "dev": true
         },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -4321,7 +5277,8 @@
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "optional": true
         },
         "node_modules/istextorbinary": {
             "version": "1.0.2",
@@ -4333,6 +5290,41 @@
             },
             "engines": {
                 "node": ">=0.4"
+            }
+        },
+        "node_modules/jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "dependencies": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            }
+        },
+        "node_modules/jest-worker/node_modules/has-flag": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/jest-worker/node_modules/supports-color": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
         "node_modules/joi": {
@@ -4350,6 +5342,19 @@
                 "node": ">=0.10.40",
                 "npm": ">=2.0.0"
             }
+        },
+        "node_modules/joycon": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
         },
         "node_modules/js-prettify": {
             "version": "1.4.0",
@@ -4396,6 +5401,11 @@
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "optional": true
         },
+        "node_modules/json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
         "node_modules/json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -4431,10 +5441,24 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "optional": true
         },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/jsonfile": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-            "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+            "dependencies": {
+                "universalify": "^2.0.0"
+            },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -4527,12 +5551,17 @@
             }
         },
         "node_modules/klaw-sync": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-2.1.0.tgz",
-            "integrity": "sha1-PTvNhgDnv971MjHHOf8FOu1WDkQ=",
-            "optionalDependencies": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+            "dependencies": {
                 "graceful-fs": "^4.1.11"
             }
+        },
+        "node_modules/kuler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
         },
         "node_modules/last-run": {
             "version": "1.1.1",
@@ -4668,9 +5697,9 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
             "dependencies": {
                 "uc.micro": "^1.0.1"
             }
@@ -4701,6 +5730,38 @@
             "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/loader-runner": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+            "engines": {
+                "node": ">=6.11.5"
+            }
+        },
+        "node_modules/loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
+        "node_modules/locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "dependencies": {
+                "p-locate": "^4.1.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/lodash": {
@@ -5028,6 +6089,27 @@
                 "node": ">=8"
             }
         },
+        "node_modules/logform": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+            "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+            "dependencies": {
+                "@colors/colors": "1.6.0",
+                "@types/triple-beam": "^1.3.2",
+                "fecha": "^4.2.0",
+                "ms": "^2.1.1",
+                "safe-stable-stringify": "^2.3.1",
+                "triple-beam": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/logform/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        },
         "node_modules/lolex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -5083,18 +6165,31 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-            "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "entities": "~1.1.1",
-                "linkify-it": "^2.0.0",
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
             },
             "bin": {
                 "markdown-it": "bin/markdown-it.js"
+            }
+        },
+        "node_modules/markdown-it/node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+        },
+        "node_modules/markdown-it/node_modules/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==",
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/markdown-spellcheck": {
@@ -5376,7 +6471,7 @@
         "node_modules/mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
@@ -5385,6 +6480,11 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "node_modules/metalsmith": {
             "version": "2.3.0",
@@ -5833,21 +6933,19 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.33.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-            "optional": true,
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.18",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-            "optional": true,
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dependencies": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.52.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -6241,14 +7339,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/mocha/node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/mocha/node_modules/readdirp": {
             "version": "3.5.0",
             "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -6466,6 +7556,11 @@
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
+        "node_modules/node-releases": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+        },
         "node_modules/node-static": {
             "version": "0.7.10",
             "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.10.tgz",
@@ -6482,27 +7577,207 @@
                 "node": ">= 0.4.1"
             }
         },
-        "node_modules/nomnom": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-            "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
-            "deprecated": "Package no longer supported. Contact support@npmjs.com for more info.",
+        "node_modules/nodemon": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
+            "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
             "dependencies": {
-                "chalk": "~0.4.0",
-                "underscore": "~1.6.0"
-            }
-        },
-        "node_modules/nomnom/node_modules/chalk": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-            "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
-            "dependencies": {
-                "ansi-styles": "~1.0.0",
-                "has-color": "~0.1.0",
-                "strip-ansi": "~0.1.0"
+                "chokidar": "^3.5.2",
+                "debug": "^4",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.1.2",
+                "pstree.remy": "^1.1.8",
+                "semver": "^7.5.3",
+                "simple-update-notifier": "^2.0.0",
+                "supports-color": "^5.5.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.5"
+            },
+            "bin": {
+                "nodemon": "bin/nodemon.js"
             },
             "engines": {
-                "node": ">=0.8.0"
+                "node": ">=10"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/nodemon"
+            }
+        },
+        "node_modules/nodemon/node_modules/anymatch": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dependencies": {
+                "normalize-path": "^3.0.0",
+                "picomatch": "^2.0.4"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/nodemon/node_modules/binary-extensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/nodemon/node_modules/braces": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "dependencies": {
+                "fill-range": "^7.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nodemon/node_modules/chokidar": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+            "dependencies": {
+                "anymatch": "~3.1.2",
+                "braces": "~3.0.2",
+                "glob-parent": "~5.1.2",
+                "is-binary-path": "~2.1.0",
+                "is-glob": "~4.0.1",
+                "normalize-path": "~3.0.0",
+                "readdirp": "~3.6.0"
+            },
+            "engines": {
+                "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/nodemon/node_modules/debug": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "dependencies": {
+                "ms": "2.1.2"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/nodemon/node_modules/fill-range": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "dependencies": {
+                "to-regex-range": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nodemon/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "hasInstallScript": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/nodemon/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/nodemon/node_modules/is-binary-path": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+            "dependencies": {
+                "binary-extensions": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nodemon/node_modules/is-number": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+            "engines": {
+                "node": ">=0.12.0"
+            }
+        },
+        "node_modules/nodemon/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/nodemon/node_modules/ms": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "node_modules/nodemon/node_modules/readdirp": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+            "dependencies": {
+                "picomatch": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=8.10.0"
+            }
+        },
+        "node_modules/nodemon/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/nodemon/node_modules/to-regex-range": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+            "dependencies": {
+                "is-number": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/nopt": {
@@ -6525,18 +7800,6 @@
                 "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
-            }
-        },
-        "node_modules/normalize-package-data/node_modules/resolve": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-            "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-            "dependencies": {
-                "is-core-module": "^2.2.0",
-                "path-parse": "^1.0.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/normalize-path": {
@@ -6765,6 +8028,14 @@
                 "wrappy": "1"
             }
         },
+        "node_modules/one-time": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+            "dependencies": {
+                "fn.name": "1.x.x"
+            }
+        },
         "node_modules/onetime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -6870,12 +8141,45 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "dependencies": {
+                "p-try": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "dependencies": {
+                "p-limit": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/p-map": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/pako": {
@@ -6936,6 +8240,14 @@
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
+        "node_modules/path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6948,6 +8260,14 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+        },
+        "node_modules/path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
@@ -7008,6 +8328,11 @@
             "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
             "optional": true
         },
+        "node_modules/picocolors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+        },
         "node_modules/picomatch": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
@@ -7044,6 +8369,17 @@
             },
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "dependencies": {
+                "find-up": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/plugin-error": {
@@ -7240,6 +8576,14 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/prismjs": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+            "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -7279,6 +8623,11 @@
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
+        },
+        "node_modules/pstree.remy": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
         },
         "node_modules/pump": {
             "version": "2.0.1",
@@ -7640,11 +8989,38 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dependencies": {
-                "path-parse": "^1.0.5"
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            },
+            "bin": {
+                "resolve": "bin/resolve"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/resolve-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+            "dependencies": {
+                "resolve-from": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/resolve-cwd/node_modules/resolve-from": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/resolve-dir": {
@@ -7774,12 +9150,75 @@
                 "ret": "~0.1.10"
             }
         },
+        "node_modules/safe-stable-stringify": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
         "node_modules/samsam": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
             "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
             "deprecated": "This package has been deprecated in favour of @sinonjs/samsam",
             "dev": true
+        },
+        "node_modules/schema-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+            "dependencies": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            }
+        },
+        "node_modules/schema-utils/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/schema-utils/node_modules/ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+            "peerDependencies": {
+                "ajv": "^6.9.1"
+            }
+        },
+        "node_modules/schema-utils/node_modules/fast-deep-equal": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+        },
+        "node_modules/schema-utils/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
         },
         "node_modules/semver": {
             "version": "5.3.0",
@@ -7843,6 +9282,17 @@
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
+        "node_modules/shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "dependencies": {
+                "kind-of": "^6.0.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -7869,6 +9319,41 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
+        },
+        "node_modules/simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+            "dependencies": {
+                "is-arrayish": "^0.3.1"
+            }
+        },
+        "node_modules/simple-swizzle/node_modules/is-arrayish": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+            "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+        },
+        "node_modules/simple-update-notifier": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/simple-update-notifier/node_modules/semver": {
+            "version": "7.6.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+            "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/simplecrawler": {
             "version": "0.6.3",
@@ -8074,6 +9559,11 @@
                 "node": ">=0.8.0"
             }
         },
+        "node_modules/source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -8093,6 +9583,15 @@
                 "resolve-url": "^0.2.1",
                 "source-map-url": "^0.4.0",
                 "urix": "^0.1.0"
+            }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "node_modules/source-map-url": {
@@ -8359,20 +9858,46 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/style-loader": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
+            "integrity": "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==",
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
         "node_modules/substitute": {
             "version": "0.0.1",
             "resolved": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz",
             "integrity": "sha1-QyhmmFsDw7DT9xrGPRrhoY369H0="
         },
         "node_modules/supports-color": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-            "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "dependencies": {
                 "has-flag": "^3.0.0"
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/sver-compat": {
@@ -8423,6 +9948,93 @@
             "engines": {
                 "node": ">=4"
             }
+        },
+        "node_modules/tapable": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/terser": {
+            "version": "5.31.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
+            "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser-webpack-plugin": {
+            "version": "5.3.10",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+            "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.20",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.1",
+                "terser": "^5.26.0"
+            },
+            "engines": {
+                "node": ">= 10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.1.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/core": {
+                    "optional": true
+                },
+                "esbuild": {
+                    "optional": true
+                },
+                "uglify-js": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/terser-webpack-plugin/node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
+        "node_modules/terser/node_modules/acorn": {
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "node_modules/text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -8632,6 +10244,14 @@
                 "node": ">=0.10.40"
             }
         },
+        "node_modules/touch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+            "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+            "bin": {
+                "nodetouch": "bin/nodetouch.js"
+            }
+        },
         "node_modules/tough-cookie": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -8642,6 +10262,14 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/triple-beam": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+            "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+            "engines": {
+                "node": ">= 14.0.0"
             }
         },
         "node_modules/tslib": {
@@ -8794,10 +10422,10 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/underscore": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-            "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+        "node_modules/undefsafe": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+            "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
         },
         "node_modules/undertaker": {
             "version": "1.3.0",
@@ -8832,6 +10460,11 @@
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.4.tgz",
             "integrity": "sha1-5qdUzI8V5YmHqpy9J69m/W9OWvk="
         },
+        "node_modules/undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
         "node_modules/union-value": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -8862,11 +10495,11 @@
             }
         },
         "node_modules/universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "engines": {
-                "node": ">= 4.0.0"
+                "node": ">= 10.0.0"
             }
         },
         "node_modules/unset-value": {
@@ -8933,6 +10566,22 @@
             "engines": {
                 "node": ">=4",
                 "yarn": "*"
+            }
+        },
+        "node_modules/uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/uri-js/node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/urijs": {
@@ -9200,6 +10849,304 @@
                 "wrap-fn": "^0.1.0"
             }
         },
+        "node_modules/watchpack": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
+            "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+            "dependencies": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
+        "node_modules/webpack": {
+            "version": "5.91.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
+            "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+            "dependencies": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^1.0.5",
+                "@webassemblyjs/ast": "^1.12.1",
+                "@webassemblyjs/wasm-edit": "^1.12.1",
+                "@webassemblyjs/wasm-parser": "^1.12.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.9.0",
+                "browserslist": "^4.21.10",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.16.0",
+                "es-module-lexer": "^1.2.1",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.11",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.2.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.3.10",
+                "watchpack": "^2.4.1",
+                "webpack-sources": "^3.2.3"
+            },
+            "bin": {
+                "webpack": "bin/webpack.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependenciesMeta": {
+                "webpack-cli": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-cli": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+            "dependencies": {
+                "@discoveryjs/json-ext": "^0.5.0",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
+                "colorette": "^2.0.14",
+                "commander": "^7.0.0",
+                "cross-spawn": "^7.0.3",
+                "fastest-levenshtein": "^1.0.12",
+                "import-local": "^3.0.2",
+                "interpret": "^2.2.0",
+                "rechoir": "^0.7.0",
+                "webpack-merge": "^5.7.3"
+            },
+            "bin": {
+                "webpack-cli": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "4.x.x || 5.x.x"
+            },
+            "peerDependenciesMeta": {
+                "@webpack-cli/generators": {
+                    "optional": true
+                },
+                "@webpack-cli/migrate": {
+                    "optional": true
+                },
+                "webpack-bundle-analyzer": {
+                    "optional": true
+                },
+                "webpack-dev-server": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/webpack-cli/node_modules/commander": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+            "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+            "engines": {
+                "node": ">= 10"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/cross-spawn": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "dependencies": {
+                "path-key": "^3.1.0",
+                "shebang-command": "^2.0.0",
+                "which": "^2.0.1"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/interpret": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/rechoir": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+            "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+            "dependencies": {
+                "resolve": "^1.9.0"
+            },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/shebang-command": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+            "dependencies": {
+                "shebang-regex": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/shebang-regex": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/which": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+            "dependencies": {
+                "isexe": "^2.0.0"
+            },
+            "bin": {
+                "node-which": "bin/node-which"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "dependencies": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
+        "node_modules/webpack-sources": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+            "dependencies": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            }
+        },
+        "node_modules/webpack/node_modules/acorn": {
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/webpack/node_modules/acorn-import-assertions": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+            "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+            "peerDependencies": {
+                "acorn": "^8"
+            }
+        },
+        "node_modules/webpack/node_modules/browserslist": {
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "dependencies": {
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
+                "node-releases": "^2.0.14",
+                "update-browserslist-db": "^1.0.13"
+            },
+            "bin": {
+                "browserslist": "cli.js"
+            },
+            "engines": {
+                "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+            }
+        },
+        "node_modules/webpack/node_modules/eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dependencies": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/webpack/node_modules/update-browserslist-db": {
+            "version": "1.0.16",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+            "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
+                }
+            ],
+            "dependencies": {
+                "escalade": "^3.1.2",
+                "picocolors": "^1.0.1"
+            },
+            "bin": {
+                "update-browserslist-db": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
+        "node_modules/webpack/node_modules/webpack-sources": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+            "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/websocket-driver": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -9244,6 +11191,11 @@
                 "string-width": "^1.0.2 || 2"
             }
         },
+        "node_modules/wildcard": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+            "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
+        },
         "node_modules/win-fork": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/win-fork/-/win-fork-1.1.1.tgz",
@@ -9263,25 +11215,43 @@
             }
         },
         "node_modules/winston": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-            "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+            "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
             "dependencies": {
-                "async": "~1.0.0",
-                "colors": "1.0.x",
-                "cycle": "1.0.x",
-                "eyes": "0.1.x",
-                "isstream": "0.1.x",
-                "stack-trace": "0.0.x"
+                "@colors/colors": "^1.6.0",
+                "@dabh/diagnostics": "^2.0.2",
+                "async": "^3.2.3",
+                "is-stream": "^2.0.0",
+                "logform": "^2.4.0",
+                "one-time": "^1.0.0",
+                "readable-stream": "^3.4.0",
+                "safe-stable-stringify": "^2.3.1",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.7.0"
             },
             "engines": {
-                "node": ">= 0.10.0"
+                "node": ">= 12.0.0"
+            }
+        },
+        "node_modules/winston-transport": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+            "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+            "dependencies": {
+                "logform": "^2.3.2",
+                "readable-stream": "^3.6.0",
+                "triple-beam": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 12.0.0"
             }
         },
         "node_modules/winston/node_modules/async": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-            "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+            "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
         },
         "node_modules/wordwrap": {
             "version": "0.0.2",
@@ -9524,21 +11494,418 @@
         }
     },
     "dependencies": {
+        "@colors/colors": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+            "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA=="
+        },
+        "@dabh/diagnostics": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
+            "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+            "requires": {
+                "colorspace": "1.1.x",
+                "enabled": "2.0.x",
+                "kuler": "^2.0.0"
+            }
+        },
+        "@discoveryjs/json-ext": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+            "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw=="
+        },
+        "@esbuild/android-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.16.17.tgz",
+            "integrity": "sha512-N9x1CMXVhtWEAMS7pNNONyA14f71VPQN9Cnavj1XQh6T7bskqiLLrSca4O0Vr8Wdcga943eThxnVp3JLnBMYtw==",
+            "optional": true
+        },
+        "@esbuild/android-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.16.17.tgz",
+            "integrity": "sha512-MIGl6p5sc3RDTLLkYL1MyL8BMRN4tLMRCn+yRJJmEDvYZ2M7tmAf80hx1kbNEUX2KJ50RRtxZ4JHLvCfuB6kBg==",
+            "optional": true
+        },
+        "@esbuild/android-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.16.17.tgz",
+            "integrity": "sha512-a3kTv3m0Ghh4z1DaFEuEDfz3OLONKuFvI4Xqczqx4BqLyuFaFkuaG4j2MtA6fuWEFeC5x9IvqnX7drmRq/fyAQ==",
+            "optional": true
+        },
+        "@esbuild/darwin-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.16.17.tgz",
+            "integrity": "sha512-/2agbUEfmxWHi9ARTX6OQ/KgXnOWfsNlTeLcoV7HSuSTv63E4DqtAc+2XqGw1KHxKMHGZgbVCZge7HXWX9Vn+w==",
+            "optional": true
+        },
+        "@esbuild/darwin-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.16.17.tgz",
+            "integrity": "sha512-2By45OBHulkd9Svy5IOCZt376Aa2oOkiE9QWUK9fe6Tb+WDr8hXL3dpqi+DeLiMed8tVXspzsTAvd0jUl96wmg==",
+            "optional": true
+        },
+        "@esbuild/freebsd-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.16.17.tgz",
+            "integrity": "sha512-mt+cxZe1tVx489VTb4mBAOo2aKSnJ33L9fr25JXpqQqzbUIw/yzIzi+NHwAXK2qYV1lEFp4OoVeThGjUbmWmdw==",
+            "optional": true
+        },
+        "@esbuild/freebsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.16.17.tgz",
+            "integrity": "sha512-8ScTdNJl5idAKjH8zGAsN7RuWcyHG3BAvMNpKOBaqqR7EbUhhVHOqXRdL7oZvz8WNHL2pr5+eIT5c65kA6NHug==",
+            "optional": true
+        },
+        "@esbuild/linux-arm": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.16.17.tgz",
+            "integrity": "sha512-iihzrWbD4gIT7j3caMzKb/RsFFHCwqqbrbH9SqUSRrdXkXaygSZCZg1FybsZz57Ju7N/SHEgPyaR0LZ8Zbe9gQ==",
+            "optional": true
+        },
+        "@esbuild/linux-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.16.17.tgz",
+            "integrity": "sha512-7S8gJnSlqKGVJunnMCrXHU9Q8Q/tQIxk/xL8BqAP64wchPCTzuM6W3Ra8cIa1HIflAvDnNOt2jaL17vaW+1V0g==",
+            "optional": true
+        },
+        "@esbuild/linux-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.16.17.tgz",
+            "integrity": "sha512-kiX69+wcPAdgl3Lonh1VI7MBr16nktEvOfViszBSxygRQqSpzv7BffMKRPMFwzeJGPxcio0pdD3kYQGpqQ2SSg==",
+            "optional": true
+        },
+        "@esbuild/linux-loong64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.16.17.tgz",
+            "integrity": "sha512-dTzNnQwembNDhd654cA4QhbS9uDdXC3TKqMJjgOWsC0yNCbpzfWoXdZvp0mY7HU6nzk5E0zpRGGx3qoQg8T2DQ==",
+            "optional": true
+        },
+        "@esbuild/linux-mips64el": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.16.17.tgz",
+            "integrity": "sha512-ezbDkp2nDl0PfIUn0CsQ30kxfcLTlcx4Foz2kYv8qdC6ia2oX5Q3E/8m6lq84Dj/6b0FrkgD582fJMIfHhJfSw==",
+            "optional": true
+        },
+        "@esbuild/linux-ppc64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.16.17.tgz",
+            "integrity": "sha512-dzS678gYD1lJsW73zrFhDApLVdM3cUF2MvAa1D8K8KtcSKdLBPP4zZSLy6LFZ0jYqQdQ29bjAHJDgz0rVbLB3g==",
+            "optional": true
+        },
+        "@esbuild/linux-riscv64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.16.17.tgz",
+            "integrity": "sha512-ylNlVsxuFjZK8DQtNUwiMskh6nT0vI7kYl/4fZgV1llP5d6+HIeL/vmmm3jpuoo8+NuXjQVZxmKuhDApK0/cKw==",
+            "optional": true
+        },
+        "@esbuild/linux-s390x": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.16.17.tgz",
+            "integrity": "sha512-gzy7nUTO4UA4oZ2wAMXPNBGTzZFP7mss3aKR2hH+/4UUkCOyqmjXiKpzGrY2TlEUhbbejzXVKKGazYcQTZWA/w==",
+            "optional": true
+        },
+        "@esbuild/linux-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.16.17.tgz",
+            "integrity": "sha512-mdPjPxfnmoqhgpiEArqi4egmBAMYvaObgn4poorpUaqmvzzbvqbowRllQ+ZgzGVMGKaPkqUmPDOOFQRUFDmeUw==",
+            "optional": true
+        },
+        "@esbuild/netbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-/PzmzD/zyAeTUsduZa32bn0ORug+Jd1EGGAUJvqfeixoEISYpGnAezN6lnJoskauoai0Jrs+XSyvDhppCPoKOA==",
+            "optional": true
+        },
+        "@esbuild/openbsd-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.16.17.tgz",
+            "integrity": "sha512-2yaWJhvxGEz2RiftSk0UObqJa/b+rIAjnODJgv2GbGGpRwAfpgzyrg1WLK8rqA24mfZa9GvpjLcBBg8JHkoodg==",
+            "optional": true
+        },
+        "@esbuild/sunos-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.16.17.tgz",
+            "integrity": "sha512-xtVUiev38tN0R3g8VhRfN7Zl42YCJvyBhRKw1RJjwE1d2emWTVToPLNEQj/5Qxc6lVFATDiy6LjVHYhIPrLxzw==",
+            "optional": true
+        },
+        "@esbuild/win32-arm64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.16.17.tgz",
+            "integrity": "sha512-ga8+JqBDHY4b6fQAmOgtJJue36scANy4l/rL97W+0wYmijhxKetzZdKOJI7olaBaMhWt8Pac2McJdZLxXWUEQw==",
+            "optional": true
+        },
+        "@esbuild/win32-ia32": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.16.17.tgz",
+            "integrity": "sha512-WnsKaf46uSSF/sZhwnqE4L/F89AYNMiD4YtEcYekBt9Q7nj0DiId2XH2Ng2PHM54qi5oPrQ8luuzGszqi/veig==",
+            "optional": true
+        },
+        "@esbuild/win32-x64": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.16.17.tgz",
+            "integrity": "sha512-y+EHuSchhL7FjHgvQL/0fnnFmO4T1bhvWANX6gcnqTjtnKWbTvUMCpGnv2+t+31d7RzyEAYAd4u2fnIhHL6N/Q==",
+            "optional": true
+        },
+        "@jridgewell/gen-mapping": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
+            "requires": {
+                "@jridgewell/set-array": "^1.2.1",
+                "@jridgewell/sourcemap-codec": "^1.4.10",
+                "@jridgewell/trace-mapping": "^0.3.24"
+            }
+        },
+        "@jridgewell/resolve-uri": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="
+        },
+        "@jridgewell/set-array": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A=="
+        },
+        "@jridgewell/source-map": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+            "requires": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
+            }
+        },
+        "@jridgewell/sourcemap-codec": {
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+        },
+        "@jridgewell/trace-mapping": {
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "requires": {
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
+            }
+        },
         "@particle/device-constants": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
             "integrity": "sha512-xskCcfBu+vh5eTebGE9LEejaKkdDueyea/nfFPCGLL7FJG51dDPZ1DfPZsueQuok4ok/V52KhZiOWH2oxkwq2Q==",
             "peer": true
         },
+        "@types/eslint": {
+            "version": "8.56.10",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
+            "integrity": "sha512-Shavhk87gCtY2fhXDctcfS3e6FdxWkCx1iUZ9eEUbh7rTqlZT0/IzOkCOVt0fCjcFuZ9FPYfuezTBImfHCDBGQ==",
+            "requires": {
+                "@types/estree": "*",
+                "@types/json-schema": "*"
+            }
+        },
+        "@types/eslint-scope": {
+            "version": "3.7.7",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+            "requires": {
+                "@types/eslint": "*",
+                "@types/estree": "*"
+            }
+        },
+        "@types/estree": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+            "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
+        },
+        "@types/json-schema": {
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
+        },
         "@types/minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA=="
         },
+        "@types/node": {
+            "version": "20.12.12",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+            "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+            "requires": {
+                "undici-types": "~5.26.4"
+            }
+        },
+        "@types/triple-beam": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+            "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw=="
+        },
         "@ungap/promise-all-settled": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
             "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q=="
+        },
+        "@webassemblyjs/ast": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
+            "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+            "requires": {
+                "@webassemblyjs/helper-numbers": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
+            "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
+            "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
+            "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+        },
+        "@webassemblyjs/helper-numbers": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
+            "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+            "requires": {
+                "@webassemblyjs/floating-point-hex-parser": "1.11.6",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
+            "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
+            "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+            "requires": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/wasm-gen": "1.12.1"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
+            "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
+            "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.11.6",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
+            "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
+            "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+            "requires": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/helper-wasm-section": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-opt": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1",
+                "@webassemblyjs/wast-printer": "1.12.1"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
+            "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+            "requires": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
+            "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+            "requires": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-buffer": "1.12.1",
+                "@webassemblyjs/wasm-gen": "1.12.1",
+                "@webassemblyjs/wasm-parser": "1.12.1"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
+            "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+            "requires": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@webassemblyjs/helper-api-error": "1.11.6",
+                "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
+                "@webassemblyjs/ieee754": "1.11.6",
+                "@webassemblyjs/leb128": "1.11.6",
+                "@webassemblyjs/utf8": "1.11.6"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.12.1",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
+            "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+            "requires": {
+                "@webassemblyjs/ast": "1.12.1",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webpack-cli/configtest": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.2.0.tgz",
+            "integrity": "sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==",
+            "requires": {}
+        },
+        "@webpack-cli/info": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.5.0.tgz",
+            "integrity": "sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==",
+            "requires": {
+                "envinfo": "^7.7.3"
+            }
+        },
+        "@webpack-cli/serve": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.7.0.tgz",
+            "integrity": "sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==",
+            "requires": {}
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -9706,40 +12073,70 @@
             }
         },
         "apidoc": {
-            "version": "0.17.5",
-            "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-0.17.5.tgz",
-            "integrity": "sha1-kc5yZLSMcX5MwYr7pkIne8aKIyU=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/apidoc/-/apidoc-1.2.0.tgz",
+            "integrity": "sha512-Qagoj7QnqNHbDUDNpU21eLP4hJSAXn6knHtEjRYWTlSEmpYDGSQijejyFXaWGByhfryW8B1gL+6B57UB/F1lxw==",
             "requires": {
-                "apidoc-core": "~0.8.1",
-                "fs-extra": "~2.0.0",
-                "lodash": "~4.17.4",
-                "markdown-it": "^8.2.2",
-                "nomnom": "~1.8.1",
-                "winston": "~2.3.1"
-            }
-        },
-        "apidoc-core": {
-            "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/apidoc-core/-/apidoc-core-0.8.3.tgz",
-            "integrity": "sha1-2dY1RYKd8lDSzKBJaDqH53U2S5Y=",
-            "requires": {
-                "fs-extra": "^3.0.1",
-                "glob": "^7.1.1",
-                "iconv-lite": "^0.4.17",
-                "klaw-sync": "^2.1.0",
-                "lodash": "~4.17.4",
-                "semver": "~5.3.0"
+                "bootstrap": "3.4.1",
+                "commander": "^10.0.0",
+                "diff-match-patch": "^1.0.5",
+                "esbuild-loader": "^2.16.0",
+                "expose-loader": "^4.0.0",
+                "fs-extra": "^11.0.0",
+                "glob": "^7.2.0",
+                "handlebars": "^4.7.7",
+                "iconv-lite": "^0.6.3",
+                "jquery": "^3.6.0",
+                "klaw-sync": "^6.0.0",
+                "lodash": "^4.17.21",
+                "markdown-it": "^12.2.0",
+                "nodemon": "^3.0.1",
+                "prismjs": "^1.25.0",
+                "semver": "^7.5.0",
+                "style-loader": "^3.3.1",
+                "webpack": "^5.64.2",
+                "webpack-cli": "^4.9.1",
+                "winston": "^3.3.3"
             },
             "dependencies": {
-                "fs-extra": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
-                    "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+                "commander": {
+                    "version": "10.0.1",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+                    "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug=="
+                },
+                "glob": {
+                    "version": "7.2.3",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+                    "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
                     "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^3.0.0",
-                        "universalify": "^0.1.0"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.1.1",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
+                },
+                "iconv-lite": {
+                    "version": "0.6.3",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+                    "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3.0.0"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "semver": {
+                    "version": "7.6.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+                    "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
                 }
             }
         },
@@ -10060,6 +12457,11 @@
                 "tweetnacl": "^0.14.3"
             }
         },
+        "big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
+        },
         "binary-extensions": {
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -10135,6 +12537,11 @@
                 "hoek": "2.x.x"
             }
         },
+        "bootstrap": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-3.4.1.tgz",
+            "integrity": "sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA=="
+        },
         "brace-expansion": {
             "version": "1.1.11",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -10195,6 +12602,11 @@
             "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
             "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74="
         },
+        "buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+        },
         "bytes": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
@@ -10241,9 +12653,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30000814",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000814.tgz",
-            "integrity": "sha512-Kt4dBhVlnTZ+jj+C8Bd4WT6RT4EJoX5/tlktHQfpqIMgLVrG1KBQlLf010ipMvuNrpQiAJ2A54e6MMbA0BaKxg=="
+            "version": "1.0.30001618",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001618.tgz",
+            "integrity": "sha512-p407+D1tIkDvsEAPS22lJxLQQaG8OTBEqo0KhzfABGk0TU4juBNDSfH0hyAp/HRyx+M8L17z/ltyhxh27FTfQg=="
         },
         "caseless": {
             "version": "0.12.0",
@@ -10344,6 +12756,11 @@
                 "readdirp": "^2.2.1",
                 "upath": "^1.1.1"
             }
+        },
+        "chrome-trace-event": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
+            "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
         },
         "circular-json": {
             "version": "0.3.3",
@@ -10477,6 +12894,16 @@
             "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
             "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg="
         },
+        "clone-deep": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+            "requires": {
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.2",
+                "shallow-clone": "^3.0.0"
+            }
+        },
         "cloneable-readable": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
@@ -10591,12 +13018,21 @@
                 "object-visit": "^1.0.0"
             }
         },
-        "color-convert": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+        "color": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
+            "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
             "requires": {
-                "color-name": "^1.1.1"
+                "color-convert": "^1.9.3",
+                "color-string": "^1.6.0"
+            }
+        },
+        "color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "requires": {
+                "color-name": "1.1.3"
             }
         },
         "color-name": {
@@ -10604,15 +13040,38 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
+        "color-string": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+            "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+            "requires": {
+                "color-name": "^1.0.0",
+                "simple-swizzle": "^0.2.2"
+            }
+        },
         "color-support": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
             "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg=="
         },
+        "colorette": {
+            "version": "2.0.20",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="
+        },
         "colors": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
             "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+        },
+        "colorspace": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
+            "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
+            "requires": {
+                "color": "^3.1.3",
+                "text-hex": "1.0.x"
+            }
         },
         "combined-stream": {
             "version": "1.0.6",
@@ -10813,11 +13272,6 @@
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
             "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0="
         },
-        "cycle": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-            "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-        },
         "d": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
@@ -10973,6 +13427,11 @@
             "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
             "dev": true
         },
+        "diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="
+        },
         "doctrine": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
@@ -11084,19 +13543,29 @@
             "integrity": "sha1-jJshKJjYzZ8alDZlDOe+ICyen/A="
         },
         "electron-to-chromium": {
-            "version": "1.3.37",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.37.tgz",
-            "integrity": "sha1-SpJzTgBEyM8LFVO+V+riGkxuX6s="
+            "version": "1.4.769",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.769.tgz",
+            "integrity": "sha512-bZu7p623NEA2rHTc9K1vykl57ektSPQYFFqQir8BOYf6EKOB+yIsbFB9Kpm7Cgt6tsLr9sRkqfqSZUw7LP1XxQ=="
         },
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
+        "emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
+        },
         "enable": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/enable/-/enable-1.3.2.tgz",
             "integrity": "sha1-nrpoN9FtCYK1n4fYib91REPVKTE="
+        },
+        "enabled": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
         },
         "end-of-stream": {
             "version": "1.4.4",
@@ -11106,10 +13575,24 @@
                 "once": "^1.4.0"
             }
         },
+        "enhanced-resolve": {
+            "version": "5.16.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
+            "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
+            "requires": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            }
+        },
         "entities": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
             "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
+        },
+        "envinfo": {
+            "version": "7.13.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
+            "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q=="
         },
         "errno": {
             "version": "0.1.7",
@@ -11127,6 +13610,11 @@
             "requires": {
                 "is-arrayish": "^0.2.1"
             }
+        },
+        "es-module-lexer": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.2.tgz",
+            "integrity": "sha512-l60ETUTmLqbVbVHv1J4/qj+M8nq7AwMzEcg3kmJDt9dCNrTk+yHcYFf/Kw75pMDwd9mPcIGCG5LcS20SxYRzFA=="
         },
         "es5-ext": {
             "version": "0.10.53",
@@ -11168,10 +13656,52 @@
                 "es6-symbol": "^3.1.1"
             }
         },
+        "esbuild": {
+            "version": "0.16.17",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.16.17.tgz",
+            "integrity": "sha512-G8LEkV0XzDMNwXKgM0Jwu3nY3lSTwSGY6XbxM9cr9+s0T/qSV1q1JVPBGzm3dcjhCic9+emZDmMffkwgPeOeLg==",
+            "requires": {
+                "@esbuild/android-arm": "0.16.17",
+                "@esbuild/android-arm64": "0.16.17",
+                "@esbuild/android-x64": "0.16.17",
+                "@esbuild/darwin-arm64": "0.16.17",
+                "@esbuild/darwin-x64": "0.16.17",
+                "@esbuild/freebsd-arm64": "0.16.17",
+                "@esbuild/freebsd-x64": "0.16.17",
+                "@esbuild/linux-arm": "0.16.17",
+                "@esbuild/linux-arm64": "0.16.17",
+                "@esbuild/linux-ia32": "0.16.17",
+                "@esbuild/linux-loong64": "0.16.17",
+                "@esbuild/linux-mips64el": "0.16.17",
+                "@esbuild/linux-ppc64": "0.16.17",
+                "@esbuild/linux-riscv64": "0.16.17",
+                "@esbuild/linux-s390x": "0.16.17",
+                "@esbuild/linux-x64": "0.16.17",
+                "@esbuild/netbsd-x64": "0.16.17",
+                "@esbuild/openbsd-x64": "0.16.17",
+                "@esbuild/sunos-x64": "0.16.17",
+                "@esbuild/win32-arm64": "0.16.17",
+                "@esbuild/win32-ia32": "0.16.17",
+                "@esbuild/win32-x64": "0.16.17"
+            }
+        },
+        "esbuild-loader": {
+            "version": "2.21.0",
+            "resolved": "https://registry.npmjs.org/esbuild-loader/-/esbuild-loader-2.21.0.tgz",
+            "integrity": "sha512-k7ijTkCT43YBSZ6+fBCW1Gin7s46RrJ0VQaM8qA7lq7W+OLsGgtLyFV8470FzYi/4TeDexniTBTPTwZUnXXR5g==",
+            "requires": {
+                "esbuild": "^0.16.17",
+                "joycon": "^3.0.1",
+                "json5": "^2.2.0",
+                "loader-utils": "^2.0.0",
+                "tapable": "^2.2.0",
+                "webpack-sources": "^1.4.3"
+            }
+        },
         "escalade": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-            "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
+            "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA=="
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -11316,19 +13846,24 @@
             }
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-            "dev": true,
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="
+                }
             }
         },
         "estraverse": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
-            "dev": true
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
         },
         "esutils": {
             "version": "2.0.2",
@@ -11349,6 +13884,11 @@
                 "stream-combiner": "~0.0.4",
                 "through": "~2.3.1"
             }
+        },
+        "events": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
         },
         "exit-hook": {
             "version": "1.1.1",
@@ -11395,6 +13935,12 @@
             "requires": {
                 "homedir-polyfill": "^1.0.1"
             }
+        },
+        "expose-loader": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/expose-loader/-/expose-loader-4.1.0.tgz",
+            "integrity": "sha512-oLAesnzerwDGGADzBMnu0LPqqnlVz6e2V9lTa+/4X6VeW9W93x/nJpw05WBrcIdbqXm/EdnEQpiVDFFiQXuNfg==",
+            "requires": {}
         },
         "ext": {
             "version": "1.4.0",
@@ -11511,11 +14057,6 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "optional": true
         },
-        "eyes": {
-            "version": "0.1.8",
-            "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-            "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
-        },
         "fancy-log": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
@@ -11535,14 +14076,18 @@
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
             "dev": true
+        },
+        "fastest-levenshtein": {
+            "version": "1.0.16",
+            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+            "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg=="
         },
         "faye-websocket": {
             "version": "0.7.3",
@@ -11551,6 +14096,11 @@
             "requires": {
                 "websocket-driver": ">=0.3.6"
             }
+        },
+        "fecha": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
         },
         "figures": {
             "version": "2.0.0",
@@ -11596,6 +14146,15 @@
                         "is-extendable": "^0.1.0"
                     }
                 }
+            }
+        },
+        "find-up": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+            "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
             }
         },
         "findup-sync": {
@@ -11713,6 +14272,11 @@
                 }
             }
         },
+        "fn.name": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+        },
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -11766,22 +14330,13 @@
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4="
         },
         "fs-extra": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-2.0.0.tgz",
-            "integrity": "sha1-M3NSve1KC3FPPrhN6M6nZenTdgA=",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+            "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
             "requires": {
-                "graceful-fs": "^4.1.2",
-                "jsonfile": "^2.1.0"
-            },
-            "dependencies": {
-                "jsonfile": {
-                    "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-                    "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-                    "requires": {
-                        "graceful-fs": "^4.1.6"
-                    }
-                }
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
             }
         },
         "fs-mkdirp-stream": {
@@ -11814,9 +14369,9 @@
             }
         },
         "function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -11940,6 +14495,11 @@
                 }
             }
         },
+        "glob-to-regexp": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="
+        },
         "glob-watcher": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/glob-watcher/-/glob-watcher-5.0.5.tgz",
@@ -12010,9 +14570,9 @@
             }
         },
         "graceful-fs": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+            "version": "4.2.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
         },
         "gray-matter": {
             "version": "2.1.1",
@@ -12505,6 +15065,14 @@
                 }
             }
         },
+        "hasown": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "requires": {
+                "function-bind": "^1.1.2"
+            }
+        },
         "hawk": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -12607,13 +15175,19 @@
         "iconv-lite": {
             "version": "0.4.19",
             "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "dev": true
         },
         "ignore": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
             "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
             "dev": true
+        },
+        "ignore-by-default": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+            "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA=="
         },
         "image-size": {
             "version": "0.5.5",
@@ -12625,6 +15199,15 @@
             "version": "3.0.6",
             "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
             "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
+        },
+        "import-local": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
+            "integrity": "sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==",
+            "requires": {
+                "pkg-dir": "^4.2.0",
+                "resolve-cwd": "^3.0.0"
+            }
         },
         "imurmurhash": {
             "version": "0.1.4",
@@ -12771,11 +15354,11 @@
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-core-module": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-            "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
             "requires": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             }
         },
         "is-data-descriptor": {
@@ -12918,6 +15501,11 @@
             "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
             "dev": true
         },
+        "is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
+        },
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
@@ -12975,7 +15563,8 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "optional": true
         },
         "istextorbinary": {
             "version": "1.0.2",
@@ -12984,6 +15573,31 @@
             "requires": {
                 "binaryextensions": "~1.0.0",
                 "textextensions": "~1.0.0"
+            }
+        },
+        "jest-worker": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+            "requires": {
+                "@types/node": "*",
+                "merge-stream": "^2.0.0",
+                "supports-color": "^8.0.0"
+            },
+            "dependencies": {
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+                },
+                "supports-color": {
+                    "version": "8.1.1",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+                    "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
             }
         },
         "joi": {
@@ -12996,6 +15610,16 @@
                 "moment": "2.x.x",
                 "topo": "1.x.x"
             }
+        },
+        "joycon": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+            "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="
+        },
+        "jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
         },
         "js-prettify": {
             "version": "1.4.0",
@@ -13035,6 +15659,11 @@
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
             "optional": true
         },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+        },
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -13067,12 +15696,18 @@
             "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
             "optional": true
         },
+        "json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
+        },
         "jsonfile": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
-            "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+            "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
             "requires": {
-                "graceful-fs": "^4.1.6"
+                "graceful-fs": "^4.1.6",
+                "universalify": "^2.0.0"
             }
         },
         "jsonify": {
@@ -13155,12 +15790,17 @@
             }
         },
         "klaw-sync": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-2.1.0.tgz",
-            "integrity": "sha1-PTvNhgDnv971MjHHOf8FOu1WDkQ=",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+            "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
             "requires": {
                 "graceful-fs": "^4.1.11"
             }
+        },
+        "kuler": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
         },
         "last-run": {
             "version": "1.1.1",
@@ -13273,9 +15913,9 @@
             }
         },
         "linkify-it": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
-            "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz",
+            "integrity": "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ==",
             "requires": {
                 "uc.micro": "^1.0.1"
             }
@@ -13302,6 +15942,29 @@
                     "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                 }
+            }
+        },
+        "loader-runner": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg=="
+        },
+        "loader-utils": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.4.tgz",
+            "integrity": "sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==",
+            "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            }
+        },
+        "locate-path": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+            "requires": {
+                "p-locate": "^4.1.0"
             }
         },
         "lodash": {
@@ -13607,6 +16270,26 @@
                 }
             }
         },
+        "logform": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/logform/-/logform-2.6.0.tgz",
+            "integrity": "sha512-1ulHeNPp6k/LD8H91o7VYFBng5i1BDE7HoKxVbZiGFidS1Rj65qcywLxX+pVfAPoQJEjRdvKcusKwOupHCVOVQ==",
+            "requires": {
+                "@colors/colors": "1.6.0",
+                "@types/triple-beam": "^1.3.2",
+                "fecha": "^4.2.0",
+                "ms": "^2.1.1",
+                "safe-stable-stringify": "^2.3.1",
+                "triple-beam": "^1.3.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+                }
+            }
+        },
         "lolex": {
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz",
@@ -13650,15 +16333,27 @@
             }
         },
         "markdown-it": {
-            "version": "8.4.2",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-            "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+            "version": "12.3.2",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
+            "integrity": "sha512-TchMembfxfNVpHkbtriWltGWc+m3xszaRD0CZup7GFFhzIgQqxIfn3eGj1yZpfuflzPvfkt611B2Q/Bsk1YnGg==",
             "requires": {
-                "argparse": "^1.0.7",
-                "entities": "~1.1.1",
-                "linkify-it": "^2.0.0",
+                "argparse": "^2.0.1",
+                "entities": "~2.1.0",
+                "linkify-it": "^3.0.1",
                 "mdurl": "^1.0.1",
                 "uc.micro": "^1.0.5"
+            },
+            "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+                },
+                "entities": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
+                    "integrity": "sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w=="
+                }
             }
         },
         "markdown-spellcheck": {
@@ -13886,12 +16581,17 @@
         "mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-            "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
+            "integrity": "sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g=="
         },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "merge-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
         },
         "metalsmith": {
             "version": "2.3.0",
@@ -14298,18 +16998,16 @@
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
         },
         "mime-db": {
-            "version": "1.33.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
-            "optional": true
+            "version": "1.52.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
         },
         "mime-types": {
-            "version": "2.1.18",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-            "optional": true,
+            "version": "2.1.35",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "requires": {
-                "mime-db": "~1.33.0"
+                "mime-db": "1.52.0"
             }
         },
         "mimic-fn": {
@@ -14577,11 +17275,6 @@
                         "p-limit": "^3.0.2"
                     }
                 },
-                "path-exists": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-                    "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-                },
                 "readdirp": {
                     "version": "3.5.0",
                     "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
@@ -14747,6 +17440,11 @@
             "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
             "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
         },
+        "node-releases": {
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+        },
         "node-static": {
             "version": "0.7.10",
             "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.10.tgz",
@@ -14757,23 +17455,135 @@
                 "optimist": ">=0.3.4"
             }
         },
-        "nomnom": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",
-            "integrity": "sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=",
+        "nodemon": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.0.tgz",
+            "integrity": "sha512-xqlktYlDMCepBJd43ZQhjWwMw2obW/JRvkrLxq5RCNcuDDX1DbcPT+qT1IlIIdf+DhnWs90JpTMe+Y5KxOchvA==",
             "requires": {
-                "chalk": "~0.4.0",
-                "underscore": "~1.6.0"
+                "chokidar": "^3.5.2",
+                "debug": "^4",
+                "ignore-by-default": "^1.0.1",
+                "minimatch": "^3.1.2",
+                "pstree.remy": "^1.1.8",
+                "semver": "^7.5.3",
+                "simple-update-notifier": "^2.0.0",
+                "supports-color": "^5.5.0",
+                "touch": "^3.1.0",
+                "undefsafe": "^2.0.5"
             },
             "dependencies": {
-                "chalk": {
-                    "version": "0.4.0",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-                    "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
+                "anymatch": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+                    "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
                     "requires": {
-                        "ansi-styles": "~1.0.0",
-                        "has-color": "~0.1.0",
-                        "strip-ansi": "~0.1.0"
+                        "normalize-path": "^3.0.0",
+                        "picomatch": "^2.0.4"
+                    }
+                },
+                "binary-extensions": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+                    "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="
+                },
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+                    "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+                    "requires": {
+                        "anymatch": "~3.1.2",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.3.2",
+                        "glob-parent": "~5.1.2",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.6.0"
+                    }
+                },
+                "debug": {
+                    "version": "4.3.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+                    "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+                    "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+                    "optional": true
+                },
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+                    "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                },
+                "is-binary-path": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+                    "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+                    "requires": {
+                        "binary-extensions": "^2.0.0"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                },
+                "readdirp": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+                    "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+                    "requires": {
+                        "picomatch": "^2.2.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.6.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+                    "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "requires": {
+                        "is-number": "^7.0.0"
                     }
                 }
             }
@@ -14795,17 +17605,6 @@
                 "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
-            },
-            "dependencies": {
-                "resolve": {
-                    "version": "1.20.0",
-                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-                    "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-                    "requires": {
-                        "is-core-module": "^2.2.0",
-                        "path-parse": "^1.0.6"
-                    }
-                }
             }
         },
         "normalize-path": {
@@ -14981,6 +17780,14 @@
                 "wrappy": "1"
             }
         },
+        "one-time": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+            "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+            "requires": {
+                "fn.name": "1.x.x"
+            }
+        },
         "onetime": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
@@ -15077,10 +17884,31 @@
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
+        "p-limit": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+            "requires": {
+                "p-try": "^2.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+            "requires": {
+                "p-limit": "^2.2.0"
+            }
+        },
         "p-map": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
             "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA=="
+        },
+        "p-try": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "pako": {
             "version": "1.0.11",
@@ -15125,6 +17953,11 @@
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
+        "path-exists": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -15134,6 +17967,11 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
             "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+        },
+        "path-key": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
         },
         "path-parse": {
             "version": "1.0.7",
@@ -15184,6 +18022,11 @@
             "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
             "optional": true
         },
+        "picocolors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+            "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+        },
         "picomatch": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
@@ -15205,6 +18048,14 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "requires": {
                 "pinkie": "^2.0.0"
+            }
+        },
+        "pkg-dir": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+            "requires": {
+                "find-up": "^4.0.0"
             }
         },
         "plugin-error": {
@@ -15355,6 +18206,11 @@
             "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
             "integrity": "sha1-t+PqQkNaTJsnWdmeDyAesZWALuE="
         },
+        "prismjs": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
+            "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
+        },
         "process-nextick-args": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
@@ -15391,6 +18247,11 @@
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
             "dev": true
+        },
+        "pstree.remy": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+            "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w=="
         },
         "pump": {
             "version": "2.0.1",
@@ -15693,11 +18554,28 @@
             }
         },
         "resolve": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
-            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "requires": {
-                "path-parse": "^1.0.5"
+                "is-core-module": "^2.13.0",
+                "path-parse": "^1.0.7",
+                "supports-preserve-symlinks-flag": "^1.0.0"
+            }
+        },
+        "resolve-cwd": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+            "requires": {
+                "resolve-from": "^5.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+                    "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+                }
             }
         },
         "resolve-dir": {
@@ -15802,11 +18680,60 @@
                 "ret": "~0.1.10"
             }
         },
+        "safe-stable-stringify": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.4.3.tgz",
+            "integrity": "sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g=="
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
         "samsam": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz",
             "integrity": "sha1-vsEf3IOp/aBjQBIQ5AF2wwJNFWc=",
             "dev": true
+        },
+        "schema-utils": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+            "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
+            "requires": {
+                "@types/json-schema": "^7.0.8",
+                "ajv": "^6.12.5",
+                "ajv-keywords": "^3.5.2"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ajv-keywords": {
+                    "version": "3.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+                    "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+                    "requires": {}
+                },
+                "fast-deep-equal": {
+                    "version": "3.1.3",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+                    "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+                }
+            }
         },
         "semver": {
             "version": "5.3.0",
@@ -15860,6 +18787,14 @@
             "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
             "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
         },
+        "shallow-clone": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+            "requires": {
+                "kind-of": "^6.0.2"
+            }
+        },
         "shebang-command": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -15880,6 +18815,36 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
             "dev": true
+        },
+        "simple-swizzle": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+            "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+            "requires": {
+                "is-arrayish": "^0.3.1"
+            },
+            "dependencies": {
+                "is-arrayish": {
+                    "version": "0.3.2",
+                    "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+                }
+            }
+        },
+        "simple-update-notifier": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+            "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+            "requires": {
+                "semver": "^7.5.3"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "7.6.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+                    "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w=="
+                }
+            }
         },
         "simplecrawler": {
             "version": "git+ssh://git@github.com/spark/node-simplecrawler.git#7d1b1350a35861699094d28d4f850432f81cb96f",
@@ -16038,6 +19003,11 @@
                 "hoek": "2.x.x"
             }
         },
+        "source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+        },
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -16053,6 +19023,15 @@
                 "resolve-url": "^0.2.1",
                 "source-map-url": "^0.4.0",
                 "urix": "^0.1.0"
+            }
+        },
+        "source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "source-map-url": {
@@ -16259,17 +19238,28 @@
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
             "dev": true
         },
+        "style-loader": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
+            "integrity": "sha512-0WqXzrsMTyb8yjZJHDqwmnwRJvhALK9LfRtRc6B4UTWe8AijYLZYZ9thuJTZc2VfQWINADW/j+LiJnfy2RoC1w==",
+            "requires": {}
+        },
         "substitute": {
             "version": "https://github.com/segmentio/substitute/archive/0.0.1.tar.gz",
             "integrity": "sha1-QyhmmFsDw7DT9xrGPRrhoY369H0="
         },
         "supports-color": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-            "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
             "requires": {
                 "has-flag": "^3.0.0"
             }
+        },
+        "supports-preserve-symlinks-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="
         },
         "sver-compat": {
             "version": "1.5.0",
@@ -16315,6 +19305,61 @@
                     }
                 }
             }
+        },
+        "tapable": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
+        },
+        "terser": {
+            "version": "5.31.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.0.tgz",
+            "integrity": "sha512-Q1JFAoUKE5IMfI4Z/lkE/E6+SwgzO+x4tq4v1AyBLRj8VSYvRO6A/rQrPg1yud4g0En9EKI1TvFRF2tQFcoUkg==",
+            "requires": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.11.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+                    "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+                },
+                "commander": {
+                    "version": "2.20.3",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+                    "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+                }
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "5.3.10",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.10.tgz",
+            "integrity": "sha512-BKFPWlPDndPs+NGGCr1U59t0XScL5317Y0UReNrHaw9/FwhPENlq6bfgs+4yPfyP51vqC1bQ4rp1EfXW5ZSH9w==",
+            "requires": {
+                "@jridgewell/trace-mapping": "^0.3.20",
+                "jest-worker": "^27.4.5",
+                "schema-utils": "^3.1.1",
+                "serialize-javascript": "^6.0.1",
+                "terser": "^5.26.0"
+            },
+            "dependencies": {
+                "serialize-javascript": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+                    "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+                    "requires": {
+                        "randombytes": "^2.1.0"
+                    }
+                }
+            }
+        },
+        "text-hex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
         },
         "text-table": {
             "version": "0.2.0",
@@ -16502,6 +19547,11 @@
                 "hoek": "2.x.x"
             }
         },
+        "touch": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+            "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA=="
+        },
         "tough-cookie": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
@@ -16510,6 +19560,11 @@
             "requires": {
                 "punycode": "^1.4.1"
             }
+        },
+        "triple-beam": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+            "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg=="
         },
         "tslib": {
             "version": "1.14.1",
@@ -16633,10 +19688,10 @@
             "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
             "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
         },
-        "underscore": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-            "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag="
+        "undefsafe": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+            "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
         },
         "undertaker": {
             "version": "1.3.0",
@@ -16667,6 +19722,11 @@
             "resolved": "https://registry.npmjs.org/undertaker-registry/-/undertaker-registry-1.0.1.tgz",
             "integrity": "sha1-XkvaMI5KiirlhPm5pDWaSZglzFA="
         },
+        "undici-types": {
+            "version": "5.26.5",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+        },
         "union-value": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
@@ -16694,9 +19754,9 @@
             }
         },
         "universalify": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
         },
         "unset-value": {
             "version": "1.0.0",
@@ -16753,6 +19813,21 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
+        },
+        "uri-js": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+            "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+                    "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
+                }
+            }
         },
         "urijs": {
             "version": "1.19.10",
@@ -16985,6 +20060,182 @@
                 "wrap-fn": "^0.1.0"
             }
         },
+        "watchpack": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.1.tgz",
+            "integrity": "sha512-8wrBCMtVhqcXP2Sup1ctSkga6uc2Bx0IIvKyT7yTFier5AXHooSI+QyQQAtTb7+E0IUCCKyTFmXqdqgum2XWGg==",
+            "requires": {
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.1.2"
+            }
+        },
+        "webpack": {
+            "version": "5.91.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
+            "integrity": "sha512-rzVwlLeBWHJbmgTC/8TvAcu5vpJNII+MelQpylD4jNERPwpBJOE2lEcko1zJX3QJeLjTTAnQxn/OJ8bjDzVQaw==",
+            "requires": {
+                "@types/eslint-scope": "^3.7.3",
+                "@types/estree": "^1.0.5",
+                "@webassemblyjs/ast": "^1.12.1",
+                "@webassemblyjs/wasm-edit": "^1.12.1",
+                "@webassemblyjs/wasm-parser": "^1.12.1",
+                "acorn": "^8.7.1",
+                "acorn-import-assertions": "^1.9.0",
+                "browserslist": "^4.21.10",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^5.16.0",
+                "es-module-lexer": "^1.2.1",
+                "eslint-scope": "5.1.1",
+                "events": "^3.2.0",
+                "glob-to-regexp": "^0.4.1",
+                "graceful-fs": "^4.2.11",
+                "json-parse-even-better-errors": "^2.3.1",
+                "loader-runner": "^4.2.0",
+                "mime-types": "^2.1.27",
+                "neo-async": "^2.6.2",
+                "schema-utils": "^3.2.0",
+                "tapable": "^2.1.1",
+                "terser-webpack-plugin": "^5.3.10",
+                "watchpack": "^2.4.1",
+                "webpack-sources": "^3.2.3"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "8.11.3",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+                    "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg=="
+                },
+                "acorn-import-assertions": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.9.0.tgz",
+                    "integrity": "sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==",
+                    "requires": {}
+                },
+                "browserslist": {
+                    "version": "4.23.0",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+                    "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001587",
+                        "electron-to-chromium": "^1.4.668",
+                        "node-releases": "^2.0.14",
+                        "update-browserslist-db": "^1.0.13"
+                    }
+                },
+                "eslint-scope": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+                    "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+                    "requires": {
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "update-browserslist-db": {
+                    "version": "1.0.16",
+                    "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+                    "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+                    "requires": {
+                        "escalade": "^3.1.2",
+                        "picocolors": "^1.0.1"
+                    }
+                },
+                "webpack-sources": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+                    "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w=="
+                }
+            }
+        },
+        "webpack-cli": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
+            "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
+            "requires": {
+                "@discoveryjs/json-ext": "^0.5.0",
+                "@webpack-cli/configtest": "^1.2.0",
+                "@webpack-cli/info": "^1.5.0",
+                "@webpack-cli/serve": "^1.7.0",
+                "colorette": "^2.0.14",
+                "commander": "^7.0.0",
+                "cross-spawn": "^7.0.3",
+                "fastest-levenshtein": "^1.0.12",
+                "import-local": "^3.0.2",
+                "interpret": "^2.2.0",
+                "rechoir": "^0.7.0",
+                "webpack-merge": "^5.7.3"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+                    "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+                },
+                "cross-spawn": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+                    "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+                    "requires": {
+                        "path-key": "^3.1.0",
+                        "shebang-command": "^2.0.0",
+                        "which": "^2.0.1"
+                    }
+                },
+                "interpret": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+                    "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
+                },
+                "rechoir": {
+                    "version": "0.7.1",
+                    "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.1.tgz",
+                    "integrity": "sha512-/njmZ8s1wVeR6pjTZ+0nCnv8SpZNRMT2D1RLOJQESlYFDBvwpTA4KWJpZ+sBJ4+vhjILRcK7JIFdGCdxEAAitg==",
+                    "requires": {
+                        "resolve": "^1.9.0"
+                    }
+                },
+                "shebang-command": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+                    "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+                    "requires": {
+                        "shebang-regex": "^3.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+                    "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+                },
+                "which": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+                    "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "webpack-merge": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
+            "requires": {
+                "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
+                "wildcard": "^2.0.0"
+            }
+        },
+        "webpack-sources": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+            "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            }
+        },
         "websocket-driver": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
@@ -17020,6 +20271,11 @@
                 "string-width": "^1.0.2 || 2"
             }
         },
+        "wildcard": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+            "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="
+        },
         "win-fork": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/win-fork/-/win-fork-1.1.1.tgz",
@@ -17031,23 +20287,38 @@
             "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0="
         },
         "winston": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-            "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
+            "integrity": "sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==",
             "requires": {
-                "async": "~1.0.0",
-                "colors": "1.0.x",
-                "cycle": "1.0.x",
-                "eyes": "0.1.x",
-                "isstream": "0.1.x",
-                "stack-trace": "0.0.x"
+                "@colors/colors": "^1.6.0",
+                "@dabh/diagnostics": "^2.0.2",
+                "async": "^3.2.3",
+                "is-stream": "^2.0.0",
+                "logform": "^2.4.0",
+                "one-time": "^1.0.0",
+                "readable-stream": "^3.4.0",
+                "safe-stable-stringify": "^2.3.1",
+                "stack-trace": "0.0.x",
+                "triple-beam": "^1.3.0",
+                "winston-transport": "^4.7.0"
             },
             "dependencies": {
                 "async": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-                    "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
+                    "version": "3.2.5",
+                    "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+                    "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
                 }
+            }
+        },
+        "winston-transport": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.7.0.tgz",
+            "integrity": "sha512-ajBj65K5I7denzer2IYW6+2bNIVqLGDHqDw3Ow8Ohh+vdW+rv4MZ6eiDvHoKhfJFZ2auyN8byXieDDJ96ViONg==",
+            "requires": {
+                "logform": "^2.3.2",
+                "readable-stream": "^3.6.0",
+                "triple-beam": "^1.3.0"
             }
         },
         "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "pdf-generation": "gulp --gulpfile ./scripts/pdf-generation/pdf-generation-gulpfile.js"
     },
     "dependencies": {
-        "apidoc": "^0.17.5",
+        "apidoc": "^1.2.0",
         "autoprefixer": "^7.1.5",
         "binary-version-reader": "^2.0.1",
         "del": "^3.0.0",

--- a/scripts/apidoc.js
+++ b/scripts/apidoc.js
@@ -7,158 +7,9 @@ var path = require('path');
 
 var apiScopes = [];
 
-function trimParam(string) {
-  if (!string) {
-    return string;
-  }
-  var pCount = (string.match(/<p>/g) || []).length;
-  if (pCount !== 1) {
-    return string;
-  }
-  if (string.indexOf('<p>') !== 0 || string.indexOf('</p>') !== string.length - 4) {
-    return string;
-  }
-  return string.trim().slice(3, -4);
-}
-
-function trimParameters(allParams) {
-  if (!allParams) return;
-
-  _.each(allParams, function (params, key) {
-    params.forEach(function (param) {
-      // remove unnecessary <p></p> tags from start and end
-      param.type = trimParam(param.type);
-      param.description = param.description;
-    });
-  });
-}
-
-function nestParameters(allParams) {
-  if (allParams) {
-    _.each(allParams, function (params, key) {
-      var indexedParameters = _.keyBy(allParams[key], 'field');
-      var nestedParams = [];
-      params.forEach(function (param) {
-        var nameParts = param.field.split('.');
-        if (nameParts.length > 1) {
-          var parent = indexedParameters[nameParts[0]];
-          if (parent) {
-            if (!parent.nestedParams) {
-              parent.nestedParams = [];
-            }
-            param.field = nameParts.slice(1).join('.');
-            parent.nestedParams.push(param);
-            nestedParams.push(param);
-          }
-        }
-      });
-      allParams[key] = _.difference(allParams[key], nestedParams);
-    });
-  }
-}
-
-function breakOutAlternativeOperations(data) {
-  for (var i=0; i < data.length; i++) {
-    var route = data[i];
-    if (!route.parameter) continue;
-
-    var baseParams, baseSuccess, baseError;
-    var examplesIndex = {};
-    var successExamplesIndex = {};
-    var errorExamplesIndex = {};
-    if (route.examples) {
-      examplesIndex = _.groupBy(route.examples, 'title');
-    } else {
-      route.examples = {};
-    }
-
-    if (route.success) {
-      successExamplesIndex = _.groupBy(route.success.examples, 'title');
-    } else {
-      route.success = {};
-    }
-
-    if (route.error) {
-      errorExamplesIndex = _.groupBy(route.error.examples, 'title');
-    } else {
-      route.error = {};
-    }
-
-    _.each(route.parameter.fields, function(params, title) {
-      if (title === 'Parameter') {
-        baseParams = params;
-        baseSuccess = (route.success.fields || {})['Success 200'] || [];
-        baseError = (route.error.fields || {})['Error 4xx'] || [];
-        return;
-      }
-
-      // create new clone route
-      var groupKey = params[0].group;
-      var newRoute = _.cloneDeep(route);
-      newRoute.title = title;
-      newRoute.description = null;
-      newRoute.parameter.fields = {
-        Parameter: baseParams.concat(params)
-      };
-
-      // grab op specific response fields too
-      var responseFields = (route.success.fields || {})[title];
-      if (responseFields) {
-        newRoute.success.fields = {
-          'Success 200': baseSuccess.concat(responseFields)
-        };
-        delete route.success.fields[title];
-      }
-      var errorFields = (route.error.fields || {})[title];
-      if (errorFields) {
-        newRoute.error.fields = {
-          'Error 4xx': baseError.concat(errorFields)
-        };
-        delete route.error.fields[title];
-      }
-
-      // copy over specific examples
-      if (examplesIndex[groupKey] && examplesIndex[groupKey].length) {
-        newRoute.examples = examplesIndex[groupKey];
-        newRoute.examples.forEach(function (ex) {
-          ex.title = ex.content;
-        });
-      } else {
-        newRoute.examples = null;
-      }
-      // remove copied examples from base
-      route.examples = _.difference(route.examples, newRoute.examples);
-
-      if (successExamplesIndex[groupKey] && successExamplesIndex[groupKey].length) {
-        newRoute.success.examples = successExamplesIndex[groupKey];
-        newRoute.success.examples.forEach(function (ex) {
-          ex.title = ex.content;
-        });
-      } else {
-        newRoute.success.examples = null;
-      }
-      route.success.examples = _.difference(route.success.examples, newRoute.success.examples);
-
-      if (errorExamplesIndex[groupKey] && errorExamplesIndex[groupKey].length) {
-        newRoute.error.examples = errorExamplesIndex[groupKey];
-        newRoute.error.examples.forEach(function (ex) {
-          ex.title = ex.content;
-        });
-      } else {
-        newRoute.error.examples = null;
-      }
-      route.error.examples = _.difference(route.error.examples, newRoute.error.examples);
-
-      // add to list of all routes
-      i++;
-      data.splice(i, 0, newRoute);
-    });
-  }
-}
-
 function assignOrder(data) {
   data.forEach(function (route) {
-    var groupParts = route.group.split('_');
+    var groupParts = route.group.split('.');
     route.group = groupParts[0];
     route.order = +groupParts[1] || 99;
   });
@@ -170,11 +21,12 @@ module.exports = function(options) {
       const savePath = path.join(__dirname, '..', 'generated', path.basename(apiOptions.src) + '.json');
       apiOptions.parse = true;
       apiOptions.src = metalsmith.path(apiOptions.src);
+      apiOptions.config = metalsmith.path(apiOptions.config);
       if (!fs.existsSync(apiOptions.src)) {
         if (fs.existsSync(savePath)) {
           return JSON.parse(fs.readFileSync(savePath, 'utf8'));
         }
-        
+
         return null;
       }
       var dirFiles = fs.readdirSync(apiOptions.src);
@@ -182,7 +34,11 @@ module.exports = function(options) {
         return null;
       }
 
-      var apiReturn = apidoc.createDoc(apiOptions);
+      const options = {
+        ...apiOptions,
+        src: [apiOptions.src]
+      };
+      var apiReturn = apidoc.createDoc(options);
       if (!apiReturn) {
         return new Error('Error');
       }
@@ -219,7 +75,6 @@ module.exports = function(options) {
     }
 
     assignOrder(apiData);
-    breakOutAlternativeOperations(apiData);
 
     apiData.forEach(function (route) {
       if (route.permission) {
@@ -229,20 +84,6 @@ module.exports = function(options) {
             apiScopes.push(obj.name);
           }
         }
-      }
-
-      if (route.parameter) {
-        trimParameters(route.parameter.fields);
-      }
-
-      if (route.success) {
-        trimParameters(route.success.fields);
-        nestParameters(route.success.fields);
-      }
-
-      if (route.error) {
-        trimParameters(route.error.fields);
-        nestParameters(route.error.fields);
       }
     });
 

--- a/scripts/metalsmith.js
+++ b/scripts/metalsmith.js
@@ -7,15 +7,15 @@
  * The frontmatter (stuff between --- at the top of the file) is added as additional properties.
  * When all the plugins are done running, the files object is written to the destination directory.
  * That's it!
- * 
+ *
  * Instead of using update-api.sh, now just clone api-service, api-service-libraries, and particle-api-js
- * into the directory above docs, so all three projects are peers. If the directories exist they will 
+ * into the directory above docs, so all three projects are peers. If the directories exist they will
  * be used to rebuild the generate documentation. If not, the saved version of the digested docs will be
  * used, so the private source does not need to be accessed during a normal build, but the build will
  * still have all of the content that would normally be there.
  */
 'use strict';
- 
+
 var Metalsmith = require('metalsmith');
 var markdown = require('metalsmith-markdown');
 var layouts = require('metalsmith-layouts');
@@ -128,7 +128,7 @@ exports.metalsmith = function () {
       })))
     .use(msIf(
       environment === 'development',
-      pinInfoGenerator(          
+      pinInfoGenerator(
       )))
     .use(msIf(
         environment === 'development',
@@ -162,12 +162,12 @@ exports.metalsmith = function () {
         apis: [
           {
             src: '../../api-service/',
-            config: '../../api-service/',
+            config: '../../api-service/apidoc.json',
             includeFilters: ['.*[vV]iews[^.]*\\.js$', 'lib/AccessTokenController.js']
           },
           {
             src: '../../api-service-libraries/',
-            config: '../../api-service/',
+            config: '../../api-service/apidoc.json',
             includeFilters: ['.*Controller\\.js$']
           },
         ]
@@ -191,10 +191,10 @@ exports.metalsmith = function () {
     }))
     // Add properties to files that match the pattern
     .use(fileMetadata([
-      { pattern: 'content/**/*.md', metadata: { 
-          assets: '/assets', 
-          branch: gitBranch, 
-          noIndex: (gitBranch == 'staging' || gitBranch == 'prerelease'), 
+      { pattern: 'content/**/*.md', metadata: {
+          assets: '/assets',
+          branch: gitBranch,
+          noIndex: (gitBranch == 'staging' || gitBranch == 'prerelease'),
           noScripts: noScripts,
           srcLocal: path.join(__dirname, '../src') } }
     ]))
@@ -242,7 +242,7 @@ exports.metalsmith = function () {
       contentDir: '../src/content',
       redirects: '../config/redirects.json'
     }))
-    .use(navMenuGenerator({      
+    .use(navMenuGenerator({
       contentDir: '../src/content',
     }))
     .use(sharedBlurb({

--- a/src/assets/files/userScopes.json
+++ b/src/assets/files/userScopes.json
@@ -8,8 +8,6 @@
   "customers:list",
   "customers:remove",
   "customers:update",
-  "devices.diagnostics.metadata:get",
-  "devices.diagnostics.summary:get",
   "devices.diagnostics:get",
   "devices.diagnostics:update",
   "devices.function:call",

--- a/src/content/reference/cloud-apis/api.md
+++ b/src/content/reference/cloud-apis/api.md
@@ -17,7 +17,7 @@ The Particle Device Cloud API is a [REST](http://en.wikipedia.org/wiki/Represent
 REST means a lot of things, but first and foremost it means that we use the URL in the way that it's intended:
 as a "Uniform Resource Locator".
 
-In this case, the unique "resource" in question is your device (Core, Photon, Electron).
+In this case, the unique "resource" in question is your device (Argon, Boron, Photon 2).
 Every device has a URL, which can be used to `GET` variables, `POST` a function call, or `PUT` new firmware.
 The variables and functions that you have written in your firmware are exposed as *subresources* under the device.
 
@@ -44,10 +44,11 @@ The Particle API accepts requests in [JSON](https://www.w3schools.com/js/js_json
 # Example with form encoded format
 curl https://api.particle.io/v1/devices/mydevice/wakeup \
      -d arg=please \
-     -d access_token=1234
+     -H "Authorization: Bearer :access_token"
 
 # Same example with JSON
-curl "https://api.particle.io/v1/devices/mydevice/wakeup?access_token=1234" \
+curl https://api.particle.io/v1/devices/mydevice/wakeup \
+     -H "Authorization: Bearer :access_token" \
      -H "Content-Type: application/json" \
      -d "{\"arg\": \"please\"}"
 ```
@@ -144,13 +145,13 @@ Permissions for controlling and communicating with your Particle device are mana
 ```bash
 # You type in your terminal
 curl https://api.particle.io/v1/devices/0123456789abcdef01234567/brew \
-     -d access_token=9876987698769876987698769876987698769876
+     -H "Authorization: Bearer 9876987698769876987698769876987698769876"
 # Response status is 200 OK, which means
 # the device says, "Yes ma'am!"
 
 # Sneaky Pete tries the same thing in his terminal
 curl https://api.particle.io/v1/devices/0123456789abcdef01234567/brew \
-     -d access_token=1234123412341234123412341234123412341234
+     -H "Authorization: Bearer 1234123412341234123412341234123412341234"
 # Response status is 403 Forbidden, which means
 # the device says, "You ain't the boss of me."
 
@@ -169,8 +170,8 @@ and only you will have permission to control your Particle device—using your a
 There are three ways to send your access token in a request.
 
 * In an HTTP Authorization header (always works)
-* In the URL query string (only works with GET requests)
-* In the request body (only works for POST, PUT and DELETE when body is form encoded)
+* **Deprecated**: In the URL query string (only works with GET requests)
+* **Deprecated**: In the request body (only works for POST and PUT when body is form encoded)
 
 ---
 
@@ -185,10 +186,11 @@ curl -H "Authorization: Bearer 38bb7b318cc6898c80317decb34525844bc9db55" \
 
 ---
 
-The query string is the part of the URL after a `?` question mark.
-To send the access token in the query string just add `access_token=38bb...`.
-Because your terminal may think the question mark is special, enclose
-the entire URL in double quotes.
+Sending the access token in the query string is **deprecated and discouraged for new application**
+since many tools log query strings so there's a chance for your access token to be logged in places
+where you don't expect it. Legacy applications sending `access_token=38bb...` in the query string
+should be updated to use the HTTP Authorization header. When using a query string in the terminal,
+enclose the entire URL in double quotes to avoid issues with special characters.
 
 ``` bash
 curl "https://api.particle.io/v1/devices?access_token=38bb7b318cc6898c80317decb34525844bc9db55"
@@ -196,11 +198,8 @@ curl "https://api.particle.io/v1/devices?access_token=38bb7b318cc6898c80317decb3
 
 ---
 
-The request body is how form contents are submitted on the web.
-Using curl, each parameter you send, including the access token is preceded by a `-d` flag.
-By default, if you add a `-d` flag, curl assumes that the request is a POST.
-If you need a different request type, you have to specifically say so with the `-X` flag,
-for example `-X PUT`.
+Sending the access token as part of the request body is **deprecated** since it only works for POST
+and PUT requests. Prefer using the HTTP Authorization header since it works for all request types.
 
 ``` bash
 curl -d access_token=38bb7b318cc6898c80317decb34525844bc9db55 \
@@ -290,11 +289,12 @@ Pass a request to the relevant endpoint with a friendly name, and the desired sc
 #### Create an API user scoped to an organization
 
 ```
-curl "https://api.particle.io/v1/orgs/:orgIDorSlug/team?access_token=xxxx" \\
-	-H "Content-Type: application/json" \\
-	-d '{ \\
-		"friendly_name": "org api user", \\
-		"scopes": [ "devices:list" ] \\
+curl https://api.particle.io/v1/orgs/:orgIDorSlug/team \
+	-H "Authorization: Bearer :access_token" \
+	-H "Content-Type: application/json" \
+	-d '{ \
+		"friendly_name": "org api user", \
+		"scopes": [ "devices:list" ] \
 	}'
 ```
 
@@ -305,11 +305,12 @@ The resulting access token can then be used by programmatic processes. As always
 #### Create an API user scoped to a product
 
 ```
-curl "https://api.particle.io/v1/products/:productIDorSlug/team?access_token=xxxx" \\
-	-H "Content-Type: application/json" \\
-	-d '{ \\
-		"friendly_name": "product api user", \\
-		"scopes": [ "devices:list" ] \\
+curl https://api.particle.io/v1/products/:productIDorSlug/team \
+	-H "Authorization: Bearer :access_token" \
+	-H "Content-Type: application/json" \
+	-d '{ \
+		"friendly_name": "product api user", \
+		"scopes": [ "devices:list" ] \
 	}'
 ```
 
@@ -342,11 +343,12 @@ The Particle API documentation includes the required scopes needed to call a par
 ### Updating an API user
 
 ```
-curl -X PUT "https://api.particle.io/v1/products/12857/team/example-api-user+6fbl2q577b@api.particle.io?access_token=xxxxxx" \\
-	-H "Content-Type: application/json" \\
-	-d '{  \\
-		"friendly_name": "Updated API user",  \\
-		"scopes": [ "devices:list", "sims:list", "customers:list" ]  \\
+curl -X PUT https://api.particle.io/v1/products/12857/team/example-api-user+6fbl2q577b@api.particle.io \
+	-H "Authorization: Bearer :access_token" \
+	-H "Content-Type: application/json" \
+	-d '{  \
+		"friendly_name": "Updated API user",  \
+		"scopes": [ "devices:list", "sims:list", "customers:list" ]  \
 	}'
 ```
 
@@ -357,7 +359,8 @@ To update the API user, you pass in the full username, in this case example-api-
 ### Listing API users
 
 ```
-curl -X GET "https://api.particle.io/v1/products/12857/team/?access_token=xxxxxx" \\
+curl -X GET https://api.particle.io/v1/products/12857/team/ \
+	-H "Authorization: Bearer :access_token" \
 	-H "Content-Type: application/json"
 ```
 
@@ -374,10 +377,10 @@ Listing API users is done by getting the team member list of the product or for 
         "name": "Administrator"
       }
     },
-	{
-		"username": "example-api-user+6fbl2q577b@api.particle.io",
-		"is_programmatic": true
-	}
+    {
+      "username": "example-api-user+6fbl2q577b@api.particle.io",
+      "is_programmatic": true
+    }
   ]
 }
 ```
@@ -385,7 +388,8 @@ Listing API users is done by getting the team member list of the product or for 
 ### Deleting an API user
 
 ```
-curl -X DELETE "https://api.particle.io/v1/products/12857/team/example-api-user+6fbl2q577b@api.particle.io?access_token=xxxxx"
+curl -X DELETE https://api.particle.io/v1/products/12857/team/example-api-user+6fbl2q577b@api.particle.io \
+     -H "Authorization: Bearer :access_token"
 ```
 
 To delete an API user and its associated access token, simply:

--- a/templates/partials/api.hbs
+++ b/templates/partials/api.hbs
@@ -30,7 +30,7 @@
         {{/if}}
 
 		{{#if parameter.fields}}
-			<ul class='api-attributes api-request' data-title='Request Arguments'>
+			<ul class='api-attributes api-request' data-title='Request URL Parameters'>
 				{{#each parameter.fields.Parameter}}
 					<li>
 						<div class='api-field'>{{field}}{{#unless optional}}<span class='field-required'>REQUIRED</span>{{/unless}}
@@ -41,7 +41,32 @@
 			</ul>
 		{{/if}}
 
-		{{#each examples}}
+        {{#if query}}
+            <ul class='api-attributes api-request' data-title='Query Parameters'>
+                {{#each query}}
+                    <li>
+                        <div class='api-field'>{{field}}{{#unless optional}}<span class='field-required'>REQUIRED</span>{{/unless}}
+                            <small>{{#if allowedValues}}{{join allowedValues ','}}{{else}}{{type}}{{/if}}</small></div>
+                        <div class='field-desc'>{{#if description}}{{{description}}}{{else}}&mdash;{{/if}}</div>
+                    </li>
+                {{/each}}
+            </ul>
+        {{/if}}
+
+
+        {{#if body}}
+            <ul class='api-attributes api-request' data-title='Request Attributes'>
+                {{#each body}}
+                    <li>
+                        <div class='api-field'>{{field}}{{#unless optional}}<span class='field-required'>REQUIRED</span>{{/unless}}
+                            <small>{{#if allowedValues}}{{join allowedValues ','}}{{else}}{{type}}{{/if}}</small></div>
+                        <div class='field-desc'>{{#if description}}{{{description}}}{{else}}&mdash;{{/if}}</div>
+                    </li>
+                {{/each}}
+            </ul>
+        {{/if}}
+
+        {{#each examples}}
 <pre class='api-code api-request-example' data-title='{{#starts-with content title}}Example Request{{else}}{{title}}{{/starts-with}}'><code class='prettyprint lang-{{this.type}}'>{{{this.content}}}</code></pre>
 		{{/each}}
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/127947

Updates the format of the API docs generation to separate URL parameters like :deviceId from query params like :page and request attributes like :notes.

Replaces all examples of access token in the query string with access token in the Authentication header since this is more secure. Access token in the query string is marked as deprecated and discouraged.

Also fixes docs generation for particle-api-js that was due to introducing Typescript annotations.

Steps to test:
- [X] Verify that all the existing API endpoints still show up in the documentation