### PR TITLE
Text update to the ilert page

### DIFF
--- a/config/sitemap.json
+++ b/config/sitemap.json
@@ -8211,8 +8211,8 @@
             "date": "2024-08-16"
         },
         "integrations/community-integrations/ilert.md": {
-            "hash": "044fcb9e450d74983e5b4636c6609bb14fe07dc83167242875ce1a06aede7887",
-            "date": "2023-11-08"
+            "hash": "e53662fd52f6ac0553bddff6d9916e6378d2b601b7be0cb28a2341af3f8b66f5",
+            "date": "2025-06-24"
         },
         "reference/device-os/api/input-output/analogsetreference.md": {
             "hash": "f924c4cf22be0bf117badfc6b519975242e16356713c9e5776d851cdfbe98b14",

--- a/src/content/integrations/community-integrations/ilert.md
+++ b/src/content/integrations/community-integrations/ilert.md
@@ -7,9 +7,7 @@ description: ulert incident management
 
 # {{title}}
 
-[ilert](https://eu1.hubs.ly/H062_XF0) is an all-in-one platform for incident management. It provides a set of features that helps companies increase their uptime 
-and react to incidents in the most comprehensive way. Alerting, call routing, on-call scheduling, ChatOps, AI assistance in incident communication and post-mortem 
-creation — these and many more functions enable teams to concentrate their efforts on issue resolution.
+[ilert](https://eu1.hubs.ly/H062_XF0) is an AI-first company offering an all-in-one incident management tool for alerting, on-call management, and incident communication to help companies increase their digital uptime. B2C and B2B companies from across the globe, including well-known brands such as IKEA, Lufthansa Systems, and NTT Data, trust ilert to empower their operations teams and ensure everything is running smoothly.
 
 The ilert integration for Particle enables users to receive alerts from devices and notify engineers by multiple channels, be it phone calls, push notifications, 
 SMS, etc. Use alert templates to enrich alerts with all vital information to help your team react quicker.


### PR DESCRIPTION
Artie requested an urgent text change to the ilert page. I hope Im not stepping on anyones feet by making these changes. 

Request:
"Steve received a partner request to update our ilert integrations page description (top part): https://docs.particle.io/integrations/community-integrations/ilert/
TO THIS:
ilert is an AI-first company offering an all-in-one incident management tool for alerting, on-call management, and incident communication to help companies increase their digital uptime. B2C and B2B companies from across the globe, including well-known brands such as IKEA, Lufthansa Systems, and NTT Data, trust ilert to empower their operations teams and ensure everything is running smoothly."

Artie approved the visual changes via local build.