### PR TITLE
Update device-constants for the updated platform display names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.3.0",
             "license": "CC-BY-SA-3.0",
             "dependencies": {
+                "@particle/device-constants": "^3.4.0",
                 "apidoc": "^1.2.0",
                 "autoprefixer": "^7.1.5",
                 "binary-version-reader": "^2.0.1",
@@ -479,10 +480,9 @@
             }
         },
         "node_modules/@particle/device-constants": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
-            "integrity": "sha512-xskCcfBu+vh5eTebGE9LEejaKkdDueyea/nfFPCGLL7FJG51dDPZ1DfPZsueQuok4ok/V52KhZiOWH2oxkwq2Q==",
-            "peer": true,
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.4.0.tgz",
+            "integrity": "sha512-3H4g9oZ6LBq9YYOhbZrApwbwU9d1jIFchyrGG41vPmj2awDUqwOQ6errPvjYusm+Kj6jJLduo4h4o74ATEWSIg==",
             "engines": {
                 "node": ">=12.x",
                 "npm": "8.x"
@@ -11690,10 +11690,9 @@
             }
         },
         "@particle/device-constants": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.0.1.tgz",
-            "integrity": "sha512-xskCcfBu+vh5eTebGE9LEejaKkdDueyea/nfFPCGLL7FJG51dDPZ1DfPZsueQuok4ok/V52KhZiOWH2oxkwq2Q==",
-            "peer": true
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.4.0.tgz",
+            "integrity": "sha512-3H4g9oZ6LBq9YYOhbZrApwbwU9d1jIFchyrGG41vPmj2awDUqwOQ6errPvjYusm+Kj6jJLduo4h4o74ATEWSIg=="
         },
         "@types/eslint": {
             "version": "8.56.10",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
         "pdf-generation": "gulp --gulpfile ./scripts/pdf-generation/pdf-generation-gulpfile.js"
     },
     "dependencies": {
+        "@particle/device-constants": "^3.4.0",
         "apidoc": "^1.2.0",
         "autoprefixer": "^7.1.5",
         "binary-version-reader": "^2.0.1",


### PR DESCRIPTION
Display names and generation numbers are updated in device-constants 3.4.0